### PR TITLE
Reminders backlog: window geometry, silent destroys, live reminder checkboxes, motion/token cleanup

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -32,9 +32,13 @@ translucent, the center goes fully transparent, and content cards carry
 their own opaque surfaces.
 
 Empty chat may use the animated dithered "aetheric mist" WebGL background
-(`DitherBackground`) — the app's only decorative element: behind content,
+(`DitherBackground`) — the app's primary decorative element: behind content,
 tinted from theme tokens, static under `prefers-reduced-motion`, and hidden
-entirely under glass (the material is the ambience there).
+entirely under glass (the material is the ambience there). The hero's
+transmutation sigil (`AlchemySymbol`) is the one other sanctioned ambient
+element: its slow cross-fade and rotation are deliberately outside the 250ms
+cap (they are its whole character) and go static under
+`prefers-reduced-motion` like everything else.
 
 The app is themeable (23 schemes, dark and light) — never hardcode a hex in a
 component; always go through the semantic tokens below.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -151,6 +151,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-updater",
+ "tauri-plugin-window-state",
  "thiserror 2.0.20",
  "tokio",
  "tokio-util",
@@ -9485,6 +9486,21 @@ dependencies = [
  "url",
  "windows-sys 0.60.2",
  "zip 4.6.1",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.13.1",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.20",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -64,6 +64,7 @@ grep-regex = "0.1"
 grep-searcher = "0.1"
 tauri-plugin-updater = "2.10.1"
 tauri-plugin-process = "2.3.1"
+tauri-plugin-window-state = "2.4.1"
 
 # Embedded MCP server for agent access (see docs/RFC-mcp-server.md):
 # official Rust MCP SDK + axum to host the streamable-HTTP transport.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -9341,7 +9341,13 @@ pub async fn new_window(
     notebook_id: Option<String>,
     note_id: Option<String>,
 ) -> Result<(), String> {
-    let label = format!("win-{}", new_id());
+    // Note readers get their own label prefix so window-state restores them
+    // at reader size, not workspace size (both still match the win-* capability).
+    let label = if note_id.is_some() {
+        format!("win-note-{}", new_id())
+    } else {
+        format!("win-{}", new_id())
+    };
     let mut boot = match notebook_id {
         Some(id) => format!("window.__ALCHEMY_NOTEBOOK__ = '{}';", id.replace('\'', "")),
         None => "window.__ALCHEMY_FRESH__ = true;".to_string(),

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -7875,6 +7875,41 @@ pub async fn create_note(
     Ok(note)
 }
 
+/// The fields of a deleted note the undo toast carries back.
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RestoredNote {
+    pub notebook_id: String,
+    pub title: String,
+    pub content: String,
+    pub kind: String,
+    pub prompt: String,
+    pub origin: String,
+    pub status: String,
+}
+
+/// Re-insert a note deleted moments ago — the undo half of the note-delete
+/// toast. Fresh id (the old row and its index entry are gone), everything
+/// else verbatim, so studio artifacts keep their kind and viewer.
+#[tauri::command]
+pub async fn restore_note(state: State<'_, AppState>, note: RestoredNote) -> Result<Note, String> {
+    let ts = now();
+    let note = Note {
+        id: new_id(),
+        notebook_id: note.notebook_id,
+        title: note.title,
+        content: note.content,
+        kind: note.kind,
+        prompt: note.prompt,
+        origin: note.origin,
+        status: note.status,
+        created_at: ts,
+        updated_at: ts,
+    };
+    e(add_note_indexed(&state, &note).await)?;
+    Ok(note)
+}
+
 #[tauri::command]
 pub async fn update_note(
     state: State<'_, AppState>,

--- a/src-tauri/src/inference/agent_cli.rs
+++ b/src-tauri/src/inference/agent_cli.rs
@@ -840,7 +840,10 @@ impl AgentCli {
                 // the lenient parser treats non-JSON lines as raw text so
                 // plain-text builds still work. No system flag — folded
                 // into the prompt below. Prompt over stdin.
-                cmd.args(["-p", "--output-format", "stream-json"]);
+                // --trust: headless runs inherit the app's cwd, which the
+                // CLI has never trusted; without it every run dies on the
+                // interactive Workspace Trust prompt.
+                cmd.args(["-p", "--output-format", "stream-json", "--trust"]);
                 set_model(&mut cmd);
             }
             AgentKind::Gemini => {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -407,6 +407,7 @@ pub fn run() {
             commands::probe_okf,
             commands::ask_everything,
             commands::create_note,
+            commands::restore_note,
             commands::build_info,
             commands::update_note,
             commands::note_opened,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -71,6 +71,33 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
+        // Window geometry survives relaunch. Pop-outs share one state slot
+        // per kind (workspace / note reader) via label mapping; render-only
+        // windows (export, capture) are denylisted. VISIBLE stays excluded:
+        // close-to-tray hides the main window, and saving visible=false
+        // would relaunch the app with no window at all.
+        .plugin(
+            tauri_plugin_window_state::Builder::new()
+                .with_state_flags(
+                    tauri_plugin_window_state::StateFlags::SIZE
+                        | tauri_plugin_window_state::StateFlags::POSITION
+                        | tauri_plugin_window_state::StateFlags::MAXIMIZED
+                        | tauri_plugin_window_state::StateFlags::FULLSCREEN,
+                )
+                .map_label(|label| {
+                    if label.starts_with("win-export-") || label.starts_with("capture-") {
+                        "ephemeral"
+                    } else if label.starts_with("win-note-") {
+                        "note"
+                    } else if label.starts_with("win-") {
+                        "workspace"
+                    } else {
+                        label
+                    }
+                })
+                .with_denylist(&["ephemeral"])
+                .build(),
+        )
         .plugin(tauri_plugin_liquid_glass::init());
 
     #[cfg(feature = "debug")]

--- a/src/components/AmbientRail.tsx
+++ b/src/components/AmbientRail.tsx
@@ -109,7 +109,7 @@ export function AmbientRail({
                 onClick={() => onInsert(c)}
                 title="Insert a reference at the cursor"
                 aria-label="Insert reference"
-                className="absolute right-1.5 top-1.5 hidden rounded border border-border bg-elevated p-1 text-muted-foreground transition-colors hover:text-foreground group-hover/card:block"
+                className="absolute right-1.5 top-1.5 rounded border border-border bg-elevated p-1 text-muted-foreground opacity-0 transition-colors hover:text-foreground group-hover/card:opacity-100 group-focus-within/card:opacity-100"
               >
                 <CornerDownLeft className="h-3 w-3" />
               </button>

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1837,13 +1837,13 @@ function ChatHero({
   return (
     <div
       className={cn(
-        "flex flex-col items-center gap-4 text-center transition-all duration-700",
+        "flex flex-col items-center gap-4 text-center transition-all duration-200",
         compact ? "pt-1" : "min-h-[62vh] justify-center",
       )}
     >
       <AlchemySymbol
         className={cn(
-          "transition-all duration-700",
+          "transition-all duration-200",
           notebookColor ? "opacity-85" : "text-citation/60",
           compact ? "h-9 w-9" : "h-16 w-16",
         )}

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -86,6 +86,19 @@ function fuzzyScore(query: string, title: string): number | null {
   return score;
 }
 
+/** Draft @mentions saved beside the draft text (chatDraftMentions:<nb>). */
+function loadDraftMentions(
+  notebookId: string | null,
+): { id: string; kind: "source" | "note"; title: string }[] {
+  if (!notebookId) return [];
+  try {
+    const raw = localStorage.getItem(`chatDraftMentions:${notebookId}`);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
 export function ChatPanel() {
   const currentId = useStore((s) => s.currentId);
   const messages = useStore((s) => s.messages);
@@ -144,10 +157,12 @@ export function ChatPanel() {
   // @ mentions: picked source/note handles for THIS message. The text keeps
   // reading naturally ("what does @Q3 Report say?") while the recorded ids
   // narrow retrieval for the one send. A mention whose "@Title" text is
-  // edited out of the draft is dropped at send time.
+  // edited out of the draft is dropped at send time. Mirrored beside the
+  // draft text — a restored draft with its @Titles but no ids would silently
+  // lose the narrowing on send.
   const [mentions, setMentions] = useState<
     { id: string; kind: "source" | "note"; title: string }[]
-  >([]);
+  >(() => loadDraftMentions(currentId));
   const [mentionSel, setMentionSel] = useState(0);
   const [mentionDismissed, setMentionDismissed] = useState(false);
   const notes = useStore((s) => s.notes);
@@ -169,12 +184,19 @@ export function ChatPanel() {
     setDraft(
       currentId ? (localStorage.getItem(`chatDraft:${currentId}`) ?? "") : "",
     );
+    setMentions(loadDraftMentions(currentId));
   }, [currentId]);
   useEffect(() => {
     if (!currentId || draftNb.current !== currentId) return;
     if (draft) localStorage.setItem(`chatDraft:${currentId}`, draft);
     else localStorage.removeItem(`chatDraft:${currentId}`);
-  }, [draft, currentId]);
+    if (draft && mentions.length > 0)
+      localStorage.setItem(
+        `chatDraftMentions:${currentId}`,
+        JSON.stringify(mentions),
+      );
+    else localStorage.removeItem(`chatDraftMentions:${currentId}`);
+  }, [draft, mentions, currentId]);
 
   // A failed send hands its text back — restore it into the composer so the
   // user can retry without retyping.

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1543,18 +1543,12 @@ function SlashPicker({
   );
 }
 
-/** Hover row under a user turn: copy, re-run, and when it happened. Re-run is
- *  a rewind — it drops this question and everything after it, then resends —
- *  so it only appears on the last question; re-running an older one would
- *  silently discard the exchanges below it. */
+/** Hover row under a user turn: copy, re-run, and when it happened. Re-run
+ *  asks the question again as a fresh turn at the end of the chat — the
+ *  earlier exchange stays put, so nothing is destroyed and any question in
+ *  the transcript can be re-asked. */
 function UserMessageActions({ message }: { message: Message }) {
   const [copied, setCopied] = useState(false);
-  const isLastUser = useStore((s) => {
-    for (let i = s.messages.length - 1; i >= 0; i--) {
-      if (s.messages[i].role === "user") return s.messages[i].id === message.id;
-    }
-    return false;
-  });
   const sending = useStore((s) => s.sending);
 
   async function copy() {
@@ -1566,14 +1560,9 @@ function UserMessageActions({ message }: { message: Message }) {
       /* clipboard unavailable */
     }
   }
-  async function rerun() {
+  function rerun() {
     const st = useStore.getState();
     if (st.sending) return;
-    const msgs = st.messages;
-    const i = msgs.findIndex((m) => m.id === message.id);
-    if (i < 0) return;
-    for (const m of msgs.slice(i)) await api.deleteMessage(m.id);
-    useStore.setState({ messages: msgs.slice(0, i) });
     void st.sendMessage(message.content);
   }
 
@@ -1598,17 +1587,15 @@ function UserMessageActions({ message }: { message: Message }) {
         )}
         {copied ? "Copied" : "Copy"}
       </button>
-      {isLastUser && (
-        <button
-          onClick={() => void rerun()}
-          disabled={sending}
-          className={btn}
-          title="Ask this again — replaces the answer below"
-        >
-          <RefreshCw className="h-3.5 w-3.5" />
-          Re-run
-        </button>
-      )}
+      <button
+        onClick={rerun}
+        disabled={sending}
+        className={btn}
+        title="Ask this again as a new turn"
+      >
+        <RefreshCw className="h-3.5 w-3.5" />
+        Re-run
+      </button>
     </div>
   );
 }

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -3,7 +3,7 @@ import { listen } from "@tauri-apps/api/event";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useStore } from "@/lib/store";
 import { api } from "@/lib/api";
-import { Button, CardAction, Textarea, useConfirm } from "./ui";
+import { Button, CardAction, RowMenu, Textarea, useConfirm } from "./ui";
 import { Markdown } from "./Markdown";
 import { cn, chatReadingClass, fmtDateTime, isWebUrl, relativeTime } from "@/lib/utils";
 import { DitherBackground } from "./DitherBackground";
@@ -1596,6 +1596,18 @@ function UserMessageActions({ message }: { message: Message }) {
         <RefreshCw className="h-3.5 w-3.5" />
         Re-run
       </button>
+      {/* Right-click parity: the same verbs from anywhere on the question. */}
+      <RowMenu
+        label="Question options"
+        items={[
+          { label: "Copy", icon: <Copy className="h-3.5 w-3.5" />, onClick: () => void copy() },
+          {
+            label: "Re-run",
+            icon: <RefreshCw className="h-3.5 w-3.5" />,
+            onClick: rerun,
+          },
+        ]}
+      />
     </div>
   );
 }
@@ -1645,6 +1657,19 @@ function MessageActions({
         {saved ? <Check className="h-3.5 w-3.5 text-success" /> : <NotebookPen className="h-3.5 w-3.5" />}
         {saved ? "Saved" : "Save as note"}
       </button>
+      {/* Right-click parity (DESIGN.md "objects are direct"): the same verbs
+          as the hover row, reachable from anywhere on the message. */}
+      <RowMenu
+        label="Message options"
+        items={[
+          { label: "Copy", icon: <Copy className="h-3.5 w-3.5" />, onClick: () => void copy() },
+          {
+            label: "Save as note",
+            icon: <NotebookPen className="h-3.5 w-3.5" />,
+            onClick: () => void save(),
+          },
+        ]}
+      />
     </div>
   );
 }

--- a/src/components/DevBadge.tsx
+++ b/src/components/DevBadge.tsx
@@ -16,7 +16,7 @@ export function DevBadge() {
   if (build?.profile !== "dev") return null;
   return (
     <span
-      className="mr-1 select-none rounded-full border border-[#e8a33d]/40 bg-[#e8a33d]/15 px-2 py-0.5 text-badge font-semibold tracking-wide text-[#e8a33d] [[data-scheme=light]_&]:text-[#7a5200]"
+      className="mr-1 select-none rounded-full border border-warning/40 bg-warning/15 px-2 py-0.5 text-badge font-semibold tracking-wide text-warning"
       title={`Dev build · ${build.commit}`}
     >
       DEV

--- a/src/components/DitherBackground.tsx
+++ b/src/components/DitherBackground.tsx
@@ -1,5 +1,22 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { THEMES, resolveThemeId, type ShaderVariant } from "@/lib/themes";
+
+/** Live prefers-reduced-motion. The CSS guard can't reach a WebGL loop, so
+ *  the shader components subscribe to the media query themselves — with a
+ *  change listener (like themes.ts's OS-appearance one), not a mount-time
+ *  snapshot, so flipping the OS setting takes effect without a reload. */
+export function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(
+    () => window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  );
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const onChange = () => setReduced(mq.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+  return reduced;
+}
 
 /**
  * Animated WebGL1 background: a theme-tinted luminance field quantized with
@@ -31,6 +48,7 @@ export function DitherBackground({
   intensity?: number;
 }) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const reducedMotion = useReducedMotion();
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -88,7 +106,6 @@ export function DitherBackground({
     let raf = 0;
     let last = 0;
     const startT = performance.now();
-    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
     // Grain is a texture, not weather — it draws once, like reduced motion.
     const isStatic = reducedMotion || variant === "grain";
     const render = (now: number) => {
@@ -117,7 +134,7 @@ export function DitherBackground({
       gl.deleteBuffer(buf);
       gl.deleteProgram(program);
     };
-  }, [themeKey, intensity]);
+  }, [themeKey, intensity, reducedMotion]);
 
   return (
     <canvas

--- a/src/components/GalleryPane.tsx
+++ b/src/components/GalleryPane.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { openUrl, revealItemInDir } from "@tauri-apps/plugin-opener";
 import { api } from "@/lib/api";
 import { removeSourcesGuarded, useStore } from "@/lib/store";
 import type { Source } from "@/lib/types";
@@ -17,14 +16,16 @@ import { cn, isWebUrl, relativeTime, urlHost } from "@/lib/utils";
 import { FilterBar } from "./FilterBar";
 import { AttachToCardModal } from "./RegistrySection";
 import { Favicon, sourceHoverData } from "./SourcesPanel";
+import {
+  sourceMetaItems,
+  sourceOriginItems,
+  useSourceMetaModals,
+} from "./SourceMetaModals";
 import { sourceIcon } from "@/lib/sourceIcon";
 import { GraphView } from "./GraphView";
 import {
   ArrowLeft,
-  ExternalLink,
-  FolderOpen,
   LayoutGrid,
-  Link2,
   MessageSquare,
   Package,
   Pencil,
@@ -139,6 +140,8 @@ export function GalleryPane() {
   const currentId = useStore((s) => s.currentId);
   const sources = useStore((s) => s.sources);
   const { confirm, dialog: confirmDialog } = useConfirm();
+  // Shared tag/note editors (SourceMetaModals) for the card menu entries.
+  const meta = useSourceMetaModals();
   const [attaching, setAttaching] = useState<Source | null>(null);
   /** Find-in-gallery (Cmd/Ctrl+F). A grid's analogue of find-in-source is
    *  filtering, not stepping through ranges — same bar, same Escape/Done,
@@ -383,7 +386,6 @@ export function GalleryPane() {
   // and on plain right-click (RowMenu opens from the nearest .group).
   const cardMenuItems = (s: Source) => {
     const st = useStore.getState();
-    const web = isWebUrl(s.url);
     const editable =
       !["url", "mac", "folder", "git", "notion", "obsidian"].includes(
         s.sourceType,
@@ -421,39 +423,9 @@ export function GalleryPane() {
             },
           ]
         : []),
-      ...(s.url && web
-        ? [
-            {
-              label: "Open original",
-              icon: <ExternalLink className="h-3.5 w-3.5" />,
-              onClick: () => void openUrl(s.url),
-            },
-          ]
-        : []),
-      ...(s.url && !web && s.sourceType !== "mac"
-        ? [
-            {
-              label: "Show in Finder",
-              icon: <FolderOpen className="h-3.5 w-3.5" />,
-              onClick: () => void revealItemInDir(s.url),
-            },
-          ]
-        : []),
-      ...(s.url && s.sourceType !== "mac"
-        ? [
-            {
-              label: web ? "Copy URL" : "Copy file path",
-              icon: <Link2 className="h-3.5 w-3.5" />,
-              onClick: () => {
-                void navigator.clipboard
-                  .writeText(s.url)
-                  .then(() =>
-                    useStore.getState().pushToast("success", "Copied"),
-                  );
-              },
-            },
-          ]
-        : []),
+      // Shared with the sources panel and reader — one menu per object.
+      ...sourceOriginItems(s),
+      ...sourceMetaItems(s, meta.setTagEdit, meta.setNoteEdit),
       {
         label: "File under a card…",
         icon: <Package className="h-3.5 w-3.5" />,
@@ -653,6 +625,7 @@ export function GalleryPane() {
         onClose={() => setAttaching(null)}
       />
       {confirmDialog}
+      {meta.modals}
       {hoverCard}
     </div>
   );

--- a/src/components/GalleryPane.tsx
+++ b/src/components/GalleryPane.tsx
@@ -12,7 +12,7 @@ import {
   useConfirm,
   useHoverCard,
 } from "./ui";
-import { cn, isWebUrl, relativeTime, urlHost } from "@/lib/utils";
+import { cn, isWebUrl, relativeTime, scrollMemory, shortcutBlocked, urlHost } from "@/lib/utils";
 import { FilterBar } from "./FilterBar";
 import { AttachToCardModal } from "./RegistrySection";
 import { Favicon, sourceHoverData } from "./SourcesPanel";
@@ -44,9 +44,8 @@ import {
  *  guards across runs, this guards within one. */
 const sweptNotebooks = new Set<string>();
 
-/** Scroll positions per notebook+level, so Reader round-trips and folder
- *  drill-ins come back to the same place. App-run lifetime is the point. */
-const scrollMemory = new Map<string, number>();
+/* Scroll positions per notebook+level ride the persistent scrollMemory in
+ * lib/utils — Reader round-trips AND relaunches come back to the same place. */
 
 /** Resolved card visuals (data URIs) per source id, so reopening the
  *  gallery paints instantly instead of re-running IPC + image fetches.
@@ -202,6 +201,9 @@ export function GalleryPane() {
   // column is a ternary), so neither listener can shadow the other.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
+      // Not while a modal owns the keyboard or the user is typing in a
+      // field — find used to open behind dialogs and steal focus mid-word.
+      if (shortcutBlocked(e)) return;
       if ((e.metaKey || e.ctrlKey) && e.key === "f") {
         e.preventDefault();
         setFindOpen(true);

--- a/src/components/GalleryPane.tsx
+++ b/src/components/GalleryPane.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { openUrl, revealItemInDir } from "@tauri-apps/plugin-opener";
 import { api } from "@/lib/api";
-import { useStore } from "@/lib/store";
+import { removeSourcesGuarded, useStore } from "@/lib/store";
 import type { Source } from "@/lib/types";
 import { GROUP_LABEL, GROUP_OF, type TypeGroup } from "@/lib/sourceGroups";
 import {
@@ -463,20 +463,7 @@ export function GalleryPane() {
         label: "Remove…",
         icon: <Trash2 className="h-3.5 w-3.5" />,
         danger: true,
-        onClick: async () => {
-          if (
-            await confirm({
-              title: `Remove "${s.title}"?`,
-              message:
-                GROUP_OF[s.sourceType] === "folders"
-                  ? "This removes the folder and everything under it from the notebook."
-                  : "This removes the source and its indexed content from the notebook.",
-              confirmLabel: "Remove",
-              danger: true,
-            })
-          )
-            void useStore.getState().deleteSource(s.id);
-        },
+        onClick: () => void removeSourcesGuarded([s.id], confirm),
       },
     ];
   };

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -622,6 +622,18 @@ export function GraphView() {
               const isNote = node.kind === "note";
               const labelled =
                 lit && (visibleLabels.has(p.id) || hovered === p.id);
+              const openNode = () => {
+                openedFromGraph = {
+                  notebook: currentId ?? "",
+                  id: p.id,
+                  focus,
+                  hops,
+                };
+                openInReader({
+                  type: isNote ? "note" : "source",
+                  id: p.id,
+                });
+              };
               return (
                 <g
                   key={p.id}
@@ -629,6 +641,19 @@ export function GraphView() {
                   transform={`translate(${p.x} ${p.y})`}
                   opacity={lit ? 1 : 0.22}
                   className="cursor-pointer"
+                  // Keyboard path: Tab walks the lit nodes (focus lights the
+                  // label like hover), Enter opens the document.
+                  tabIndex={lit ? 0 : -1}
+                  role="button"
+                  aria-label={`Open ${node.title}`}
+                  onFocus={() => setHovered(p.id)}
+                  onBlur={() => setHovered(null)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      openNode();
+                    }
+                  }}
                   onMouseEnter={(e) => {
                     setHovered(p.id);
                     const data = cardFor(p.id, node.kind);
@@ -647,16 +672,7 @@ export function GraphView() {
                       setFocus(p.id === focus ? null : p.id);
                       return;
                     }
-                    openedFromGraph = {
-                      notebook: currentId ?? "",
-                      id: p.id,
-                      focus,
-                      hops,
-                    };
-                    openInReader({
-                      type: isNote ? "note" : "source",
-                      id: p.id,
-                    });
+                    openNode();
                   }}
                 >
                   {/* Notes are hollow, sources solid — the same distinction

--- a/src/components/HomeSections.tsx
+++ b/src/components/HomeSections.tsx
@@ -395,7 +395,7 @@ export function StaffSidebar({
                   </span>
                   <button
                     type="button"
-                    className="ml-auto hidden shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground group-hover:block"
+                    className="ml-auto shrink-0 rounded p-0.5 text-muted-foreground opacity-0 hover:text-foreground group-hover:opacity-100 group-focus-within:opacity-100"
                     onClick={() => void runNow(r)}
                     disabled={runningId !== null}
                     title="Run now"

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -31,6 +31,7 @@ import {
   Archive,
   ArchiveRestore,
   BookOpen,
+  FileDown,
   ChevronRight,
   PanelRight,
   Plus,
@@ -76,6 +77,7 @@ function NotebookTable({
   pickedIds,
   onRowClick,
   onRowOpen,
+  colorPop,
 }: {
   notebooks: Notebook[];
   onNew: () => void;
@@ -88,6 +90,9 @@ function NotebookTable({
   /** Keyboard path: Tab reaches each row, Enter opens it (bypassing the
    *  pointer-only selection logic in onRowClick). */
   onRowOpen: (nb: Notebook) => void;
+  /** The color palette pop-over ("Change color…" in the row menu) — rendered
+   *  by the host so the table shares the grid's dismissal wiring. */
+  colorPop: (nb: Notebook) => React.ReactNode;
 }) {
   return (
     <>
@@ -118,7 +123,8 @@ function NotebookTable({
               pickedIds.has(nb.id) && "bg-primary/10 hover:bg-primary/15",
             )}
           >
-            <td className="px-3 py-2">
+            <td className="relative px-3 py-2">
+              {colorPop(nb)}
               <span className="flex items-center gap-2">
                 {(() => {
                   const Icon = notebookIcon(nb.icon);
@@ -367,6 +373,23 @@ export function HomeView({ onOpenSettings }: { onOpenSettings: () => void }) {
           icon: nb.icon,
         }),
     },
+    // Right-click parity: color was hover-swatch-only (cards) and export was
+    // palette-only — both belong on the object's one menu.
+    {
+      label: "Change color…",
+      icon: (
+        <span
+          className="block h-3.5 w-3.5 rounded-full border border-border"
+          style={{ backgroundColor: nb.color || NOTEBOOK_PALETTE[0] }}
+        />
+      ),
+      onClick: () => setColorPickerFor(nb.id),
+    },
+    {
+      label: "Export notebook…",
+      icon: <FileDown className="h-3.5 w-3.5" />,
+      onClick: () => void useStore.getState().exportNotebookOkf(nb.id),
+    },
     {
       label: "Archive",
       icon: <Archive className="h-3.5 w-3.5" />,
@@ -507,6 +530,39 @@ export function HomeView({ onOpenSettings }: { onOpenSettings: () => void }) {
     setColorPickerFor(null);
     setColor(notebookId, color);
   };
+
+  /** The color palette pop-over, positioned by the host (card corner or
+   *  table row). One markup: the outside-click/Escape dismissal keys off
+   *  its data attribute, so it works wherever it renders. */
+  const colorPalettePop = (nb: Notebook, className: string) =>
+    colorPickerFor === nb.id ? (
+      <div
+        onClick={(e) => e.stopPropagation()}
+        onPointerDown={(e) => e.stopPropagation()}
+        data-notebook-color-palette
+        className={cn(
+          "menu-glass absolute z-30 flex rounded-md border border-border px-2 py-1.5 shadow-sm",
+          className,
+        )}
+      >
+        {NOTEBOOK_PALETTE.map((c) => (
+          <button
+            key={c}
+            type="button"
+            onClick={() => onPickColor(nb.id, c)}
+            onPointerDown={(e) => e.stopPropagation()}
+            aria-label={`Set ${nb.title} color to ${c}`}
+            className={cn(
+              "m-0.5 h-5 w-5 rounded-full border border-border",
+              c === (nb.color || NOTEBOOK_PALETTE[0])
+                ? "ring-2 ring-foreground ring-offset-1 ring-offset-surface"
+                : "",
+            )}
+            style={{ backgroundColor: c }}
+          />
+        ))}
+      </div>
+    ) : null;
 
   function openNote(note: Note) {
     // StudioPanel auto-opens this id once the notebook's notes load.
@@ -836,6 +892,7 @@ export function HomeView({ onOpenSettings }: { onOpenSettings: () => void }) {
                     if (!pick.handleClick(e, nb.id)) open(nb.id);
                   }}
                   onRowOpen={(nb) => open(nb.id)}
+                  colorPop={(nb) => colorPalettePop(nb, "left-8 top-8")}
                   rowMenu={(nb) => (
                     <RowMenu
                       label={`Options for ${nb.title}`}
@@ -934,31 +991,7 @@ export function HomeView({ onOpenSettings }: { onOpenSettings: () => void }) {
                         items={notebookRowItems(nb)}
                       />
                     </div>
-                    {colorPickerFor === nb.id && (
-                      <div
-                        onClick={(e) => e.stopPropagation()}
-                        onPointerDown={(e) => e.stopPropagation()}
-                        data-notebook-color-palette
-                        className="menu-glass absolute right-2 top-10 z-30 flex rounded-md border border-border px-2 py-1.5 shadow-sm"
-                      >
-                        {NOTEBOOK_PALETTE.map((c) => (
-                          <button
-                            key={c}
-                            type="button"
-                            onClick={() => onPickColor(nb.id, c)}
-                            onPointerDown={(e) => e.stopPropagation()}
-                            aria-label={`Set ${nb.title} color to ${c}`}
-                            className={cn(
-                              "m-0.5 h-5 w-5 rounded-full border border-border",
-                              c === (nb.color || NOTEBOOK_PALETTE[0])
-                                ? "ring-2 ring-foreground ring-offset-1 ring-offset-surface"
-                                : "",
-                            )}
-                            style={{ backgroundColor: c }}
-                          />
-                        ))}
-                      </div>
-                    )}
+                    {colorPalettePop(nb, "right-2 top-10")}
                   </div>
                 ))}
               </div>

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -75,6 +75,7 @@ function NotebookTable({
   rowMenu,
   pickedIds,
   onRowClick,
+  onRowOpen,
 }: {
   notebooks: Notebook[];
   onNew: () => void;
@@ -84,6 +85,9 @@ function NotebookTable({
   rowMenu: (nb: Notebook) => React.ReactNode;
   pickedIds: Set<string>;
   onRowClick: (e: React.MouseEvent, nb: Notebook) => void;
+  /** Keyboard path: Tab reaches each row, Enter opens it (bypassing the
+   *  pointer-only selection logic in onRowClick). */
+  onRowOpen: (nb: Notebook) => void;
 }) {
   return (
     <>
@@ -101,7 +105,14 @@ function NotebookTable({
           <tr
             key={nb.id}
             data-pick-id={nb.id}
+            tabIndex={0}
             onClick={(e) => onRowClick(e, nb)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && e.target === e.currentTarget) {
+                e.preventDefault();
+                onRowOpen(nb);
+              }
+            }}
             className={cn(
               "group cursor-pointer border-b border-border transition-colors last:border-b-0 hover:bg-surface-2",
               pickedIds.has(nb.id) && "bg-primary/10 hover:bg-primary/15",
@@ -824,6 +835,7 @@ export function HomeView({ onOpenSettings }: { onOpenSettings: () => void }) {
                     if (justEnded()) return;
                     if (!pick.handleClick(e, nb.id)) open(nb.id);
                   }}
+                  onRowOpen={(nb) => open(nb.id)}
                   rowMenu={(nb) => (
                     <RowMenu
                       label={`Options for ${nb.title}`}
@@ -1086,16 +1098,31 @@ export function HomeView({ onOpenSettings }: { onOpenSettings: () => void }) {
                     role="separator"
                     aria-orientation="horizontal"
                     aria-label="Resize the brief"
+                    tabIndex={0}
                     onPointerDown={onSplitDrag}
                     onDoubleClick={() => {
                       setBriefSplit(40);
                       localStorage.setItem("homeBriefSplit", "40");
                     }}
-                    className="group/resize relative h-2 shrink-0 cursor-row-resize rounded transition-colors hover:bg-ring/30 active:bg-ring/40"
+                    onKeyDown={(e) => {
+                      // Arrow keys nudge the split — the same keyboard
+                      // affordance ResizeHandle gives the vertical edges.
+                      const delta =
+                        e.key === "ArrowDown" ? 2 : e.key === "ArrowUp" ? -2 : 0;
+                      if (!delta) return;
+                      e.preventDefault();
+                      const pct = clampSplit(briefSplit + delta);
+                      setBriefSplit(pct);
+                      localStorage.setItem(
+                        "homeBriefSplit",
+                        String(Math.round(pct)),
+                      );
+                    }}
+                    className="group/resize relative h-2 shrink-0 cursor-row-resize rounded transition-colors hover:bg-ring/30 active:bg-ring/40 focus-visible:bg-ring/30"
                   >
                     <span
                       aria-hidden
-                      className="absolute top-1/2 left-1/2 flex -translate-x-1/2 -translate-y-1/2 gap-0.5 opacity-40 transition-opacity group-hover/resize:opacity-100"
+                      className="absolute top-1/2 left-1/2 flex -translate-x-1/2 -translate-y-1/2 gap-0.5 opacity-40 transition-opacity group-hover/resize:opacity-100 group-focus-visible/resize:opacity-100"
                     >
                       <span className="h-0.5 w-0.5 rounded-full bg-muted-foreground" />
                       <span className="h-0.5 w-0.5 rounded-full bg-muted-foreground" />

--- a/src/components/HomeViewControls.tsx
+++ b/src/components/HomeViewControls.tsx
@@ -8,7 +8,7 @@
    doesn't search inside anything. ⌘K is still the way to search content. */
 import { useEffect, useRef } from "react";
 import { useStore } from "@/lib/store";
-import { cn } from "@/lib/utils";
+import { cn, shortcutBlocked } from "@/lib/utils";
 import { LayoutGrid, List, Search, X } from "lucide-react";
 
 /** Case-insensitive substring over whatever the row shows as its name. */
@@ -44,6 +44,9 @@ export function HomeViewControls({
   // the same key means "find within what I'm looking at" everywhere.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
+      // Not while a modal owns the keyboard or the user is typing in a
+      // field — find used to open behind dialogs and steal focus mid-word.
+      if (shortcutBlocked(e)) return;
       if ((e.metaKey || e.ctrlKey) && e.key === "f") {
         e.preventDefault();
         inputRef.current?.focus();

--- a/src/components/Infographic.tsx
+++ b/src/components/Infographic.tsx
@@ -351,7 +351,7 @@ function BlockView({
                   aria-hidden
                 >
                   <div
-                    className="h-full rounded-full transition-[width] duration-700 ease-out"
+                    className="h-full rounded-full transition-[width] duration-200 ease-out"
                     style={{
                       width: `${grown ? width : 0}%`,
                       background: `linear-gradient(90deg, color-mix(in srgb, ${color} 70%, transparent), ${color})`,
@@ -374,7 +374,7 @@ function BlockView({
             return (
               <div
                 key={i}
-                className="flex items-center justify-between gap-3 rounded-lg px-4 py-2 transition-[width] duration-700 ease-out"
+                className="flex items-center justify-between gap-3 rounded-lg px-4 py-2 transition-[width] duration-200 ease-out"
                 style={{
                   width: `${grown ? width : 18}%`,
                   minWidth: "fit-content",

--- a/src/components/LedgerPane.tsx
+++ b/src/components/LedgerPane.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { api } from "@/lib/api";
 import { useStore } from "@/lib/store";
 import type { LedgerEntry } from "@/lib/types";
-import { Button, EmptyState, Input, RowMenu, useConfirm } from "./ui";
+import { Button, EmptyState, Input, RowMenu } from "./ui";
 import { cn, relativeTime } from "@/lib/utils";
 import {
   HelpCircle,
@@ -62,7 +62,6 @@ export function LedgerPane() {
   const ledgerBump = useStore((s) => s.ledgerBump);
   const openSourceViewer = useStore((s) => s.openSourceViewer);
   const pushToast = useStore((s) => s.pushToast);
-  const { confirm, dialog: confirmDialog } = useConfirm();
 
   const [entries, setEntries] = useState<LedgerEntry[] | null>(null);
   const [filter, setFilter] = useState<"all" | Kind>("all");
@@ -111,18 +110,34 @@ export function LedgerPane() {
   }
 
   async function remove(entry: LedgerEntry) {
-    if (
-      !(await confirm({
-        title: "Delete this entry?",
-        message: `“${entry.text.slice(0, 120)}” will be removed from the ledger permanently.`,
-        confirmLabel: "Delete",
-        danger: true,
-      }))
-    )
-      return;
+    // Undo beats confirm: the toast recreates the entry with its anchors and
+    // status (chat-minted origin doesn't survive — the restored row is yours).
     try {
       await api.deleteLedgerEntry(entry.id);
       void load();
+      pushToast(
+        "success",
+        `Deleted “${entry.text.slice(0, 60)}” — click to undo`,
+        () =>
+          void (async () => {
+            try {
+              const restored = await api.addLedgerEntry(
+                entry.notebookId,
+                entry.kind,
+                entry.text,
+                entry.why || undefined,
+                entry.anchors,
+              );
+              if (entry.status)
+                await api.updateLedgerEntry(restored.id, {
+                  status: entry.status,
+                });
+              void load();
+            } catch (e) {
+              pushToast("error", e instanceof Error ? e.message : String(e));
+            }
+          })(),
+      );
     } catch (e) {
       pushToast("error", e instanceof Error ? e.message : String(e));
     }
@@ -394,7 +409,6 @@ export function LedgerPane() {
           )}
         </div>
       </div>
-      {confirmDialog}
     </div>
   );
 }

--- a/src/components/MacConnect.tsx
+++ b/src/components/MacConnect.tsx
@@ -79,7 +79,7 @@ export function FdaHint({ message }: { message: string }) {
   return (
     <div className="flex flex-col gap-2 rounded-md border border-border bg-surface-2/40 px-3 py-2.5">
       <div className="flex items-start gap-2 text-caption leading-relaxed text-foreground/90">
-        <ShieldAlert className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[#e8a33d]" />
+        <ShieldAlert className="mt-0.5 h-3.5 w-3.5 shrink-0 text-warning" />
         <span>{message}</span>
       </div>
       <div>

--- a/src/components/MigrationOverlay.tsx
+++ b/src/components/MigrationOverlay.tsx
@@ -27,7 +27,7 @@ export function MigrationOverlay() {
 
         <div className="mb-2 h-2 overflow-hidden rounded-full bg-surface-2">
           <div
-            className="h-full rounded-full bg-primary transition-all duration-300"
+            className="h-full rounded-full bg-primary transition-all duration-200"
             style={{ width: `${Math.max(3, pct)}%` }}
           />
         </div>

--- a/src/components/ReaderPane.tsx
+++ b/src/components/ReaderPane.tsx
@@ -33,6 +33,7 @@ import {
   fmtDay,
   folderProvider,
   isWebUrl,
+  scrollMemory,
   shortcutBlocked,
   urlHost,
 } from "@/lib/utils";
@@ -364,8 +365,8 @@ function applyFindHighlights(ranges: Range[], active: number): boolean {
   return true;
 }
 
-/** Per-document scroll positions, remembered for the session. */
-const scrollMemory = new Map<string, number>();
+// Per-document scroll positions ride the persistent scrollMemory in
+// lib/utils, so reading position survives relaunch, not just the session.
 
 /** Restore (once content is ready) and record a container's scroll position.
  *  `restore` false records without jumping (e.g. a citation anchor wins). */
@@ -1965,6 +1966,9 @@ function SourceReader({
   // exists only while finding).
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
+      // Not while a modal owns the keyboard or the user is typing in a
+      // field — find used to open behind dialogs and steal focus mid-word.
+      if (shortcutBlocked(e)) return;
       if ((e.metaKey || e.ctrlKey) && e.key === "f") {
         e.preventDefault();
         onFindOpen();
@@ -2860,9 +2864,14 @@ function InlineNote({ note }: { note: Note }) {
     timer.current = window.setTimeout(() => flushRef.current(), 1200);
   };
 
-  // Doc switch or leaving the reader saves whatever is pending.
+  // Doc switch or leaving the reader saves whatever is pending — and so
+  // does quitting: pagehide is the last synchronous moment the webview
+  // gives us, and a 1200ms debounce otherwise loses the final keystrokes.
   useEffect(() => {
+    const onPageHide = () => flushRef.current();
+    window.addEventListener("pagehide", onPageHide);
     return () => {
+      window.removeEventListener("pagehide", onPageHide);
       if (timer.current) window.clearTimeout(timer.current);
       flushRef.current();
     };

--- a/src/components/ReaderPane.tsx
+++ b/src/components/ReaderPane.tsx
@@ -1683,6 +1683,135 @@ function DocProperties({
   );
 }
 
+/** One open reminder parsed out of a Reminders source body. The id rides the
+ *  text as a trailing code span (mac.rs carries it for exactly this); rows
+ *  without one render inert — there is no way to name them to cider. */
+type ReminderRow = {
+  title: string;
+  id: string | null;
+  due: string | null;
+  notes: string | null;
+};
+
+function parseReminders(text: string): { heading: string; items: ReminderRow[] } {
+  const items: ReminderRow[] = [];
+  let heading = "";
+  for (const line of text.split("\n")) {
+    const h = /^# (.*)$/.exec(line);
+    if (h) {
+      heading = h[1];
+      continue;
+    }
+    const m = /^- \[ \] (.*)$/.exec(line);
+    if (m) {
+      let rest = m[1];
+      let due: string | null = null;
+      const dm = / — due (\d{4}-\d{2}-\d{2})$/.exec(rest);
+      if (dm) {
+        due = dm[1];
+        rest = rest.slice(0, -dm[0].length);
+      }
+      let id: string | null = null;
+      const im = / `([^`]+)`$/.exec(rest);
+      if (im) {
+        id = im[1];
+        rest = rest.slice(0, -im[0].length);
+      }
+      items.push({ title: rest, id, due, notes: null });
+      continue;
+    }
+    const n = /^ {2}- (.*)$/.exec(line);
+    if (n && items.length > 0) items[items.length - 1].notes = n[1];
+  }
+  return { heading, items };
+}
+
+/** A Reminders-list source rendered live: each reminder is a real checkbox
+ *  wired to complete_mac_reminder — the same call agents already have — not
+ *  inert markdown. Checking one completes it in Apple Reminders and resyncs
+ *  the source; the row holds its checked state until the refetched body
+ *  (open reminders only) drops it. */
+function RemindersView({
+  content,
+  sourceId,
+  onCompleted,
+}: {
+  content: string;
+  sourceId: string;
+  onCompleted: () => void;
+}) {
+  const parsed = useMemo(() => parseReminders(content), [content]);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [done, setDone] = useState<Set<string>>(new Set());
+
+  async function complete(row: ReminderRow) {
+    if (!row.id || busy) return;
+    setBusy(row.id);
+    try {
+      await api.completeMacReminder(sourceId, row.id);
+      setDone((d) => new Set(d).add(row.id!));
+      onCompleted();
+    } catch (err) {
+      useStore.getState().pushToast("error", String(err));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div className="selectable">
+      {parsed.heading && (
+        <h1 className="mb-4 text-title font-semibold text-foreground">
+          {parsed.heading}
+        </h1>
+      )}
+      <ul className="flex flex-col gap-1.5">
+        {parsed.items.map((row, i) => {
+          const checked = !!row.id && done.has(row.id);
+          return (
+            <li key={row.id ?? `row-${i}`} className="flex items-start gap-2.5">
+              <input
+                type="checkbox"
+                className="select-quiet mt-1"
+                checked={checked}
+                disabled={!row.id || checked || busy === row.id}
+                onChange={() => void complete(row)}
+                aria-label={`Complete “${row.title}”`}
+                title={row.id ? "Check off in Apple Reminders" : undefined}
+              />
+              <div className="min-w-0">
+                <div
+                  className={cn(
+                    "text-body leading-relaxed text-foreground/90",
+                    checked && "text-muted-foreground line-through",
+                  )}
+                >
+                  {row.title}
+                  {row.due && (
+                    <span className="ml-2 text-caption text-subtle-foreground">
+                      due {row.due}
+                    </span>
+                  )}
+                </div>
+                {row.notes && (
+                  <div className="text-caption text-muted-foreground">
+                    {row.notes}
+                  </div>
+                )}
+              </div>
+            </li>
+          );
+        })}
+        {parsed.items.length === 0 && (
+          <li className="text-body text-muted-foreground">
+            Nothing left on this list.
+          </li>
+        )}
+      </ul>
+    </div>
+  );
+}
+
 function SourceReader({
   source,
   highlight,
@@ -1908,6 +2037,14 @@ function SourceReader({
   // syntax colors; find-in-source over the colored view re-anchors on the
   // rendered DOM each keystroke.
   const codeMode = source.sourceType === "code" && !highlight;
+  // A Reminders list renders as live checkboxes (complete-in-place) instead
+  // of inert markdown — except during find or a citation anchor, which need
+  // the text views' highlight machinery.
+  const remindersMode =
+    source.sourceType === "mac" &&
+    source.url.startsWith("cider://reminders/list/") &&
+    !query.trim() &&
+    !highlight;
   // "DOM-rendered": find walks text nodes instead of painting the plain
   // <mark> segments. True for both the markdown and code (shiki) views.
   const domMode = richMode || codeMode;
@@ -2320,6 +2457,12 @@ function SourceReader({
                 </span>
               )}
             </div>
+          ) : remindersMode ? (
+            <RemindersView
+              content={content}
+              sourceId={source.id}
+              onCompleted={() => setHydrateTick((t) => t + 1)}
+            />
           ) : codeMode ? (
             <CodeView path={source.title} code={content} lineNums />
           ) : richMode ? (

--- a/src/components/ReaderPane.tsx
+++ b/src/components/ReaderPane.tsx
@@ -710,7 +710,9 @@ export function ReaderPane() {
   ];
   return (
     <div ref={rootRef} className="relative flex h-full flex-1 flex-col min-w-0">
-      <div className="relative z-10 flex h-12 shrink-0 items-center gap-0.5 border-b border-border px-3">
+      {/* `group`: the toolbar RowMenu binds right-click to its nearest .group
+          ancestor — without one, right-clicking the title bar did nothing. */}
+      <div className="group relative z-10 flex h-12 shrink-0 items-center gap-0.5 border-b border-border px-3">
         <Button
           variant="ghost"
           size="icon"

--- a/src/components/ReaderPane.tsx
+++ b/src/components/ReaderPane.tsx
@@ -2166,11 +2166,23 @@ function SourceReader({
 
   // Selection → ask toolbar (window-level mouseup so releasing outside the
   // container still raises it; the handler validates the selection home).
+  // selectionchange rides along, debounced, for keyboard selection —
+  // shift+arrows never fires a mouseup.
   const updateSelectionRef = useRef<() => void>(() => {});
   useEffect(() => {
     const onUp = () => updateSelectionRef.current();
+    let timer: number | null = null;
+    const onChange = () => {
+      if (timer) window.clearTimeout(timer);
+      timer = window.setTimeout(() => updateSelectionRef.current(), 200);
+    };
     window.addEventListener("mouseup", onUp);
-    return () => window.removeEventListener("mouseup", onUp);
+    document.addEventListener("selectionchange", onChange);
+    return () => {
+      if (timer) window.clearTimeout(timer);
+      window.removeEventListener("mouseup", onUp);
+      document.removeEventListener("selectionchange", onChange);
+    };
   }, []);
 
   function updateSelection() {
@@ -3344,6 +3356,23 @@ function RepoView({ source, map }: { source: Source; map: string | null }) {
       setTierBusy(false);
     }
   }
+
+  // Keyboard selection (shift+arrows) never fires the pane's onMouseUp —
+  // follow selectionchange too, debounced so drags don't churn the toolbar.
+  const captureSelectionRef = useRef<() => void>(() => {});
+  captureSelectionRef.current = captureSelection;
+  useEffect(() => {
+    let timer: number | null = null;
+    const onChange = () => {
+      if (timer) window.clearTimeout(timer);
+      timer = window.setTimeout(() => captureSelectionRef.current(), 200);
+    };
+    document.addEventListener("selectionchange", onChange);
+    return () => {
+      if (timer) window.clearTimeout(timer);
+      document.removeEventListener("selectionchange", onChange);
+    };
+  }, []);
 
   function captureSelection() {
     const container = paneRef.current;

--- a/src/components/RegistrySection.tsx
+++ b/src/components/RegistrySection.tsx
@@ -828,7 +828,15 @@ function CardTable({
             <tr
               key={c.id}
               data-pick-id={c.id}
+              tabIndex={0}
               onClick={(e) => onRowClick(e, c.id)}
+              onKeyDown={(e) => {
+                // Keyboard path: Tab reaches the row, Enter opens the card.
+                if (e.key === "Enter" && e.target === e.currentTarget) {
+                  e.preventDefault();
+                  useStore.setState({ openCardId: c.id });
+                }
+              }}
               className={cn(
                 "group cursor-pointer border-b border-border transition-colors last:border-b-0 hover:bg-surface-2",
                 pickedIds.has(c.id) && "bg-primary/10 hover:bg-primary/15",
@@ -1611,7 +1619,7 @@ function FactRow({
       <span className="group flex items-center gap-2 text-foreground">
         <span className="min-w-0 flex-1">{fact.value}</span>
         <button
-          className="shrink-0 text-subtle-foreground opacity-0 transition hover:text-destructive group-hover:opacity-100"
+          className="shrink-0 text-subtle-foreground opacity-0 transition hover:text-destructive group-hover:opacity-100 group-focus-within:opacity-100"
           onClick={onRemove}
           title="Remove this fact"
         >

--- a/src/components/RegistrySection.tsx
+++ b/src/components/RegistrySection.tsx
@@ -900,10 +900,28 @@ function SuggestionStrip({
   );
   const recommended = cards.filter((c) => c.triage === "recommended").length;
 
+  // Dismissing is sticky ("won't be suggested again"), so the toast carries
+  // the undo: put the dismissed cards back in the queue as suggestions. The
+  // triage highlight is queue metadata and doesn't survive the round trip.
+  const undoDismiss = (dismissed: RegistryCard[]) => {
+    const label =
+      dismissed.length === 1
+        ? `Dismissed “${dismissed[0].name}” — click to undo`
+        : `Dismissed ${dismissed.length} suggestions — click to undo`;
+    useStore.getState().pushToast("success", label, () =>
+      void (async () => {
+        for (const c of dismissed) await api.setCardOrigin(c.id, "auto");
+        onChanged();
+      })(),
+    );
+  };
+
   const rule = async (id: string, origin: string) => {
     setBusy(id);
     try {
+      const card = cards.find((c) => c.id === id);
       await api.setCardOrigin(id, origin);
+      if (origin === "dismissed" && card) undoDismiss([card]);
       onChanged();
     } finally {
       setBusy(null);
@@ -913,7 +931,11 @@ function SuggestionStrip({
   const ruleAll = async (key: string, origin: string, onlyRec?: boolean) => {
     setBusy(key);
     try {
+      const affected = onlyRec
+        ? cards.filter((c) => c.triage === "recommended")
+        : cards;
       await api.ruleAllSuggested(origin, onlyRec);
+      if (origin === "dismissed" && affected.length > 0) undoDismiss(affected);
       onChanged();
     } finally {
       setBusy(null);

--- a/src/components/RegistrySection.tsx
+++ b/src/components/RegistrySection.tsx
@@ -54,6 +54,44 @@ import {
   X,
 } from "lucide-react";
 
+/** The one card-delete path (DESIGN.md §9: undo beats confirm). Deletes
+ *  immediately; the toast's undo recreates each card — identifiers, note,
+ *  facts — and re-files its attachments. Ruling metadata (origin/triage)
+ *  doesn't survive, which only matters for suggested cards, and those are
+ *  dismissed rather than deleted. */
+async function deleteCardsUndoable(cards: RegistryCard[], after: () => void) {
+  if (cards.length === 0) return;
+  for (const c of cards) await api.deleteRegistryCard(c.id);
+  after();
+  const label =
+    cards.length === 1
+      ? `Deleted “${cards[0].name}” — click to undo`
+      : `Deleted ${cards.length} cards — click to undo`;
+  useStore.getState().pushToast("success", label, () =>
+    void (async () => {
+      try {
+        for (const c of cards) {
+          const restored = await api.addRegistryCard(
+            c.kind,
+            c.name,
+            c.identifiers,
+            c.note,
+            c.facts,
+          );
+          for (const a of c.attachments) {
+            await api.attachSourceToCard(restored.id, a.sourceId, a.status);
+          }
+        }
+      } catch (e) {
+        useStore
+          .getState()
+          .pushToast("error", e instanceof Error ? e.message : String(e));
+      }
+      after();
+    })(),
+  );
+}
+
 const KINDS: { id: CardKind; label: string; icon: React.ReactNode }[] = [
   { id: "asset", label: "Assets", icon: <Package className="h-4 w-4" /> },
   { id: "person", label: "People", icon: <User className="h-4 w-4" /> },
@@ -266,21 +304,11 @@ export function RegistrySection() {
       danger: true,
       onClick: () =>
         void (async () => {
-          const names = ids.map(
-            (id) => mine.find((c) => c.id === id)?.name ?? "Untitled",
-          );
-          const ok = await confirm({
-            title: `Delete ${ids.length} cards?`,
-            message:
-              "The documents filed under them are untouched — only the cards and their filings go away.",
-            items: names,
-            confirmLabel: "Delete",
-            danger: true,
+          const cards = mine.filter((c) => ids.includes(c.id));
+          await deleteCardsUndoable(cards, () => {
+            useStore.getState().clearPicked();
+            void load();
           });
-          if (!ok) return;
-          for (const id of ids) await api.deleteRegistryCard(id);
-          useStore.getState().clearPicked();
-          void load();
         })(),
     },
   ];
@@ -773,7 +801,6 @@ function CardTable({
   onRowClick: (e: React.MouseEvent, id: string) => void;
   onContextItems: (id: string) => () => RowMenuItem[] | null;
 }) {
-  const { confirm, dialog } = useConfirm();
   return (
     <>
       {/* No "New card" button here — the header's covers both views. */}
@@ -850,20 +877,9 @@ function CardTable({
                       onClick: () => useStore.setState({ openCardId: c.id }),
                     },
                     {
-                      label: "Delete card…",
+                      label: "Delete card",
                       danger: true,
-                      onClick: () => void (async () => {
-                        const ok = await confirm({
-                          title: `Delete “${c.name}”?`,
-                          message:
-                            "The documents filed under it are untouched — only the card and its filing go away.",
-                          confirmLabel: "Delete",
-                          danger: true,
-                        });
-                        if (!ok) return;
-                        await api.deleteRegistryCard(c.id);
-                        onChanged();
-                      })(),
+                      onClick: () => void deleteCardsUndoable([c], onChanged),
                     },
                   ]}
                 />
@@ -872,7 +888,6 @@ function CardTable({
           );
         })}
       </HomeTable>
-      {dialog}
     </>
   );
 }
@@ -1056,7 +1071,6 @@ function CardTile({
   onActivate?: (e: React.MouseEvent) => true | undefined;
   onContextItems?: () => RowMenuItem[] | null;
 }) {
-  const { confirm, dialog } = useConfirm();
   const docs = confirmed(card).length;
   const pending = proposed(card).length;
   return (
@@ -1110,25 +1124,13 @@ function CardTile({
           items={[
             { label: "Open", onClick: onOpen },
             {
-              label: "Delete card…",
+              label: "Delete card",
               danger: true,
-              onClick: () => void (async () => {
-                const ok = await confirm({
-                  title: `Delete “${card.name}”?`,
-                  message:
-                    "The documents filed under it are untouched — only the card and its filing go away.",
-                  confirmLabel: "Delete",
-                  danger: true,
-                });
-                if (!ok) return;
-                await api.deleteRegistryCard(card.id);
-                onChanged();
-              })(),
+              onClick: () => void deleteCardsUndoable([card], onChanged),
             },
           ]}
         />
       </div>
-      {dialog}
     </div>
   );
 }
@@ -1242,7 +1244,6 @@ function CardDetail({
   onChanged: () => void;
 }) {
   const notebooks = useStore((s) => s.notebooks);
-  const { confirm, dialog } = useConfirm();
   const [titles, setTitles] = useState<Map<string, Source>>(new Map());
 
   // Escape backs out, the way it leaves the reader — a detail view you can
@@ -1477,19 +1478,12 @@ function CardDetail({
           <Button
             variant="ghost"
             size="sm"
-            onClick={async () => {
-              const ok = await confirm({
-                title: `Delete “${card.name}”?`,
-                message:
-                  "The documents filed under it are untouched — only the card and its filing go away.",
-                confirmLabel: "Delete",
-                danger: true,
-              });
-              if (!ok) return;
-              await api.deleteRegistryCard(card.id);
-              onBack();
-              onChanged();
-            }}
+            onClick={() =>
+              void deleteCardsUndoable([card], () => {
+                onBack();
+                onChanged();
+              })
+            }
           >
             <Trash2 className="h-3.5 w-3.5" />
           </Button>
@@ -1531,7 +1525,6 @@ function CardDetail({
         </div>
       </div>
       {docMarquee}
-      {dialog}
     </div>
   );
 }

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -78,7 +78,6 @@ export function SettingsDialog({
   const [tab, setTab] = useState(initialTab);
   const [draft, setDraft] = useState<AiConfig | null>(null);
   const [saving, setSaving] = useState(false);
-  const [confirmReembed, setConfirmReembed] = useState(false);
 
   useEffect(() => {
     if (open) setTab(initialTab);
@@ -100,9 +99,15 @@ export function SettingsDialog({
 
   async function onSave() {
     if (!draft) return;
-    // Switching the embedding model invalidates existing vectors — re-embed.
+    // Switching the embedding model invalidates existing vectors — save and
+    // re-embed straight away. Destroys nothing; the migration overlay is the
+    // feedback, not a confirm (DESIGN.md §9).
     if (embedChanged && totalSources > 0) {
-      setConfirmReembed(true);
+      setSaving(true);
+      await save(draft);
+      setSaving(false);
+      onClose();
+      await reembedAll();
       return;
     }
     setSaving(true);
@@ -127,22 +132,6 @@ export function SettingsDialog({
     onClose();
   }
 
-  async function confirmSwitch() {
-    if (!draft) return;
-    setConfirmReembed(false);
-    setSaving(true);
-    await save(draft);
-    setSaving(false);
-    onClose();
-    await reembedAll();
-  }
-
-  function cancelSwitch() {
-    // Keep the previous embedding model so we never leave a broken index.
-    setConfirmReembed(false);
-    if (draft && aiConfig)
-      setDraft({ ...draft, embedModel: aiConfig.embedModel });
-  }
 
   if (!draft) {
     return (
@@ -252,35 +241,6 @@ export function SettingsDialog({
         </div>
       </div>
 
-      <Modal
-        open={confirmReembed}
-        onClose={cancelSwitch}
-        title="Switch search model?"
-      >
-        <div className="flex flex-col gap-4">
-          <p className="text-body leading-relaxed text-muted-foreground">
-            Switching to{" "}
-            <span className="font-medium text-foreground">
-              {draft.embedder === "builtin"
-                ? "the built-in model"
-                : draft.embedModel}
-            </span>{" "}
-            rebuilds the search index for all{" "}
-            <span className="font-medium text-foreground">{totalSources}</span>{" "}
-            source
-            {totalSources === 1 ? "" : "s"}. This runs locally and may take a
-            moment.
-          </p>
-          <div className="flex justify-end gap-2">
-            <Button variant="ghost" onClick={cancelSwitch}>
-              Cancel
-            </Button>
-            <Button variant="primary" onClick={confirmSwitch}>
-              Switch & re-embed
-            </Button>
-          </div>
-        </div>
-      </Modal>
     </Modal>
   );
 }

--- a/src/components/SourceMetaModals.tsx
+++ b/src/components/SourceMetaModals.tsx
@@ -1,0 +1,197 @@
+import { useState } from "react";
+import { openUrl, revealItemInDir } from "@tauri-apps/plugin-opener";
+import { useStore } from "@/lib/store";
+import { isWebUrl } from "@/lib/utils";
+import type { Source } from "@/lib/types";
+import { Button, Input, Modal, Textarea, type RowMenuItem } from "./ui";
+import {
+  ExternalLink,
+  FolderOpen,
+  Link2,
+  StickyNote,
+  Tag,
+} from "lucide-react";
+
+/* One source, one menu (DESIGN.md "objects are direct"): the shared pieces
+ * of the source menu so the panel, the gallery, and the reader stop drifting
+ * three separate copies. Surfaces compose these with their own verbs. */
+
+/** Open original / Show in Finder / Copy URL — the origin trio, identical
+ *  wherever a source row can be right-clicked. */
+export function sourceOriginItems(s: Source): RowMenuItem[] {
+  if (!s.url || s.sourceType === "mac") return [];
+  const web = isWebUrl(s.url);
+  return [
+    ...(web
+      ? [
+          {
+            label: "Open original",
+            icon: <ExternalLink className="h-3.5 w-3.5" />,
+            onClick: () => void openUrl(s.url),
+          },
+        ]
+      : [
+          {
+            label: "Show in Finder",
+            icon: <FolderOpen className="h-3.5 w-3.5" />,
+            onClick: () => void revealItemInDir(s.url),
+          },
+        ]),
+    {
+      label: web ? "Copy URL" : "Copy file path",
+      icon: <Link2 className="h-3.5 w-3.5" />,
+      onClick: () => {
+        void navigator.clipboard
+          .writeText(s.url)
+          .then(() => useStore.getState().pushToast("success", "Copied"));
+      },
+    },
+  ];
+}
+
+export type TagEditState = { ids: string[]; title: string; value: string } | null;
+export type NoteEditState = { id: string; title: string; value: string } | null;
+
+/** Tags / note menu entries, aimed at the host's SourceMetaModals state. */
+export function sourceMetaItems(
+  s: Source,
+  openTagEdit: (state: NonNullable<TagEditState>) => void,
+  openNoteEdit: (state: NonNullable<NoteEditState>) => void,
+): RowMenuItem[] {
+  return [
+    {
+      label: s.tags ? "Edit tags…" : "Add tags…",
+      icon: <Tag className="h-3.5 w-3.5" />,
+      onClick: () => openTagEdit({ ids: [s.id], title: s.title, value: s.tags }),
+    },
+    {
+      label: s.note ? "Edit note…" : "Add note…",
+      icon: <StickyNote className="h-3.5 w-3.5" />,
+      onClick: () =>
+        openNoteEdit({ id: s.id, title: s.title, value: s.note }),
+    },
+  ];
+}
+
+/** Bundled state for hosts that only need the default wiring. */
+export function useSourceMetaModals() {
+  const [tagEdit, setTagEdit] = useState<TagEditState>(null);
+  const [noteEdit, setNoteEdit] = useState<NoteEditState>(null);
+  return {
+    tagEdit,
+    setTagEdit,
+    noteEdit,
+    setNoteEdit,
+    modals: (
+      <SourceMetaModals
+        tagEdit={tagEdit}
+        setTagEdit={setTagEdit}
+        noteEdit={noteEdit}
+        setNoteEdit={setNoteEdit}
+      />
+    ),
+  };
+}
+
+/** The tag and note editors themselves — the single copy every surface
+ *  mounts (they were pasted per-panel before). */
+export function SourceMetaModals({
+  tagEdit,
+  setTagEdit,
+  noteEdit,
+  setNoteEdit,
+}: {
+  tagEdit: TagEditState;
+  setTagEdit: (s: TagEditState) => void;
+  noteEdit: NoteEditState;
+  setNoteEdit: (s: NoteEditState) => void;
+}) {
+  const setSourceTags = useStore((s) => s.setSourceTags);
+  const setSourcesTagsBatch = useStore((s) => s.setSourcesTagsBatch);
+  const setSourceNote = useStore((s) => s.setSourceNote);
+  return (
+    <>
+      <Modal
+        open={!!tagEdit}
+        onClose={() => setTagEdit(null)}
+        title={`Tags for "${tagEdit?.title ?? ""}"`}
+        width="max-w-md"
+      >
+        <form
+          onSubmit={async (e) => {
+            e.preventDefault();
+            if (!tagEdit) return;
+            const { ids, value } = tagEdit;
+            setTagEdit(null);
+            if (ids.length === 1) await setSourceTags(ids[0], value);
+            else await setSourcesTagsBatch(ids, value);
+          }}
+          className="flex flex-col gap-3"
+        >
+          <Input
+            autoFocus
+            name="source-tags"
+            aria-label="Source tags"
+            placeholder="research rust retrieval"
+            value={tagEdit?.value ?? ""}
+            onChange={(e) =>
+              setTagEdit(tagEdit ? { ...tagEdit, value: e.target.value } : tagEdit)
+            }
+          />
+          <p className="text-micro leading-relaxed text-subtle-foreground">
+            Space-separated; "#" and case don't matter. Tags show up in
+            chat's source list and help match questions to notebooks.
+          </p>
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="ghost" onClick={() => setTagEdit(null)}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="primary">
+              Save
+            </Button>
+          </div>
+        </form>
+      </Modal>
+
+      <Modal
+        open={!!noteEdit}
+        onClose={() => setNoteEdit(null)}
+        title={`Note on "${noteEdit?.title ?? ""}"`}
+        width="max-w-md"
+      >
+        <form
+          onSubmit={async (e) => {
+            e.preventDefault();
+            if (!noteEdit) return;
+            const { id, value } = noteEdit;
+            setNoteEdit(null);
+            await setSourceNote(id, value);
+          }}
+          className="flex flex-col gap-3"
+        >
+          <Textarea
+            autoFocus
+            rows={5}
+            name="source-note"
+            aria-label="Source note"
+            placeholder="Why did you save this? Chat can recall it."
+            value={noteEdit?.value ?? ""}
+            onChange={(e) =>
+              setNoteEdit(
+                noteEdit ? { ...noteEdit, value: e.target.value } : noteEdit,
+              )
+            }
+          />
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="ghost" onClick={() => setNoteEdit(null)}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="primary">
+              Save
+            </Button>
+          </div>
+        </form>
+      </Modal>
+    </>
+  );
+}

--- a/src/components/SourcesPanel.tsx
+++ b/src/components/SourcesPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useStore } from "@/lib/store";
+import { removeSourcesGuarded, useStore } from "@/lib/store";
 import { api } from "@/lib/api";
 import {
   Badge,
@@ -223,7 +223,6 @@ export function SourcesPanel() {
   const setSourceNote = useStore((s) => s.setSourceNote);
   const addMacReminder = useStore((s) => s.addMacReminder);
   const refreshSource = useStore((s) => s.refreshSource);
-  const deleteSource = useStore((s) => s.deleteSource);
   const draggingFiles = useStore((s) => s.draggingFiles);
   const toggleSources = useStore((s) => s.toggleSources);
   const openSourceViewer = useStore((s) => s.openSourceViewer);
@@ -428,16 +427,9 @@ export function SourcesPanel() {
   }
 
   async function confirmRemoveBatch(ids: string[]) {
-    if (
-      await confirm({
-        title: `Remove ${ids.length} sources?`,
-        message:
-          "This deletes the selected sources and their embedded chunks from the notebook (folders take their files along). Nothing on disk is touched.",
-        confirmLabel: "Remove",
-        danger: true,
-      })
-    )
-      void deleteSourcesBatch(ids);
+    // Undo beats confirm: restorable sources delete straight away with a
+    // click-to-undo toast; only connector sources still ask.
+    await removeSourcesGuarded(ids, confirm);
   }
   const confirmRemoveBatchRef = useRef(confirmRemoveBatch);
   confirmRemoveBatchRef.current = confirmRemoveBatch;
@@ -1030,19 +1022,8 @@ export function SourcesPanel() {
                                 label: "Remove",
                                 icon: <Trash2 className="h-3.5 w-3.5" />,
                                 danger: true,
-                                onClick: async () => {
-                                  if (
-                                    await confirm({
-                                      title: `Remove "${s.title}"?`,
-                                      message: isFolder
-                                        ? `This removes the folder and its ${childCount(s.id)} file sources (with their embedded chunks) from the notebook. Nothing on disk is touched.`
-                                        : "This deletes the source and its embedded chunks from the notebook.",
-                                      confirmLabel: "Remove",
-                                      danger: true,
-                                    })
-                                  )
-                                    deleteSource(s.id);
-                                },
+                                onClick: () =>
+                                  void removeSourcesGuarded([s.id], confirm),
                               },
                             ]}
                           />

--- a/src/components/SourcesPanel.tsx
+++ b/src/components/SourcesPanel.tsx
@@ -28,6 +28,11 @@ import {
 } from "@/lib/utils";
 import { sourceIcon } from "@/lib/sourceIcon";
 import { AttachToCardModal } from "./RegistrySection";
+import {
+  SourceMetaModals,
+  sourceMetaItems,
+  sourceOriginItems,
+} from "./SourceMetaModals";
 import type { Source } from "@/lib/types";
 import {
   ChevronRight,
@@ -46,7 +51,6 @@ import {
   Cloud,
   MessageSquare,
   Package,
-  StickyNote,
   Tag,
 } from "lucide-react";
 
@@ -219,8 +223,6 @@ export function SourcesPanel() {
   const folderScan = useStore((s) => s.folderScan);
   const editSourceText = useStore((s) => s.editSourceText);
   const updateMacNote = useStore((s) => s.updateMacNote);
-  const setSourceTags = useStore((s) => s.setSourceTags);
-  const setSourceNote = useStore((s) => s.setSourceNote);
   const addMacReminder = useStore((s) => s.addMacReminder);
   const refreshSource = useStore((s) => s.refreshSource);
   const draggingFiles = useStore((s) => s.draggingFiles);
@@ -372,7 +374,6 @@ export function SourcesPanel() {
   const rowIds = rows.map((r) => r.s.id);
   const rowIdsRef = useRef(rowIds);
   rowIdsRef.current = rowIds;
-  const setSourcesTagsBatch = useStore((s) => s.setSourcesTagsBatch);
 
   const listRef = useRef<HTMLDivElement>(null);
   // An additive drag unions against the selection as it stood when the drag
@@ -992,26 +993,11 @@ export function SourcesPanel() {
                                     },
                                   ]
                                 : []),
-                              {
-                                label: s.tags ? "Edit tags…" : "Add tags…",
-                                icon: <Tag className="h-3.5 w-3.5" />,
-                                onClick: () =>
-                                  setTagEdit({
-                                    ids: [s.id],
-                                    title: s.title,
-                                    value: s.tags,
-                                  }),
-                              },
-                              {
-                                label: s.note ? "Edit note…" : "Add note…",
-                                icon: <StickyNote className="h-3.5 w-3.5" />,
-                                onClick: () =>
-                                  setNoteEdit({
-                                    id: s.id,
-                                    title: s.title,
-                                    value: s.note,
-                                  }),
-                              },
+                              // Origin trio + tags/note come from the shared
+                              // builders, so this menu, the gallery's, and
+                              // the reader's stay one list per object.
+                              ...sourceOriginItems(s),
+                              ...sourceMetaItems(s, setTagEdit, setNoteEdit),
                               {
                                 label: "File under a card…",
                                 icon: <Package className="h-3.5 w-3.5" />,
@@ -1199,85 +1185,12 @@ export function SourcesPanel() {
         onClose={() => setAttaching(null)}
       />
 
-      <Modal
-        open={!!tagEdit}
-        onClose={() => setTagEdit(null)}
-        title={`Tags for "${tagEdit?.title ?? ""}"`}
-        width="max-w-md"
-      >
-        <form
-          onSubmit={async (e) => {
-            e.preventDefault();
-            if (!tagEdit) return;
-            const { ids, value } = tagEdit;
-            setTagEdit(null);
-            if (ids.length === 1) await setSourceTags(ids[0], value);
-            else await setSourcesTagsBatch(ids, value);
-          }}
-          className="flex flex-col gap-3"
-        >
-          <Input
-            autoFocus
-            name="source-tags"
-            aria-label="Source tags"
-            placeholder="research rust retrieval"
-            value={tagEdit?.value ?? ""}
-            onChange={(e) =>
-              setTagEdit((s) => (s ? { ...s, value: e.target.value } : s))
-            }
-          />
-          <p className="text-micro leading-relaxed text-subtle-foreground">
-            Space-separated; "#" and case don't matter. Tags show up in
-            chat's source list and help match questions to notebooks.
-          </p>
-          <div className="flex justify-end gap-2">
-            <Button type="button" variant="ghost" onClick={() => setTagEdit(null)}>
-              Cancel
-            </Button>
-            <Button type="submit" variant="primary">
-              Save
-            </Button>
-          </div>
-        </form>
-      </Modal>
-
-      <Modal
-        open={!!noteEdit}
-        onClose={() => setNoteEdit(null)}
-        title={`Note on "${noteEdit?.title ?? ""}"`}
-        width="max-w-md"
-      >
-        <form
-          onSubmit={async (e) => {
-            e.preventDefault();
-            if (!noteEdit) return;
-            const { id, value } = noteEdit;
-            setNoteEdit(null);
-            await setSourceNote(id, value);
-          }}
-          className="flex flex-col gap-3"
-        >
-          <Textarea
-            autoFocus
-            rows={5}
-            name="source-note"
-            aria-label="Source note"
-            placeholder="Why did you save this? Chat can recall it."
-            value={noteEdit?.value ?? ""}
-            onChange={(e) =>
-              setNoteEdit((s) => (s ? { ...s, value: e.target.value } : s))
-            }
-          />
-          <div className="flex justify-end gap-2">
-            <Button type="button" variant="ghost" onClick={() => setNoteEdit(null)}>
-              Cancel
-            </Button>
-            <Button type="submit" variant="primary">
-              Save
-            </Button>
-          </div>
-        </form>
-      </Modal>
+      <SourceMetaModals
+        tagEdit={tagEdit}
+        setTagEdit={setTagEdit}
+        noteEdit={noteEdit}
+        setNoteEdit={setNoteEdit}
+      />
 
       {/* Hygiene review (RFC-source-hygiene): every removal is a human
           decision — per-item Keep / Remove, nothing automatic. */}

--- a/src/components/StudioPanel.tsx
+++ b/src/components/StudioPanel.tsx
@@ -13,7 +13,6 @@ import {
   type RowMenuItem,
   Spinner,
   CardAction,
-  useConfirm,
   useHoverCard,
   useMarquee,
 } from "./ui";
@@ -227,7 +226,6 @@ export function StudioPanel() {
   const pickSet = useStore((s) => s.pickSet);
   const clearPicked = useStore((s) => s.clearPicked);
   const deleteNotesBatch = useStore((s) => s.deleteNotesBatch);
-  const { confirm, dialog: confirmDialog } = useConfirm();
 
   // ---- Finder-style selection over the notes list (RFC-multi-select) ----
   const pickedNoteIds = useMemo(
@@ -291,15 +289,9 @@ export function StudioPanel() {
   }
 
   async function confirmDeleteNotes(ids: string[]) {
-    if (
-      await confirm({
-        title: `Delete ${ids.length} notes?`,
-        message: "The selected notes will be permanently removed.",
-        confirmLabel: "Delete",
-        danger: true,
-      })
-    )
-      void deleteNotesBatch(ids);
+    // Undo beats confirm: the delete toast restores notes with their kind
+    // intact, so there is nothing left to warn about.
+    await deleteNotesBatch(ids);
   }
   const confirmDeleteNotesRef = useRef(confirmDeleteNotes);
   confirmDeleteNotesRef.current = confirmDeleteNotes;
@@ -752,18 +744,7 @@ export function StudioPanel() {
                           label: "Delete",
                           icon: <Trash2 className="h-3.5 w-3.5" />,
                           danger: true,
-                          onClick: async () => {
-                            if (
-                              await confirm({
-                                title: `Delete "${n.title}"?`,
-                                message:
-                                  "This note will be permanently removed.",
-                                confirmLabel: "Delete",
-                                danger: true,
-                              })
-                            )
-                              deleteNote(n.id);
-                          },
+                          onClick: () => void deleteNote(n.id),
                         },
                       ]}
                     />
@@ -880,7 +861,6 @@ export function StudioPanel() {
       </Modal>
 
       {marquee}
-      {confirmDialog}
       {hoverCard}
     </div>
   );

--- a/src/components/settings/ModelsTab.tsx
+++ b/src/components/settings/ModelsTab.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { RefreshCw } from "lucide-react";
 import { api } from "@/lib/api";
 import { useStore } from "@/lib/store";
-import { Button, Input, Modal, useConfirm } from "../ui";
+import { Button, Input, Modal } from "../ui";
 import { Field } from "./SettingsTabs";
 import { OllamaModelPicker } from "./OllamaModelPicker";
 import { cn } from "@/lib/utils";
@@ -156,18 +156,11 @@ export function ModelsTab({
   const [wizard, setWizard] = useState<null | { editId?: string }>(null);
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const reembedAll = useStore((s) => s.reembedAll);
-  const { confirm, dialog: confirmDialog } = useConfirm();
 
-  async function handleReembed() {
-    const ok = await confirm({
-      title: "Re-embed all sources?",
-      message:
-        "Rebuilds the search index for every notebook with the current embedding model. " +
-        "Needed after switching models or if search stopped matching; it reprocesses " +
-        "all sources and can take a few minutes.",
-      confirmLabel: "Re-embed",
-    });
-    if (ok) void reembedAll();
+  function handleReembed() {
+    // Destroys nothing — the migration overlay is the feedback, not a
+    // confirm (DESIGN.md §9).
+    void reembedAll();
   }
 
   // The set of provider ids drives every probe below: re-run when a provider
@@ -698,7 +691,6 @@ export function ModelsTab({
           onClose={() => setWizard(null)}
         />
       )}
-      {confirmDialog}
     </div>
   );
 }

--- a/src/components/settings/SettingsTabs.tsx
+++ b/src/components/settings/SettingsTabs.tsx
@@ -4,7 +4,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { checkForUpdates } from "@/lib/updates";
 import { api } from "@/lib/api";
 import { useStore } from "@/lib/store";
-import { SYSTEM_THEME, THEME_LIST } from "@/lib/themes";
+import { SYSTEM_THEME, THEME_LIST, THEMES, resolveThemeId } from "@/lib/themes";
 import { SLASH_COMMANDS } from "@/lib/slashCommands";
 import type { BuildInfo, ChatConfig } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -401,7 +401,12 @@ function ThemePicker() {
       <ThemeButton
         label="System"
         selected={theme === SYSTEM_THEME}
-        colors={["#08090a", "#eceef1", "#5e6ad2"]}
+        // The swatch shows what System resolves to right now, from the same
+        // theme table as every other row — not a hand-copied triple.
+        colors={(() => {
+          const t = THEMES[resolveThemeId(SYSTEM_THEME)];
+          return [t.vars.background, t.vars.surface, t.vars.primary];
+        })()}
         onClick={() => setTheme(SYSTEM_THEME)}
       />
       {THEME_LIST.map((item) => {

--- a/src/components/settings/TileShader.tsx
+++ b/src/components/settings/TileShader.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { useReducedMotion } from "../DitherBackground";
 
 /**
  * Tiny per-tile WebGL fields for the Activity stat tiles — same family as
@@ -27,6 +28,7 @@ export function TileShader({
   tintVar: string;
 }) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const reducedMotion = useReducedMotion();
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -90,9 +92,7 @@ export function TileShader({
     let raf = 0;
     let last = 0;
     const startT = performance.now();
-    const isStatic = window.matchMedia(
-      "(prefers-reduced-motion: reduce)",
-    ).matches;
+    const isStatic = reducedMotion;
     const render = (now: number) => {
       if (!isStatic) raf = requestAnimationFrame(render);
       if (now - last < 33) return;
@@ -118,7 +118,7 @@ export function TileShader({
       gl.deleteBuffer(buf);
       gl.deleteProgram(program);
     };
-  }, [mode, hour, intensity, tintVar]);
+  }, [mode, hour, intensity, tintVar, reducedMotion]);
 
   return (
     <canvas

--- a/src/index.css
+++ b/src/index.css
@@ -32,6 +32,7 @@
 
   --destructive: #eb5757;
   --success: #4cb782;
+  --warning: #e8a33d;
 
   --citation: #8b95f5;
 
@@ -65,6 +66,7 @@
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
   --color-success: var(--success);
+  --color-warning: var(--warning);
   --color-citation: var(--citation);
   --color-artifact-generate: var(--artifact-generate);
   --color-artifact-learning: var(--artifact-learning);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -439,6 +439,21 @@ export const api = {
   ) => run(ai<MetaAnswer>("ask_everything", { question, history, deep: deep ?? null })),
   createNote: (notebookId: string, title: string, content: string) =>
     run(cmd<Note>("create_note", { notebookId, title, content })),
+  /** Undo half of the note-delete toast: re-insert with kind/prompt intact. */
+  restoreNote: (n: Note) =>
+    run(
+      cmd<Note>("restore_note", {
+        note: {
+          notebookId: n.notebookId,
+          title: n.title,
+          content: n.content,
+          kind: n.kind,
+          prompt: n.prompt,
+          origin: n.origin,
+          status: n.status,
+        },
+      }),
+    ),
   updateNote: (id: string, title: string, content: string) =>
     run(cmd<void>("update_note", { id, title, content })),
   deleteNote: (id: string) => run(cmd<void>("delete_note", { id })),

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -7,7 +7,7 @@ import {
 } from "@tauri-apps/api/webviewWindow";
 import { open, save } from "@tauri-apps/plugin-dialog";
 import { api } from "./api";
-import { SUPPORTED_EXTENSIONS, visibleTitle } from "./utils";
+import { isWebUrl, SUPPORTED_EXTENSIONS, visibleTitle } from "./utils";
 import { applyTheme, SYSTEM_THEME, themeIsDark } from "./themes";
 import { refreshEpigraph } from "./epigraph";
 import { notify } from "./notify";
@@ -32,6 +32,74 @@ import type {
   ReadingPrefs,
   Source,
 } from "./types";
+
+/** Can an undo toast bring this source back by re-importing its origin?
+ *  Connector types (git/notion/obsidian) carry setup state a re-add can't
+ *  reproduce — their delete keeps the confirm dialog instead. */
+export function sourceRestorable(s: Source): boolean {
+  return !["git", "notion", "obsidian"].includes(s.sourceType);
+}
+
+/** The undo half of the source-remove toast: re-import from the origin the
+ *  dialog copy always promised was untouched. Pasted text has no origin, so
+ *  its content rides in as a pre-delete snapshot. Fresh id, fresh embed;
+ *  tags and the user's note are re-applied after. */
+async function restoreSource(
+  nb: string,
+  s: Source,
+  text: string | undefined,
+): Promise<Source | null> {
+  let restored: Source;
+  if (s.sourceType === "mac") {
+    const m = /^cider:\/\/([^/]+)\/[^/]+\/(.+)$/.exec(s.url);
+    if (!m) return null;
+    restored = await api.addSourceMac(nb, m[1], m[2], s.title);
+  } else if (s.sourceType === "folder") {
+    restored = await api.addSourceFolder(nb, s.url);
+  } else if (s.sourceType === "url" || isWebUrl(s.url)) {
+    restored = await api.addSourceUrl(nb, s.url);
+  } else if (s.url) {
+    restored = await api.addSourceFile(nb, s.url);
+  } else {
+    restored = await api.addSourceText(nb, s.title, text ?? "");
+  }
+  if (s.tags) await api.setSourceTags(restored.id, s.tags);
+  if (s.note) await api.setSourceNote(restored.id, s.note);
+  return restored;
+}
+
+/** The one guarded source-remove path (DESIGN.md §9: undo beats confirm).
+ *  Restorable sources delete immediately — the toast carries the undo.
+ *  Connector sources, which an undo can't rebuild, still ask first; this is
+ *  the single copy of that dialog for every call site. */
+export async function removeSourcesGuarded(
+  ids: string[],
+  confirmFn: (opts: {
+    title: string;
+    message?: string;
+    items?: string[];
+    confirmLabel?: string;
+    danger?: boolean;
+  }) => Promise<boolean>,
+): Promise<void> {
+  const sources = useStore.getState().sources.filter((s) => ids.includes(s.id));
+  const blocked = sources.filter((s) => !sourceRestorable(s));
+  if (blocked.length > 0) {
+    const ok = await confirmFn({
+      title:
+        ids.length === 1
+          ? `Remove “${sources[0]?.title ?? "source"}”?`
+          : `Remove ${ids.length} sources?`,
+      message:
+        "Connected sources can't be brought back by undo — restoring means reconnecting. Nothing on disk is touched.",
+      items: blocked.map((s) => s.title),
+      confirmLabel: "Remove",
+      danger: true,
+    });
+    if (!ok) return;
+  }
+  await useStore.getState().deleteSourcesBatch(ids);
+}
 
 // Side panels stay usable at any drag position: wide enough for content,
 // narrow enough to leave the chat column room at the 1040px minimum window.
@@ -1337,13 +1405,7 @@ export const useStore = create<AppState>((set, get) => {
       if (get().currentId === id) set({ sources: await api.listSources(id) });
     },
 
-    deleteSource: (id) =>
-      guard(async () => {
-        await api.deleteSource(id);
-        const nb = get().currentId;
-        if (nb) set({ sources: await api.listSources(nb) });
-        get().pushToast("success", "Source removed");
-      }),
+    deleteSource: (id) => get().deleteSourcesBatch([id]),
 
     // ---- Finder-style selection (RFC-multi-select) ----------------------
 
@@ -1418,17 +1480,40 @@ export const useStore = create<AppState>((set, get) => {
     deleteSourcesBatch: (sourceIds) =>
       guard(async () => {
         if (sourceIds.length === 0) return;
-        await api.deleteSources(get().currentId ?? "", sourceIds);
-        const nb = get().currentId;
+        const nb = get().currentId ?? "";
+        // Snapshot before the rows go: what to restore, and the content of
+        // pasted-text sources (their only copy). Children of a folder being
+        // deleted are skipped — restoring the folder re-scans them.
+        const doomed = get().sources.filter(
+          (s) => sourceIds.includes(s.id) && !sourceIds.includes(s.parentId),
+        );
+        const texts = new Map<string, string>();
+        for (const s of doomed) {
+          if (!s.url && sourceRestorable(s))
+            texts.set(s.id, await api.getSourceContent(s.id));
+        }
+        await api.deleteSources(nb, sourceIds);
         if (nb) set({ sources: await api.listSources(nb) });
         set({ picked: null });
-        get().pushToast(
-          "success",
-          sourceIds.length === 1
-            ? "Source removed"
-            : `${sourceIds.length} sources removed`,
-        );
         void get().refreshHygiene();
+        const restorable = doomed.filter(sourceRestorable);
+        const label =
+          sourceIds.length === 1
+            ? `Removed “${doomed[0]?.title ?? "source"}”`
+            : `Removed ${sourceIds.length} sources`;
+        if (restorable.length === 0 || !nb) {
+          get().pushToast("success", label);
+          return;
+        }
+        get().pushToast("success", `${label} — click to undo`, () =>
+          guard(async () => {
+            for (const s of restorable)
+              await restoreSource(nb, s, texts.get(s.id));
+            if (get().currentId === nb)
+              set({ sources: await api.listSources(nb) });
+            void get().refreshHygiene();
+          }),
+        );
       }),
 
     setSourcesTagsBatch: (sourceIds, tags) =>
@@ -1448,16 +1533,24 @@ export const useStore = create<AppState>((set, get) => {
     deleteNotesBatch: (noteIds) =>
       guard(async () => {
         if (noteIds.length === 0) return;
+        // Snapshot for the undo toast: restore_note re-inserts with kind and
+        // prompt intact, so studio artifacts keep their viewer.
+        const doomed = get().notes.filter((n) => noteIds.includes(n.id));
         await api.deleteNotes(noteIds);
         set({
           notes: get().notes.filter((n) => !noteIds.includes(n.id)),
           picked: null,
         });
-        get().pushToast(
-          "success",
+        const label =
           noteIds.length === 1
-            ? "Note deleted"
-            : `${noteIds.length} notes deleted`,
+            ? `Deleted “${visibleTitle(doomed[0]?.title ?? "note")}”`
+            : `Deleted ${noteIds.length} notes`;
+        get().pushToast("success", `${label} — click to undo`, () =>
+          guard(async () => {
+            for (const n of doomed) await api.restoreNote(n);
+            const nb = get().currentId;
+            if (nb) set({ notes: await api.listNotes(nb) });
+          }),
         );
       }),
 
@@ -2008,12 +2101,7 @@ export const useStore = create<AppState>((set, get) => {
         set({ notes: await api.listNotes(id) });
       }),
 
-    deleteNote: (noteId) =>
-      guard(async () => {
-        await api.deleteNote(noteId);
-        set({ notes: get().notes.filter((n) => n.id !== noteId) });
-        get().pushToast("success", "Note deleted");
-      }),
+    deleteNote: (noteId) => get().deleteNotesBatch([noteId]),
 
     discussNoteInChat: (noteId) =>
       guard(async () => {

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -534,6 +534,8 @@ export const useStore = create<AppState>((set, get) => {
           nb: string | null;
           mode: "chat" | "reader" | "ledger" | "gallery";
           doc?: ReaderDoc;
+          readerHistory?: ReaderDoc[];
+          readerIndex?: number;
           section?: "notebooks" | "registry";
           card?: string | null;
         } | null = null;
@@ -551,9 +553,21 @@ export const useStore = create<AppState>((set, get) => {
           view === null ? localStorage.getItem("lastNotebookId") : view.nb;
         if (last && notebooks.some((n) => n.id === last)) {
           await get().selectNotebook(last);
+          // Restore the reader's whole back/forward stack, not just the
+          // open page — ⌘[ works across a relaunch.
+          const hist = (view?.readerHistory ?? []).filter(
+            (d) => !!d?.type && !!d?.id,
+          );
+          if (hist.length > 0) {
+            const index = Math.min(
+              Math.max(view?.readerIndex ?? hist.length - 1, 0),
+              hist.length - 1,
+            );
+            set({ reader: { open: view?.mode === "reader", history: hist, index } });
+          }
           if (view?.mode === "ledger") set({ ledgerOpen: true });
           else if (view?.mode === "gallery") set({ galleryOpen: true });
-          else if (view?.mode === "reader" && view.doc)
+          else if (view?.mode === "reader" && hist.length === 0 && view.doc)
             get().openInReader(view.doc);
         }
       }
@@ -2456,6 +2470,13 @@ if (getCurrentWebview().label === "main") {
               : "chat",
         // Highlight is a one-time citation jump, not a place — drop it.
         doc: doc && { type: doc.type, id: doc.id },
+        // The whole back/forward stack (doc refs only), so ⌘[ still works
+        // after a relaunch — not just the page you were on.
+        readerHistory: s.reader.history.map((d) => ({
+          type: d.type,
+          id: d.id,
+        })),
+        readerIndex: s.reader.index,
         // Home is a place too: the Registry and the card you had open are
         // as much "where you were" as a notebook's center mode.
         section: s.homeSection,

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -2154,8 +2154,8 @@ export const useStore = create<AppState>((set, get) => {
 
     // The one export verb: a .okf.zip is the notebook's portable form —
     // share it, back it up, or unzip it into an OKF folder for OK tooling.
-    exportNotebookOkf: async () => {
-      const id = get().currentId;
+    exportNotebookOkf: async (notebookId) => {
+      const id = notebookId ?? get().currentId;
       if (!id) {
         get().pushToast("info", "Open a notebook to export it");
         return;

--- a/src/lib/storeTypes.ts
+++ b/src/lib/storeTypes.ts
@@ -249,7 +249,8 @@ export interface AppState {
   openAddSource: (step?: "url" | "text") => void;
   closeAddSource: () => void;
 
-  exportNotebookOkf: () => Promise<void>;
+  /** Omit the id to export the currently open notebook (palette/menu). */
+  exportNotebookOkf: (notebookId?: string) => Promise<void>;
   importOkfOpen: boolean;
   pendingImportPath: string | null;
   importOkf: (path: string, notebookId?: string | null) => Promise<void>;

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -483,6 +483,12 @@ export function applyTheme(name: string) {
   for (const [key, value] of Object.entries(theme.vars)) {
     root.style.setProperty(`--${key}`, value);
   }
+  // Semantic warning amber. Themes may override with a `warning` var; the
+  // default darkens in light schemes so amber text keeps contrast. Set
+  // unconditionally — applyTheme only writes the vars a theme declares, so
+  // a per-theme value would otherwise leak across switches.
+  if (!theme.vars.warning)
+    root.style.setProperty("--warning", theme.dark ? "#e8a33d" : "#9a6700");
   root.dataset.theme = theme.id;
   root.dataset.scheme = theme.dark ? "dark" : "light";
   root.style.colorScheme = theme.dark ? "dark" : "light";

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -212,3 +212,54 @@ export function activeParagraph(prev: string, next: string): string {
   }
   return "";
 }
+
+// ---- Persistent scroll memory ("state survives", DESIGN.md) ----------------
+
+type ScrollEntry = { v: number; at: number };
+const SCROLL_LS_KEY = "scrollMemory:v1";
+/** Most-recent keys kept on disk; older reading positions age out. */
+const SCROLL_CAP = 200;
+
+function loadScrollMemory(): Map<string, ScrollEntry> {
+  try {
+    const raw = localStorage.getItem(SCROLL_LS_KEY);
+    return raw
+      ? new Map(Object.entries(JSON.parse(raw) as Record<string, ScrollEntry>))
+      : new Map();
+  } catch {
+    return new Map();
+  }
+}
+
+const scrollMap = loadScrollMemory();
+let scrollFlush: number | null = null;
+
+function persistScrollMemory() {
+  if (scrollFlush !== null) return;
+  scrollFlush = window.setTimeout(() => {
+    scrollFlush = null;
+    try {
+      const entries = [...scrollMap.entries()]
+        .sort((a, b) => a[1].at - b[1].at)
+        .slice(-SCROLL_CAP);
+      localStorage.setItem(
+        SCROLL_LS_KEY,
+        JSON.stringify(Object.fromEntries(entries)),
+      );
+    } catch {
+      /* storage full or unavailable — scroll memory is best-effort */
+    }
+  }, 500);
+}
+
+/** Reader/gallery scroll positions, persisted across relaunch (they used to
+ *  live in per-module in-memory Maps and reset with the app). */
+export const scrollMemory = {
+  get(key: string): number | undefined {
+    return scrollMap.get(key)?.v;
+  },
+  set(key: string, v: number): void {
+    scrollMap.set(key, { v, at: Date.now() });
+    persistScrollMemory();
+  },
+};


### PR DESCRIPTION
Works through the Alchemy Reminders backlog: the two original quick wins plus seven of the ten design-audit items (P2–P7, P9, P10).

## P2 — Persist window geometry across relaunch
`tauri-plugin-window-state` with label mapping: workspace pop-outs share one saved slot, note readers another (new `win-note-*` label, still matches the `win-*` capability), export/capture render windows denylisted. The `VISIBLE` flag is deliberately excluded — close-to-tray hides the main window, and saving `visible=false` would relaunch the app with no window at all.

## Cursor CLI error reminder
Headless `cursor-agent` runs died on the interactive Workspace Trust prompt (bundled apps inherit an untrusted cwd). Now passes `--trust` — verified against the installed CLI that it trusts the workspace without `--yolo`-style command auto-approval.

## P4 — Guard the silent chat/registry destroys
- **Re-run** no longer rewinds the transcript: it re-asks as a fresh turn, so the old answer survives — and any question can be re-asked, not just the last one.
- **Dismiss** (single and Dismiss-all) raises an undo toast that returns cards to the queue via `set_card_origin("auto")`.
- `resendFailed` left as-is: it only deletes the failed exchange it immediately recreates.

## P7 — Let users check off reminders in the UI
`complete_mac_reminder` existed for agents with zero UI call sites. Reminders-list sources now render live checkboxes that complete the reminder in Apple Reminders and resync. Find/citation anchors fall back to the text views.

## P9 — Motion and token cleanup
Over-cap transitions down to 200ms; WebGL shaders track `prefers-reduced-motion` live via a shared hook; new semantic `--warning` token replaces hardcoded ambers; System theme swatch derives from the theme table. **Design call for review:** the hero sigil's slow morph stays — DESIGN.md now names it the second sanctioned ambient element instead of capping it to 250ms.

## P3 — Undo toasts replace confirm modals on recoverable deletes
Nine confirm sites now delete immediately with click-to-undo:
- **Sources** re-import from their origin (pasted text snapshots content pre-delete; tags/note re-applied). One shared `removeSourcesGuarded` path; only connector sources (git/Notion/Obsidian), which undo can't rebuild, still confirm.
- **Notes** restore through a new `restore_note` command preserving kind/prompt, so studio artifacts keep their viewer.
- **Registry cards** recreate with identifiers, note, facts, and re-filed attachments (shared `deleteCardsUndoable`, four sites).
- **Ledger entries** recreate with anchors and status.
- Re-embed confirms dropped (destroy nothing; the migration overlay is the feedback). The orphaned-cards sweep keeps its named confirm on purpose.

## P5 — Keyboard-reach gaps
Selection toolbars follow `selectionchange` (shift+arrow selection raises them); notebook/registry table rows are tabbable, Enter opens; the home split separator gets focus + arrow keys; graph nodes are tabbable with Enter-to-open; hover-only reveals also reveal on focus.

## P6 — Right-click parity: one menu per object
Chat messages gain context menus (Copy / Save as note; Copy / Re-run on questions); the reader toolbar's right-click works (it had no `.group` ancestor); source menus unify through a new `SourceMetaModals` module — the panel gains the origin trio, the gallery gains tags/note editing; the notebook menu gains "Change color…" (palette now also renders in table view) and "Export notebook…".

## P10 — State-restore polish
Reader/gallery scroll positions persist across relaunch (bounded localStorage map); `lastView` carries the reader's whole back/forward stack so ⌘[ works after restart; NoteReader flushes pending edits on pagehide; chat draft @mentions persist beside draft text; the three cmd-F handlers respect `shortcutBlocked`.

## Gates
`cargo fmt` ✓ · `clippy -D warnings` ✓ · `cargo test` green (346 passed on first batch, full suite re-run green after `restore_note`) · `pnpm build` ✓

Not addressed: P1 (menu bar as command index) and P8 (drag content out) — the two remaining audit items — plus the loose backlog. "Bob returned this error" is an IBM account suspension, not fixable in code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)