### PR TITLE
Survive concurrent MCP imports: gate, heartbeat, longer session keep-alive

### DIFF
--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -120,9 +120,19 @@ async fn start_server(
     let listener = tokio::net::TcpListener::bind(("127.0.0.1", port)).await?;
     let shutdown = tokio_util::sync::CancellationToken::new();
 
+    // The session manager's keep-alive kills a session after that much time
+    // without a single session event — and a batch of parallel add_source
+    // imports (scanned PDFs OCR'ing page by page) can sit quiet far longer
+    // than the 5-minute default, terminating the session under every
+    // still-running call ("Session service terminated", seen live with 6
+    // parallel PDF imports). Long imports also heartbeat progress (see
+    // sources.rs), but the ceiling must outlast the slowest legitimate call:
+    // the 20-minute generation watchdog, plus margin.
+    let mut sessions = LocalSessionManager::default();
+    sessions.session_config.keep_alive = Some(std::time::Duration::from_secs(30 * 60));
     let service = StreamableHttpService::new(
         move || Ok(AlchemyMcp::new(app.clone())),
-        LocalSessionManager::default().into(),
+        sessions.into(),
         StreamableHttpServerConfig::default(),
     );
     let router = axum::Router::new()

--- a/src-tauri/src/mcp/sources.rs
+++ b/src-tauri/src/mcp/sources.rs
@@ -1,7 +1,53 @@
 //! Source ingest and read tools.
 
 use super::*;
-use rmcp::{handler::server::wrapper::Parameters, tool, tool_router, ErrorData as McpError};
+use rmcp::{
+    handler::server::wrapper::Parameters, service::RequestContext, tool, tool_router,
+    ErrorData as McpError, RoleServer,
+};
+
+/// Concurrent add_source calls queue here instead of all running at once.
+/// Imports are heavy — PDFium rasterization (globally mutexed), per-page OCR,
+/// embedding — and a burst of parallel calls mostly serializes on those locks
+/// anyway, stretching every call's wall clock past the clients' idle
+/// timeouts. Two at a time lets a small text add slip past a big scanned PDF
+/// without letting a batch starve them all.
+static IMPORT_GATE: tokio::sync::Semaphore = tokio::sync::Semaphore::const_new(2);
+
+/// Progress heartbeat for one long import. MCP clients abandon a call that
+/// stays silent too long (Claude Code: 300s), so while an import waits on the
+/// gate or OCRs a scanned PDF, a beat every 20 seconds keeps the call — and
+/// the rmcp session's own keep-alive — visibly alive. Clients that sent no
+/// progress token get no beats (the spec forbids inventing one); the raised
+/// session keep-alive in mod.rs still covers them server-side.
+struct Heartbeat(Option<tokio::task::JoinHandle<()>>);
+
+impl Heartbeat {
+    fn start(ctx: &RequestContext<RoleServer>, message: String) -> Self {
+        let Some(token) = ctx.meta.get_progress_token() else {
+            return Self(None);
+        };
+        let peer = ctx.peer.clone();
+        Self(Some(tokio::spawn(async move {
+            for beat in 1u64.. {
+                tokio::time::sleep(std::time::Duration::from_secs(20)).await;
+                let progress = ProgressNotificationParam::new(token.clone(), beat as f64)
+                    .with_message(message.clone());
+                if peer.notify_progress(progress).await.is_err() {
+                    return; // peer gone — nothing left to keep alive
+                }
+            }
+        })))
+    }
+}
+
+impl Drop for Heartbeat {
+    fn drop(&mut self) {
+        if let Some(task) = self.0.take() {
+            task.abort();
+        }
+    }
+}
 
 #[derive(serde::Deserialize, schemars::JsonSchema)]
 struct AddSourceReq {
@@ -65,6 +111,7 @@ impl AlchemyMcp {
             file_path,
             title,
         }): Parameters<AddSourceReq>,
+        ctx: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
         let state = self.state();
         let provided = [url.is_some(), text.is_some(), file_path.is_some()]
@@ -74,6 +121,16 @@ impl AlchemyMcp {
         if provided != 1 {
             return Err(invalid("provide exactly one of url, text, or file_path"));
         }
+        let what = url
+            .clone()
+            .or_else(|| file_path.clone())
+            .or_else(|| title.clone())
+            .unwrap_or_else(|| "pasted text".into());
+        let _heartbeat = Heartbeat::start(&ctx, format!("importing {what}"));
+        let _permit = IMPORT_GATE
+            .acquire()
+            .await
+            .expect("import gate never closes");
         let source = if let Some(url) = url {
             if crate::mac::is_mac_uri(&url) {
                 // Mac items connect as living, auto-syncing sources — never


### PR DESCRIPTION
## Problem

Six parallel `add_source` calls (observed 2026-07-31 with PDF imports) killed the streamable-HTTP MCP session with **"Session service terminated"**; other in-flight calls hit 300s idle timeouts even though some imports completed server-side.

Root cause: rmcp's `LocalSessionManager` terminates a session after **300s without a single session event** (`SessionConfig::keep_alive` → `WorkerQuitReason::IdleTimeout`). SSE keep-alive pings don't count — only client messages and server responses do. Heavy imports serialize on PDFium's global FFI mutex, the OCR model, and the embedder, so once the quick calls return, the stragglers produce zero session traffic for >5 minutes and the server kills the session under them.

## Fix (three layers)

- **Session keep-alive → 30 min** (`mcp/mod.rs`): outlasts the 20-minute generation watchdog (c4bc981) with margin; covers clients that send no progress token.
- **Import gate** (`mcp/sources.rs`): a 2-permit semaphore — concurrent `add_source` calls queue instead of thrashing PDFium/OCR/embedding all at once.
- **Progress heartbeats** (`mcp/sources.rs`): when the client sends a `progressToken`, a 20s heartbeat emits progress notifications for the whole import (including time queued on the gate), resetting both the client's idle timer and the session keep-alive.

## Verification

- `cargo fmt` / `clippy -D warnings` / 190 tests: clean.
- Live: dev app + raw streamable-HTTP MCP client firing **6 concurrent `add_source` calls on one session** — 2 image-only scanned PDFs (OCR'd via deepseek-ocr), 1 large arXiv PDF, 3 small text files. All 6 succeeded (`status=ready`, real OCR text), heartbeats observed every 20s on every in-flight call, and `list_sources` on the same session succeeded afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)