### PR TITLE
URL sources: readability extraction, drop comments/hidden markup

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -62,6 +62,7 @@ dependencies = [
  "base64 0.22.1",
  "calamine",
  "chrono",
+ "dom_smoothie",
  "futures",
  "futures-util",
  "image",
@@ -1446,7 +1447,20 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
 dependencies = [
- "cssparser-macros",
+ "cssparser-macros 0.6.1",
+ "dtoa-short",
+ "itoa",
+ "phf 0.13.1",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
+dependencies = [
+ "cssparser-macros 0.7.0",
  "dtoa-short",
  "itoa",
  "phf 0.13.1",
@@ -1458,6 +1472,16 @@ name = "cssparser-macros"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -2439,12 +2463,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
  "bit-set",
- "cssparser",
+ "cssparser 0.36.0",
  "foldhash 0.2.0",
- "html5ever",
+ "html5ever 0.38.0",
  "precomputed-hash",
- "selectors",
+ "selectors 0.36.1",
  "tendril",
+]
+
+[[package]]
+name = "dom_query"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac5fca71e65e94cc718a6e2af65d6e0f9c6027751c2aa562fbb5087fda639bc"
+dependencies = [
+ "bit-set",
+ "cssparser 0.37.0",
+ "foldhash 0.2.0",
+ "html5ever 0.39.0",
+ "nom 8.0.0",
+ "precomputed-hash",
+ "selectors 0.38.0",
+ "tendril",
+]
+
+[[package]]
+name = "dom_smoothie"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8b9b294aabb8010b37c49a07d6f82175152f4927855d534979a38737721875"
+dependencies = [
+ "dom_query 0.28.0",
+ "flagset",
+ "foldhash 0.2.0",
+ "gjson",
+ "html-escape",
+ "once_cell",
+ "phf 0.13.1",
+ "tendril",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -2698,6 +2756,12 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flatbuffers"
@@ -3097,6 +3161,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gjson"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43503cc176394dd30a6525f5f36e838339b8b5619be33ed9a7783841580a97b6"
+
+[[package]]
 name = "glib"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3325,13 +3395,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "html-escape"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c1ff2d1cbf39efe5af0900ced8a069b5e61557a17544eb0c4a50239937389e"
+
+[[package]]
 name = "html5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
 dependencies = [
  "log",
- "markup5ever",
+ "markup5ever 0.38.0",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever 0.39.0",
 ]
 
 [[package]]
@@ -4836,6 +4922,17 @@ name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
 dependencies = [
  "log",
  "tendril",
@@ -6873,7 +6970,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
 dependencies = [
  "bitflags 2.13.0",
- "cssparser",
+ "cssparser 0.36.0",
+ "derive_more",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.13.1",
+ "phf_codegen",
+ "precomputed-hash",
+ "rustc-hash",
+ "servo_arc",
+ "smallvec",
+]
+
+[[package]]
+name = "selectors"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
+dependencies = [
+ "bitflags 2.13.0",
+ "cssparser 0.37.0",
  "derive_more",
  "log",
  "new_debug_unreachable",
@@ -7863,7 +7979,7 @@ dependencies = [
  "brotli",
  "cargo_metadata",
  "ctor",
- "dom_query",
+ "dom_query 0.27.0",
  "dunce",
  "glob",
  "http",
@@ -9489,7 +9605,7 @@ dependencies = [
  "cookie",
  "crossbeam-channel",
  "dirs",
- "dom_query",
+ "dom_query 0.27.0",
  "dpi",
  "dunce",
  "gdkx11",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,6 +44,9 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "str
 tauri-plugin-debug-bridge = { version = "0.4", optional = true }
 model2vec-rs = "0.2.1"
 tokio-util = { version = "0.7.18", default-features = false }
+# Readability-style article extraction for URL sources. Built on dom_query,
+# which is already in the tree via tauri-utils.
+dom_smoothie = "0.18"
 
 [features]
 # Dev-only: exposes the debug bridge for CLI automation/inspection.

--- a/src-tauri/src/ingest.rs
+++ b/src-tauri/src/ingest.rs
@@ -429,7 +429,7 @@ fn hidden_element_end(rest: &str, tag: &str, after_open: usize) -> Option<usize>
     }
     let name: String = tag
         .chars()
-        .take_while(|c| c.is_ascii_alphanumeric())
+        .take_while(|c| c.is_ascii_alphanumeric() || matches!(*c, '-' | ':' | '_'))
         .collect::<String>()
         .to_ascii_lowercase();
     if name.is_empty() || is_void_element(&name) {
@@ -502,12 +502,13 @@ fn is_void_element(name: &str) -> bool {
     )
 }
 
-/// Is the byte at `idx` an ASCII alphanumeric? Used as a tag-name boundary
-/// check so `<div` doesn't match `<divx`.
+/// Is the byte at `idx` a valid ASCII tag-name character? Used as a tag-name
+/// boundary check so `<div` doesn't match `<divx` and `<my-element` doesn't
+/// match `<my-element-extra`.
 fn next_is_alnum(s: &str, idx: usize) -> bool {
-    s.as_bytes()
-        .get(idx)
-        .is_some_and(|b| b.is_ascii_alphanumeric())
+    s.as_bytes().get(idx).is_some_and(|b| {
+        b.is_ascii_alphanumeric() || matches!(b, b'-' | b':' | b'_')
+    })
 }
 
 /// Collapse runs of blank (or whitespace-only) lines down to one blank line.

--- a/src-tauri/src/ingest.rs
+++ b/src-tauri/src/ingest.rs
@@ -221,19 +221,46 @@ pub async fn extract_url(raw_url: &str) -> Result<Extracted> {
     }
     let body = resp.text().await.context("failed to read response body")?;
 
-    let text = normalize(&strip_html(&body));
+    let (article_title, text) = readable_text(&body, &url);
     if text.trim().is_empty() {
         return Err(anyhow!(
             "no readable text found at {url} (the page may be JavaScript-rendered)"
         ));
     }
-    let title = extract_title(&body).unwrap_or_else(|| url.clone());
+    let title = article_title
+        .or_else(|| extract_title(&body))
+        .unwrap_or_else(|| url.clone());
     Ok(Extracted {
         title,
         source_type: "url".to_string(),
         url,
         text,
     })
+}
+
+/// Readability-style article extraction (drops nav, footers, comments, hidden
+/// elements) with a plain tag-strip fallback for pages that don't look like
+/// articles (dashboards, listings, bot walls). Returns the article title, if
+/// one was found, alongside the text.
+fn readable_text(body: &str, url: &str) -> (Option<String>, String) {
+    let cfg = dom_smoothie::Config {
+        text_mode: dom_smoothie::TextMode::Formatted,
+        ..Default::default()
+    };
+    let article = dom_smoothie::Readability::new(body, Some(url), Some(cfg))
+        .ok()
+        .and_then(|mut r| r.parse().ok());
+    if let Some(article) = article {
+        let text = normalize(&article.text_content);
+        // Same threshold as looks_blocked: shorter than this means the
+        // article extraction probably picked the wrong (or no) node, so
+        // whole-page extraction is the safer bet.
+        if text.chars().count() >= 200 {
+            let title = Some(article.title.trim().to_string()).filter(|t| !t.is_empty());
+            return (title, text);
+        }
+    }
+    (None, normalize(&strip_html(body)))
 }
 
 /// Heuristic: does this extracted text look like a bot wall / login page /
@@ -336,15 +363,26 @@ fn normalize(text: &str) -> String {
 }
 
 fn strip_html(html: &str) -> String {
-    // Drop script/style blocks, then remove all remaining tags. Operates on
-    // char boundaries throughout so Unicode pages can't trigger a slice panic.
-    // Tag names are ASCII, so case-insensitive comparison is done byte-wise
-    // (avoids `to_lowercase`, which can shift byte offsets).
+    // Drop comments, script/style blocks, and elements marked hidden, then
+    // remove all remaining tags. Operates on char boundaries throughout so
+    // Unicode pages can't trigger a slice panic. Tag names are ASCII, so
+    // case-insensitive comparison is done byte-wise (avoids `to_lowercase`,
+    // which can shift byte offsets).
     let mut cleaned = String::with_capacity(html.len());
     let len = html.len();
     let mut i = 0; // always a char boundary
     while i < len {
         let rest = &html[i..];
+        if rest.starts_with("<!--") {
+            match rest.find("-->") {
+                Some(end) => {
+                    i += end + 3;
+                    cleaned.push(' ');
+                    continue;
+                }
+                None => break,
+            }
+        }
         if starts_with_ci(rest, "<script") || starts_with_ci(rest, "<style") {
             let close = if starts_with_ci(rest, "<script") {
                 "</script>"
@@ -363,7 +401,11 @@ fn strip_html(html: &str) -> String {
         if ch == '<' {
             match rest.find('>') {
                 Some(end) => {
-                    i += end + 1;
+                    if let Some(skip) = hidden_element_end(rest, &rest[1..end], end + 1) {
+                        i += skip;
+                    } else {
+                        i += end + 1;
+                    }
                     cleaned.push(' ');
                     continue;
                 }
@@ -373,7 +415,118 @@ fn strip_html(html: &str) -> String {
         cleaned.push(ch);
         i += ch.len_utf8();
     }
-    decode_entities(&cleaned)
+    collapse_blank_lines(&decode_entities(&cleaned))
+}
+
+/// If `tag` (the text between '<' and '>') opens an element marked hidden,
+/// return the offset in `rest` just past its matching close tag. `rest` starts
+/// at the element's '<'; `after_open` is the offset just past its opening '>'.
+/// Returns None for visible, self-closing, void, or unclosed elements (the
+/// caller then drops only the tag itself).
+fn hidden_element_end(rest: &str, tag: &str, after_open: usize) -> Option<usize> {
+    if tag.starts_with('/') || tag.ends_with('/') || !tag_is_hidden(tag) {
+        return None;
+    }
+    let name: String = tag
+        .chars()
+        .take_while(|c| c.is_ascii_alphanumeric())
+        .collect::<String>()
+        .to_ascii_lowercase();
+    if name.is_empty() || is_void_element(&name) {
+        return None;
+    }
+    let open = format!("<{name}");
+    let close = format!("</{name}");
+    let mut depth = 1usize;
+    let mut i = after_open;
+    while i < rest.len() {
+        let lt = rest[i..].find('<')? + i;
+        let at = &rest[lt..];
+        if starts_with_ci(at, &close) && !next_is_alnum(at, close.len()) {
+            let gt = at.find('>')? + lt + 1;
+            depth -= 1;
+            if depth == 0 {
+                return Some(gt);
+            }
+            i = gt;
+        } else if starts_with_ci(at, &open) && !next_is_alnum(at, open.len()) {
+            let gt = at.find('>')? + lt + 1;
+            if !rest[lt..gt - 1].ends_with('/') {
+                depth += 1;
+            }
+            i = gt;
+        } else {
+            i = lt + 1;
+        }
+    }
+    None
+}
+
+/// Cheap check for markup that hides an element: inline display/visibility,
+/// the bare `hidden` attribute, or aria-hidden="true".
+fn tag_is_hidden(tag: &str) -> bool {
+    let squished: String = tag
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect::<String>()
+        .to_ascii_lowercase();
+    if squished.contains("display:none")
+        || squished.contains("visibility:hidden")
+        || squished.contains("aria-hidden=\"true\"")
+        || squished.contains("aria-hidden='true'")
+    {
+        return true;
+    }
+    tag.split_whitespace()
+        .skip(1)
+        .any(|t| t.eq_ignore_ascii_case("hidden") || t.to_ascii_lowercase().starts_with("hidden="))
+}
+
+fn is_void_element(name: &str) -> bool {
+    matches!(
+        name,
+        "area"
+            | "base"
+            | "br"
+            | "col"
+            | "embed"
+            | "hr"
+            | "img"
+            | "input"
+            | "link"
+            | "meta"
+            | "param"
+            | "source"
+            | "track"
+            | "wbr"
+    )
+}
+
+/// Is the byte at `idx` an ASCII alphanumeric? Used as a tag-name boundary
+/// check so `<div` doesn't match `<divx`.
+fn next_is_alnum(s: &str, idx: usize) -> bool {
+    s.as_bytes()
+        .get(idx)
+        .is_some_and(|b| b.is_ascii_alphanumeric())
+}
+
+/// Collapse runs of blank (or whitespace-only) lines down to one blank line.
+fn collapse_blank_lines(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut pending_blank = false;
+    for line in text.lines() {
+        if line.trim().is_empty() {
+            pending_blank = !out.is_empty();
+        } else {
+            if pending_blank {
+                out.push('\n');
+                pending_blank = false;
+            }
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    out
 }
 
 /// ASCII case-insensitive prefix check (safe on any UTF-8 input).
@@ -454,6 +607,89 @@ mod tests {
     #[test]
     fn strip_html_decodes_entities() {
         assert_eq!(strip_html("a &amp; b &lt;c&gt;").trim(), "a & b <c>");
+    }
+
+    #[test]
+    fn strip_html_drops_comments_hidden_elements_and_extra_blanks() {
+        let html = r#"<html><head><title>Dealer</title></head>
+<body>
+<!-- OFFICIAL FERRARI DEALER / Ferrari Silicon Valley -->
+<p>Visible paragraph.</p>
+<!--
+<div class="save-bar"><span>Saved</span></div>
+-->
+<div style="display: none">Hidden inline style.</div>
+<div hidden><p>Hidden attr block.</p></div>
+<span aria-hidden="true">Decorative</span>
+<input type="hidden" value="csrf-token">
+
+
+
+<p>After many blank lines.</p>
+<!-- unterminated comment swallows the rest
+</body></html>"#;
+        let text = strip_html(html);
+        assert!(text.contains("Visible paragraph."));
+        assert!(text.contains("After many blank lines."));
+        assert!(!text.contains("-->"), "no comment delimiters: {text}");
+        assert!(!text.contains("OFFICIAL FERRARI DEALER"));
+        assert!(!text.contains("Saved"), "commented-out markup dropped");
+        assert!(!text.contains("Hidden inline style."));
+        assert!(!text.contains("Hidden attr block."));
+        assert!(!text.contains("Decorative"), "aria-hidden dropped");
+        assert!(!text.contains("csrf-token"));
+        assert!(!text.contains("unterminated"));
+        assert!(!text.contains("\n\n\n"), "blank runs collapsed: {text:?}");
+    }
+
+    #[test]
+    fn readable_text_extracts_article_and_drops_boilerplate() {
+        let para = "The quick brown fox jumps over the lazy dog near the riverbank at dawn, \
+                    watching the water drift slowly past the old stone bridge into town.";
+        let html = format!(
+            r#"<html><head><title>Fox Story — Example News</title></head>
+<body>
+<nav><a href="/">Home</a> <a href="/about">About</a> <a href="/contact">Contact</a></nav>
+<!-- OFFICIAL FERRARI DEALER / Ferrari Silicon Valley -->
+<div hidden><span>Saved</span></div>
+<article><h1>Fox Story</h1>
+<p>{para}</p><p>{para}</p><p>{para}</p><p>{para}</p><p>{para}</p>
+</article>
+<footer>Copyright 2026 Example News. Privacy Policy. Terms of Service.</footer>
+</body></html>"#
+        );
+        let (title, text) = readable_text(&html, "https://example.com/fox");
+        assert!(text.contains("quick brown fox"));
+        assert!(!text.contains("Privacy Policy"), "footer dropped: {text}");
+        assert!(!text.contains("OFFICIAL FERRARI DEALER"));
+        assert!(!text.contains("Saved"));
+        assert!(!text.contains("-->"));
+        assert!(title.is_some(), "article title extracted");
+    }
+
+    #[test]
+    fn readable_text_falls_back_to_full_page_on_non_articles() {
+        // Too little content for readability — the tag-strip fallback must
+        // keep the page's text rather than returning nothing.
+        let html = "<html><body><h1>Dashboard</h1><p>3 sources indexed.</p></body></html>";
+        let (title, text) = readable_text(html, "https://example.com/app");
+        assert!(text.contains("3 sources indexed."));
+        assert!(title.is_none(), "fallback leaves title to extract_title");
+    }
+
+    #[test]
+    fn strip_html_keeps_content_after_hidden_and_nested_hidden() {
+        // Nested same-name tags inside a hidden element must not truncate
+        // the visible content that follows it.
+        let html = r#"<div hidden><div><span>inner</span></div></div><p>still here</p>"#;
+        let text = strip_html(html);
+        assert!(!text.contains("inner"));
+        assert!(text.contains("still here"));
+
+        // A hidden element that never closes falls back to dropping only the
+        // tag, keeping the document readable.
+        let text = strip_html("<div hidden>orphan <p>tail</p>");
+        assert!(text.contains("tail"));
     }
 
     #[test]


### PR DESCRIPTION
## Why

Scraped URL sources showed HTML-comment artifacts in the SourceViewer: stray `-->` lines, orphaned words like "Saved", and repeated blocks ("OFFICIAL FERRARI DEALER / Ferrari Silicon Valley") from commented-out or hidden markup. Root cause: `strip_html` treated `<!--` like a normal tag and skipped only to the first `>` inside the comment, leaking the rest of the comment body into the extracted text.

## What

- **`strip_html` fixes** (still used for docx/pptx XML and as the URL fallback):
  - Drop `<!-- ... -->` comments entirely (unterminated comment drops the rest, matching script/style behavior)
  - Skip elements marked hidden (`display:none`/`visibility:hidden` inline styles, bare `hidden` attribute, `aria-hidden="true"`), depth-aware for same-name nesting, with a safe fallback for unclosed elements
  - Collapse runs of blank lines to at most one
- **`extract_url` now uses `dom_smoothie`** (Readability.js port) for article extraction — drops nav/footer/boilerplate too, and provides the article title. Falls back to whole-page `strip_html` extraction when the article result is under 200 chars (non-article pages: dashboards, listings, bot walls).

## Tests

New unit tests cover: comment/hidden/blank-run stripping against a dealer-page-style fixture, nested-hidden and unclosed-hidden edge cases, readability extraction dropping boilerplate, and the whole-page fallback for non-article pages.

`cargo fmt -- --check && cargo clippy -- -D warnings && cargo test` — all green (26 tests).

Dependency note: `dom_smoothie` adds its own `dom_query 0.28`/`html5ever 0.39` pair alongside Tauri's pinned `0.27`/`0.38` until Tauri bumps — minor compile-time cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)