### PR TITLE
Menu bar command index, navigation-proof streams, TTFT instrumentation

### DIFF
--- a/src-tauri/src/acp/mod.rs
+++ b/src-tauri/src/acp/mod.rs
@@ -166,6 +166,10 @@ struct SessionHandle {
     tx: mpsc::UnboundedSender<HostCmd>,
     /// Permission requests awaiting a UI answer, keyed by the id we emitted.
     permissions: Arc<Mutex<HashMap<String, PendingPermission>>>,
+    /// Clock for the turn in flight, so the agent pane reports the same
+    /// send-to-first-token wait the chat surfaces do. Taken by the first
+    /// answer chunk of the turn; None between turns.
+    ttft: Arc<Mutex<Option<crate::commands::TtftClock>>>,
 }
 
 struct PendingPermission {
@@ -367,6 +371,7 @@ pub async fn acp_start(
     let state = app.state::<AcpState>();
     let (tx, rx) = mpsc::unbounded_channel();
     let permissions: Arc<Mutex<HashMap<String, PendingPermission>>> = Arc::default();
+    let ttft: Arc<Mutex<Option<crate::commands::TtftClock>>> = Arc::default();
     {
         let mut sessions = state.sessions.lock().unwrap();
         if let Some(old) = sessions.remove(&notebook_id) {
@@ -378,6 +383,7 @@ pub async fn acp_start(
                 agent_id: agent_id.clone(),
                 tx,
                 permissions: permissions.clone(),
+                ttft: ttft.clone(),
             },
         );
     }
@@ -399,6 +405,7 @@ pub async fn acp_start(
             rx,
             ready_tx,
             permissions,
+            ttft,
         )
         .await;
         // Clear the slot — but only if this session still owns it. A restart
@@ -437,6 +444,17 @@ pub async fn acp_start(
 /// Send a user prompt into the notebook's hosted session.
 #[tauri::command]
 pub fn acp_prompt(app: AppHandle, notebook_id: String, text: String) -> Result<(), String> {
+    // Start the turn clock before the prompt goes out, so the agent pane's
+    // time to first token covers the same span the chat surfaces time.
+    if let Some(handle) = app
+        .state::<AcpState>()
+        .sessions
+        .lock()
+        .unwrap()
+        .get(&notebook_id)
+    {
+        *handle.ttft.lock().unwrap() = Some(crate::commands::TtftClock::start());
+    }
     send_cmd(&app, &notebook_id, HostCmd::Prompt(text))
 }
 
@@ -578,6 +596,7 @@ async fn run_session(
     mut rx: mpsc::UnboundedReceiver<HostCmd>,
     ready_tx: oneshot::Sender<Result<(), String>>,
     permissions: Arc<Mutex<HashMap<String, PendingPermission>>>,
+    ttft: Arc<Mutex<Option<crate::commands::TtftClock>>>,
 ) -> Result<(), agent_client_protocol::Error> {
     let agent = AcpAgent::new(config);
     // Errors name the agent the way the picker does ("Claude Code"), not by
@@ -586,6 +605,9 @@ async fn run_session(
 
     let update_app = app.clone();
     let update_notebook = notebook_id.clone();
+    let update_ttft = ttft.clone();
+    // Ranked under the label the picker shows ("Claude Code"), not the id.
+    let update_model = agent_label.to_string();
     let perm_app = app.clone();
     let perm_notebook = notebook_id.clone();
 
@@ -599,6 +621,26 @@ async fn run_session(
             async move |notification: SessionNotification, _cx| {
                 let update =
                     serde_json::to_value(&notification.update).unwrap_or(serde_json::Value::Null);
+                // First answer chunk of the turn stops the clock — thoughts
+                // and tool calls stream before it, but "first answer token"
+                // is what the chat surfaces measure, so the agent pane is
+                // ranked on the same basis.
+                if update.get("sessionUpdate").and_then(|v| v.as_str())
+                    == Some("agent_message_chunk")
+                {
+                    if let Some(clock) = update_ttft.lock().unwrap().take() {
+                        clock.mark();
+                        if let Some(state) = update_app.try_state::<crate::commands::AppState>() {
+                            state.record_ttft(
+                                &update_model,
+                                "agent-pane",
+                                &update_notebook,
+                                &clock,
+                                None,
+                            );
+                        }
+                    }
+                }
                 let _ = update_app.emit(
                     "acp://update",
                     UpdateEvent {

--- a/src-tauri/src/activity.rs
+++ b/src-tauri/src/activity.rs
@@ -66,6 +66,12 @@ pub fn aggregate(
     note_times: &[i64],
     sources: &[(String, i64, i64)],
     notebook_titles: &HashMap<String, String>,
+    // Notebooks to leave out of the "most active" ranking. Archiving a
+    // notebook means "stop showing me this" — it already leaves the shelf,
+    // and a set-aside notebook topping a list of where your attention goes
+    // is noise. Their turns still count toward totals, the heatmap, and
+    // peak hour: the work genuinely happened.
+    rank_excluded: &std::collections::HashSet<String>,
     retrieval_times: &[i64],
     today: NaiveDate,
 ) -> ActivityStats {
@@ -182,6 +188,9 @@ pub fn aggregate(
     // under one label and sink below every living one.
     let mut nb_label_counts: HashMap<String, i64> = HashMap::new();
     for (id, count) in notebook_counts {
+        if rank_excluded.contains(&id) {
+            continue;
+        }
         let label = notebook_titles
             .get(&id)
             .cloned()
@@ -249,7 +258,15 @@ mod tests {
 
     #[test]
     fn empty_inputs_are_a_fresh_install() {
-        let s = aggregate(&[], &[], &[], &HashMap::new(), &[], date(2026, 8, 20));
+        let s = aggregate(
+            &[],
+            &[],
+            &[],
+            &HashMap::new(),
+            &Default::default(),
+            &[],
+            date(2026, 8, 20),
+        );
         assert_eq!(s.total_messages, 0);
         assert_eq!(s.peak_hour, -1);
         assert_eq!(s.current_streak, 0);
@@ -273,6 +290,7 @@ mod tests {
             &notes,
             &[],
             &HashMap::new(),
+            &Default::default(),
             &[],
             date(2026, 8, 20),
         );
@@ -287,7 +305,15 @@ mod tests {
     #[test]
     fn current_streak_breaks_after_a_quiet_day() {
         let messages = vec![msg("nb1", "user", "", noon(2026, 8, 17), 1)];
-        let s = aggregate(&messages, &[], &[], &HashMap::new(), &[], date(2026, 8, 20));
+        let s = aggregate(
+            &messages,
+            &[],
+            &[],
+            &HashMap::new(),
+            &Default::default(),
+            &[],
+            date(2026, 8, 20),
+        );
         assert_eq!(s.longest_streak, 1);
         assert_eq!(s.current_streak, 0, "two days quiet = no live streak");
     }
@@ -312,12 +338,48 @@ mod tests {
             msg("nb1", "assistant", "Ollama", noon(2026, 8, 3), 10),
             msg("nb1", "assistant", "Ollama", noon(2026, 8, 4), 10),
         ];
-        let s = aggregate(&messages, &[], &[], &HashMap::new(), &[], date(2026, 8, 20));
+        let s = aggregate(
+            &messages,
+            &[],
+            &[],
+            &HashMap::new(),
+            &Default::default(),
+            &[],
+            date(2026, 8, 20),
+        );
         assert_eq!(s.favorite_model, "Ollama", "tie breaks to more recent");
         assert_eq!(s.models.len(), 2);
         assert_eq!(s.models[0].count, 2);
         assert_eq!(s.assistant_words, 40);
         assert_eq!(s.total_user_messages, 0);
+    }
+
+    #[test]
+    fn archived_notebooks_leave_the_ranking_but_keep_their_totals() {
+        let messages = vec![
+            msg("live", "user", "", noon(2026, 8, 1), 1),
+            msg("shelved", "user", "", noon(2026, 8, 1), 1),
+            msg("shelved", "user", "", noon(2026, 8, 1), 1),
+        ];
+        let titles = HashMap::from([
+            ("live".to_string(), "Research".to_string()),
+            ("shelved".to_string(), "QA fixtures".to_string()),
+        ]);
+        let excluded = std::collections::HashSet::from(["shelved".to_string()]);
+        let s = aggregate(
+            &messages,
+            &[],
+            &[],
+            &titles,
+            &excluded,
+            &[],
+            date(2026, 8, 20),
+        );
+        // Ranked out even though it has the most turns...
+        assert_eq!(s.notebooks.len(), 1);
+        assert_eq!(s.notebooks[0].label, "Research");
+        // ...but the work still counts toward the totals.
+        assert_eq!(s.total_messages, 3);
     }
 
     #[test]
@@ -328,7 +390,15 @@ mod tests {
             msg("kept", "user", "", noon(2026, 8, 1), 1),
         ];
         let titles = HashMap::from([("kept".to_string(), "Research".to_string())]);
-        let s = aggregate(&messages, &[], &[], &titles, &[], date(2026, 8, 20));
+        let s = aggregate(
+            &messages,
+            &[],
+            &[],
+            &titles,
+            &Default::default(),
+            &[],
+            date(2026, 8, 20),
+        );
         assert_eq!(s.notebooks.len(), 2);
         assert_eq!(s.notebooks[0].label, "Research");
         assert_eq!(s.notebooks[1].label, "(deleted)");

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -71,6 +71,10 @@ pub async fn run(
     history: &[ChatTurn],
     extra_system: &str,
     source_ids: Option<&[String]>,
+    // Timed by the caller so deep research reports the same
+    // send-to-first-token wait the direct chat path does — the loop's tool
+    // rounds run before this stream, and that delay is part of it.
+    ttft: &crate::commands::TtftClock,
 ) -> Result<(String, Vec<Citation>, Option<crate::ai::GenStats>)> {
     let mut read_remaining = if ollama.config().is_gateway() {
         READ_CHARS_GATEWAY
@@ -223,8 +227,10 @@ pub async fn run(
         &crate::inference::ContextProfile::default(),
     );
     let app_cb = app.clone();
+    let ttft_cb = ttft.clone();
     let outcome = ollama
         .chat_stream(&messages, |tok| {
+            ttft_cb.mark();
             let _ = app_cb.emit(
                 "chat://token",
                 TokenEvent {

--- a/src-tauri/src/ai/mod.rs
+++ b/src-tauri/src/ai/mod.rs
@@ -712,6 +712,51 @@ impl Ai {
         }
     }
 
+    /// The identity to record speed metrics under, for the configured chat
+    /// provider or a named one.
+    ///
+    /// `active_chat_model` is the caption ("Codex", "Hermes") — right for a
+    /// transcript row, but too coarse for a ranking: reasoning effort and the
+    /// model an agent CLI routes to move time-to-first-token more than the
+    /// choice of CLI does, so pooling `Codex minimal` with `Codex max` under
+    /// one average answers nothing. Anything that changes the wait belongs in
+    /// the key.
+    pub fn chat_metrics_key(&self, provider_id: Option<&str>) -> String {
+        let id = provider_id.unwrap_or(&self.config.chat_provider);
+        let base = match provider_id {
+            // An override names its own provider; resolve that entry's
+            // caption the same way the active one is resolved.
+            Some(_) => self
+                .config
+                .provider_by_id(id)
+                .map(|p| {
+                    let model = p.chat_model.trim();
+                    match p.kind.as_str() {
+                        "gateway" | "ollama" if !model.is_empty() => model.to_string(),
+                        _ if !p.label.trim().is_empty() => p.label.clone(),
+                        other => other.to_string(),
+                    }
+                })
+                .unwrap_or_else(|| self.active_chat_model()),
+            None => self.active_chat_model(),
+        };
+        let Some(entry) = self.config.provider_by_id(id) else {
+            return base;
+        };
+        let mut key = base;
+        // Agent CLIs caption as their label, so the model they route to is
+        // not in the key yet — and it is exactly what the user picked.
+        let model = entry.chat_model.trim();
+        if !model.is_empty() && !key.contains(model) {
+            key = format!("{key} \u{b7} {model}");
+        }
+        let effort = entry.effort.trim();
+        if !effort.is_empty() {
+            key = format!("{key} \u{b7} {effort}");
+        }
+        key
+    }
+
     /// Resolve a per-call provider override: the engine for the configured
     /// entry with this id, plus the model name to key stats under. `Err`
     /// names the valid ids — an agent typo should read as "pick one of

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -9721,16 +9721,25 @@ pub async fn activity_stats(
     let messages = e(state.db.message_activity().await)?;
     let notes = e(state.db.note_activity().await)?;
     let sources = e(state.db.source_activity().await)?;
-    let titles: std::collections::HashMap<String, String> = e(state.db.list_notebooks().await)?
-        .into_iter()
-        .map(|n| (n.id, n.title))
+    let all_notebooks = e(state.db.list_notebooks().await)?;
+    // Archived and system notebooks stay out of the "most active" ranking:
+    // both are already absent from the shelf, and neither is where the
+    // user's attention currently goes. Their turns still count everywhere
+    // else — totals, heatmap, peak hour — because they really happened.
+    let ranked_out: std::collections::HashSet<String> = all_notebooks
+        .iter()
+        .filter(|n| n.status == "archived" || n.status == "system")
+        .map(|n| n.id.clone())
         .collect();
+    let titles: std::collections::HashMap<String, String> =
+        all_notebooks.into_iter().map(|n| (n.id, n.title)).collect();
     let retrievals = crate::activity::trace_times(&state.trace_dir);
     Ok(crate::activity::aggregate(
         &messages,
         &notes,
         &sources,
         &titles,
+        &ranked_out,
         &retrievals,
         chrono::Local::now().date_naive(),
     ))

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -11231,14 +11231,39 @@ pub async fn provider_models(
 }
 
 #[tauri::command]
-pub async fn check_models(state: State<'_, AppState>) -> Result<ModelHealth, String> {
+pub async fn check_models(
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<ModelHealth, String> {
     let ai = state.ai.read().await.clone();
     let cfg = ai.config().clone();
     let norm = |m: &str| m.trim_end_matches(":latest").to_string();
 
-    // Chat status comes from the configured provider; embeddings and vision
-    // remain Ollama-backed below.
-    let gateway_chat = if cfg.provider == "openai" {
+    // Chat status comes from the ACTIVE chat provider. Only an Ollama-kind
+    // provider is Ollama's problem — Apple FM, gateways, and agent CLIs
+    // probe on their own, so a sleeping Ollama no longer flags a working
+    // chat setup ("Chat model: Ollama not reachable" over an FM answer).
+    let provider_chat = match cfg.provider_by_id(&cfg.chat_provider) {
+        Some(entry) if entry.kind != "ollama" => {
+            let (ready, detail) = readiness_for_entry(&app, entry, &cfg).await?;
+            Some(ModelStatus {
+                name: if entry.chat_model.trim().is_empty() {
+                    entry.label.clone()
+                } else {
+                    entry.chat_model.clone()
+                },
+                installed: ready,
+                working: ready,
+                detail: format!("{} · {detail}", entry.label),
+            })
+        }
+        _ => None,
+    };
+    // Legacy flat-config path: no provider entry resolved, but the flat
+    // provider says gateway.
+    let gateway_chat = if provider_chat.is_some() {
+        provider_chat
+    } else if cfg.provider == "openai" {
         let name = cfg.openai_chat_model.clone();
         Some(if name.trim().is_empty() {
             ModelStatus {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -169,6 +169,7 @@ impl AppState {
                     0.0
                 },
                 samples: a.samples,
+                ttft_samples: a.ttft_samples,
                 last_ttft_ms: a.last_ttft_ms,
                 avg_ttft_ms: if a.ttft_samples > 0 {
                     a.total_ttft_ms as f64 / a.ttft_samples as f64

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -7302,16 +7302,20 @@ pub async fn send_message(
         .as_deref()
         .map(str::trim)
         .filter(|s| !s.is_empty());
-    let (override_engine, model) = {
+    // `model` captions the transcript row; `metrics_key` additionally carries
+    // the model and reasoning effort behind it, because those move latency and
+    // a speed ranking that pools them measures nothing.
+    let (override_engine, model, metrics_key) = {
         let ai = state.ai.read().await.clone();
         match override_id {
             Some(id) => {
                 let (engine, model) = ai
                     .engine_for_provider(id)
                     .map_err(|err| friendly_error(&format!("{err:#}")))?;
-                (Some(engine), model)
+                let key = ai.chat_metrics_key(Some(id));
+                (Some(engine), model, key)
             }
-            None => (None, ai.active_chat_model()),
+            None => (None, ai.active_chat_model(), ai.chat_metrics_key(None)),
         }
     };
     // On-device model only: cap the prompt to its 8192-token window before
@@ -7391,10 +7395,10 @@ pub async fn send_message(
             None => (partial.lock().unwrap().clone(), "chat", None, None, model),
         }
     };
-    state.record_chat_stats(&model, stats);
+    state.record_chat_stats(&metrics_key, stats);
     if kind == "chat" {
         state.record_ttft(
-            &model,
+            &metrics_key,
             "chat",
             &notebook_id,
             &ttft,
@@ -7484,9 +7488,10 @@ pub async fn send_message_agentic(
 
     let cancel = state.begin_generation(&format!("chat:{}", window.label()));
     let ttft = TtftClock::start();
-    let (answer, kind, citations, stats, model) = {
+    let (answer, kind, citations, stats, model, metrics_key) = {
         let ai = state.ai.read().await.clone();
         let model = ai.active_chat_model();
+        let metrics_key = ai.chat_metrics_key(None);
         let out = tokio::select! {
             r = crate::agent::run(
                 &app,
@@ -7502,7 +7507,9 @@ pub async fn send_message_agentic(
             _ = cancel.cancelled() => None,
         };
         match out {
-            Some(Ok((answer, citations, stats))) => (answer, "chat", citations, stats, model),
+            Some(Ok((answer, citations, stats))) => {
+                (answer, "chat", citations, stats, model, metrics_key)
+            }
             // Durable transcript row for a failed run — same contract as the
             // direct chat path: fix-classified (phase 1), then one capped
             // diagnosis call for unclassified shapes (phase 2).
@@ -7512,14 +7519,21 @@ pub async fn send_message_agentic(
                 if let Some(extra) = crate::selfheal::diagnose(&ai, &raw).await {
                     text.push_str(&extra);
                 }
-                (text, "error", vec![], None, model)
+                (text, "error", vec![], None, model, metrics_key)
             }
-            None => ("_(Stopped.)_".to_string(), "chat", vec![], None, model),
+            None => (
+                "_(Stopped.)_".to_string(),
+                "chat",
+                vec![],
+                None,
+                model,
+                metrics_key,
+            ),
         }
     };
-    state.record_chat_stats(&model, stats);
+    state.record_chat_stats(&metrics_key, stats);
     if kind == "chat" {
-        state.record_ttft(&model, "deep-research", &notebook_id, &ttft, None);
+        state.record_ttft(&metrics_key, "deep-research", &notebook_id, &ttft, None);
     }
 
     let assistant_msg = Message {
@@ -11009,7 +11023,7 @@ pub async fn ask_everything(
     let ttft_cb = ttft.clone();
     let (answer, stats, model) = {
         let ai = state.ai.read().await.clone();
-        let model = ai.active_chat_model();
+        let model = ai.chat_metrics_key(None);
         let streamed = tokio::select! {
             out = ai.chat_stream(&messages, |tok| {
                 ttft_cb.mark();

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -9437,6 +9437,31 @@ pub async fn rebuild_app_menu(
     crate::menu::fill_recents(&app, &tray_recent.0, &recents).map_err(|err| err.to_string())
 }
 
+/// Fill the frontend-owned menu lists — View > Theme (themes.ts is the
+/// authority on the 23 schemes) and Notebook > Generate (studioArtifacts.tsx
+/// owns the roster). Called at startup and again when the theme changes so
+/// the selection dot tracks. In-place mutation, like Open Recent.
+#[tauri::command]
+pub fn fill_menu_lists(
+    app: AppHandle,
+    themes_menu: State<'_, crate::menu::ThemeMenu>,
+    generate_menu: State<'_, crate::menu::GenerateMenu>,
+    themes: Vec<(String, String)>,
+    generators: Vec<(String, String)>,
+    current_theme: String,
+) -> Result<(), String> {
+    crate::menu::fill_themes(&app, &themes_menu.0, &themes, &current_theme)
+        .map_err(|err| err.to_string())?;
+    crate::menu::fill_generators(&app, &generate_menu.0, &generators).map_err(|err| err.to_string())
+}
+
+/// The Settings → Shortcuts rows, straight from the menu's command registry
+/// — one source of truth (menu.rs::CMD) for both surfaces.
+#[tauri::command]
+pub fn list_shortcuts() -> Vec<crate::menu::ShortcutRow> {
+    crate::menu::shortcut_rows()
+}
+
 // ---- Home page: activity, stats, global search ----------------------------
 
 #[tauri::command]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -51,6 +51,43 @@ pub struct ModelStatAcc {
     pub last_ttft_ms: u64,
 }
 
+/// Wall-clock time to first token for one streamed answer: started when the
+/// user's turn is accepted (retrieval included, because that is the wait the
+/// user actually feels) and stopped by the first token the engine emits.
+///
+/// Cloneable so a streaming callback can hold one — every path that emits a
+/// token calls `mark`, and only the first call sticks.
+#[derive(Clone)]
+pub struct TtftClock {
+    start: std::time::Instant,
+    first_ms: Arc<std::sync::atomic::AtomicU64>,
+}
+
+impl TtftClock {
+    pub fn start() -> Self {
+        Self {
+            start: std::time::Instant::now(),
+            first_ms: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+        }
+    }
+
+    /// Record this instant if no token has arrived yet. Clamped to 1ms so an
+    /// instant first token still reads as measured rather than as "never".
+    pub fn mark(&self) {
+        let _ = self.first_ms.compare_exchange(
+            0,
+            (self.start.elapsed().as_millis() as u64).max(1),
+            std::sync::atomic::Ordering::Relaxed,
+            std::sync::atomic::Ordering::Relaxed,
+        );
+    }
+
+    /// Milliseconds to the first token; 0 when none ever arrived.
+    pub fn ttft_ms(&self) -> u64 {
+        self.first_ms.load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
 pub struct AppState {
     pub db: Arc<Db>,
     pub ai: tokio::sync::RwLock<Ai>,
@@ -145,16 +182,50 @@ impl AppState {
         }
     }
 
-    /// Fold one chat's time-to-first-token into the running stats.
-    pub fn record_chat_ttft(&self, model: &str, ttft_ms: u64) {
-        let mut map = self.model_stats.lock().unwrap();
-        let entry = map.entry(model.to_string()).or_default();
-        entry.ttft_samples += 1;
-        entry.total_ttft_ms += ttft_ms;
-        entry.last_ttft_ms = ttft_ms;
-        if let Ok(json) = serde_json::to_string_pretty(&*map) {
-            let _ = std::fs::write(&self.stats_path, json);
+    /// Fold one answer's time-to-first-token into the running stats and
+    /// leave a timing trace line. `path` names which chat surface produced
+    /// it (direct chat, deep research, ask-everything) so the trace can tell
+    /// them apart later; the per-model average deliberately pools them,
+    /// because "how long until this model starts answering me" is one
+    /// question regardless of which surface asked it.
+    ///
+    /// A clock that never saw a token records nothing: a failed or stopped
+    /// turn has no first token to time.
+    pub fn record_ttft(
+        &self,
+        model: &str,
+        path: &str,
+        notebook_id: &str,
+        clock: &TtftClock,
+        phases: Option<(u64, u64)>,
+    ) {
+        let ttft_ms = clock.ttft_ms();
+        if ttft_ms == 0 {
+            return;
         }
+        {
+            let mut map = self.model_stats.lock().unwrap();
+            let entry = map.entry(model.to_string()).or_default();
+            entry.ttft_samples += 1;
+            entry.total_ttft_ms += ttft_ms;
+            entry.last_ttft_ms = ttft_ms;
+            if let Ok(json) = serde_json::to_string_pretty(&*map) {
+                let _ = std::fs::write(&self.stats_path, json);
+            }
+        }
+        let mut record = serde_json::json!({
+            "ts": now(),
+            "surface": "chat-timing",
+            "path": path,
+            "notebookId": notebook_id,
+            "model": model,
+            "ttftMs": ttft_ms,
+        });
+        if let Some((embed_ms, retrieval_ms)) = phases {
+            record["embedMs"] = embed_ms.into();
+            record["retrievalMs"] = retrieval_ms.into();
+        }
+        crate::trace::log(&self.trace_dir, record);
     }
 
     pub fn model_stats_snapshot(&self) -> Vec<ModelStat> {
@@ -7081,6 +7152,7 @@ pub async fn send_message(
     let extra = chat_style_instruction(&config.unwrap_or_default());
     // Time-to-first-token clock: from the send to the first chat://token
     // emit. Phase marks land in the chat-timing trace line below.
+    let ttft = TtftClock::start();
     let t0 = std::time::Instant::now();
 
     // Persist the user's turn first.
@@ -7269,8 +7341,7 @@ pub async fn send_message(
     let partial = Arc::new(Mutex::new(String::new()));
     let partial_cb = partial.clone();
     // 0 = no token yet; the first token stores max(elapsed, 1).
-    let first_tok = Arc::new(std::sync::atomic::AtomicU64::new(0));
-    let first_tok_cb = first_tok.clone();
+    let ttft_cb = ttft.clone();
     let (answer, kind, stats, cost_usd, model) = {
         let ai = state.ai.read().await.clone();
         let engine = override_engine
@@ -7282,12 +7353,7 @@ pub async fn send_message(
         let app_for_steps = app.clone();
         let streamed = tokio::select! {
             out = engine.chat_stream_steps(&messages, |tok| {
-                let _ = first_tok_cb.compare_exchange(
-                    0,
-                    (t0.elapsed().as_millis() as u64).max(1),
-                    std::sync::atomic::Ordering::Relaxed,
-                    std::sync::atomic::Ordering::Relaxed,
-                );
+                ttft_cb.mark();
                 partial_cb.lock().unwrap().push_str(tok);
                 let _ = app_for_cb.emit(
                     "chat://token",
@@ -7326,20 +7392,13 @@ pub async fn send_message(
         }
     };
     state.record_chat_stats(&model, stats);
-    let ttft_ms = first_tok.load(std::sync::atomic::Ordering::Relaxed);
-    if kind == "chat" && ttft_ms > 0 {
-        state.record_chat_ttft(&model, ttft_ms);
-        crate::trace::log(
-            &state.trace_dir,
-            serde_json::json!({
-                "ts": now(),
-                "surface": "chat-timing",
-                "notebookId": notebook_id,
-                "model": model,
-                "ttftMs": ttft_ms,
-                "embedMs": embed_ms,
-                "retrievalMs": retrieval_ms,
-            }),
+    if kind == "chat" {
+        state.record_ttft(
+            &model,
+            "chat",
+            &notebook_id,
+            &ttft,
+            Some((embed_ms, retrieval_ms)),
         );
     }
 
@@ -7424,6 +7483,7 @@ pub async fn send_message_agentic(
         .collect();
 
     let cancel = state.begin_generation(&format!("chat:{}", window.label()));
+    let ttft = TtftClock::start();
     let (answer, kind, citations, stats, model) = {
         let ai = state.ai.read().await.clone();
         let model = ai.active_chat_model();
@@ -7437,6 +7497,7 @@ pub async fn send_message_agentic(
                 &history_turns,
                 &extra,
                 source_ids.as_deref(),
+                &ttft,
             ) => Some(r),
             _ = cancel.cancelled() => None,
         };
@@ -7457,6 +7518,9 @@ pub async fn send_message_agentic(
         }
     };
     state.record_chat_stats(&model, stats);
+    if kind == "chat" {
+        state.record_ttft(&model, "deep-research", &notebook_id, &ttft, None);
+    }
 
     let assistant_msg = Message {
         id: new_id(),
@@ -10941,11 +11005,14 @@ pub async fn ask_everything(
     let cancel = state.begin_generation(&format!("meta:{}", window.label()));
     let partial = Arc::new(Mutex::new(String::new()));
     let partial_cb = partial.clone();
+    let ttft = TtftClock::start();
+    let ttft_cb = ttft.clone();
     let (answer, stats, model) = {
         let ai = state.ai.read().await.clone();
         let model = ai.active_chat_model();
         let streamed = tokio::select! {
             out = ai.chat_stream(&messages, |tok| {
+                ttft_cb.mark();
                 partial_cb.lock().unwrap().push_str(tok);
                 let _ = app_for_cb.emit(
                     "meta://token",
@@ -10960,6 +11027,7 @@ pub async fn ask_everything(
         }
     };
     state.record_chat_stats(&model, stats);
+    state.record_ttft(&model, "ask-everything", "", &ttft, None);
 
     Ok(MetaAnswer { answer, citations })
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -39,6 +39,16 @@ pub struct ModelStatAcc {
     pub total_tokens: u64,
     pub total_seconds: f64,
     pub last_tps: f64,
+    /// Time to first streamed token over the chat surface, wall-clock from
+    /// the send to the first chat://token emit — retrieval included, because
+    /// that is the wait the user actually feels. serde(default) so stats
+    /// files from before the field deserialize.
+    #[serde(default)]
+    pub ttft_samples: u64,
+    #[serde(default)]
+    pub total_ttft_ms: u64,
+    #[serde(default)]
+    pub last_ttft_ms: u64,
 }
 
 pub struct AppState {
@@ -135,6 +145,18 @@ impl AppState {
         }
     }
 
+    /// Fold one chat's time-to-first-token into the running stats.
+    pub fn record_chat_ttft(&self, model: &str, ttft_ms: u64) {
+        let mut map = self.model_stats.lock().unwrap();
+        let entry = map.entry(model.to_string()).or_default();
+        entry.ttft_samples += 1;
+        entry.total_ttft_ms += ttft_ms;
+        entry.last_ttft_ms = ttft_ms;
+        if let Ok(json) = serde_json::to_string_pretty(&*map) {
+            let _ = std::fs::write(&self.stats_path, json);
+        }
+    }
+
     pub fn model_stats_snapshot(&self) -> Vec<ModelStat> {
         let map = self.model_stats.lock().unwrap();
         map.iter()
@@ -147,6 +169,12 @@ impl AppState {
                     0.0
                 },
                 samples: a.samples,
+                last_ttft_ms: a.last_ttft_ms,
+                avg_ttft_ms: if a.ttft_samples > 0 {
+                    a.total_ttft_ms as f64 / a.ttft_samples as f64
+                } else {
+                    0.0
+                },
             })
             .collect()
     }
@@ -7050,6 +7078,9 @@ pub async fn send_message(
         return Err("Message is empty".into());
     }
     let extra = chat_style_instruction(&config.unwrap_or_default());
+    // Time-to-first-token clock: from the send to the first chat://token
+    // emit. Phase marks land in the chat-timing trace line below.
+    let t0 = std::time::Instant::now();
 
     // Persist the user's turn first.
     let user_msg = Message {
@@ -7073,9 +7104,14 @@ pub async fn send_message(
     // retrieval depth can scale with how much text is actually in play
     // (RFC-infinite-context §3) and the manifest reuses the same rows.
     let ai = state.ai.read().await.clone();
-    let query_vec = e(ai.embed_one(&content).await)?;
+    // Embedding the question and listing sources are independent — overlap
+    // them; every pre-stream millisecond is felt time-to-first-token.
+    let (query_vec, sources_list) =
+        tokio::join!(ai.embed_one(&content), state.db.list_sources(&notebook_id));
+    let query_vec = e(query_vec)?;
+    let embed_ms = t0.elapsed().as_millis() as u64;
     let profile = ai.profile(crate::inference::Role::Chat);
-    let selected_sources: Vec<Source> = e(state.db.list_sources(&notebook_id).await)?
+    let selected_sources: Vec<Source> = e(sources_list)?
         .into_iter()
         .filter(|s| source_ids.as_ref().is_none_or(|ids| ids.contains(&s.id)))
         .collect();
@@ -7135,6 +7171,7 @@ pub async fn send_message(
     let pool_cap = pool.len() + grep_hits.len();
     let citations = fuse_grep_hits(pool, grep_hits, pool_cap);
     let citations = ai.rerank_hits(&content, citations, k).await;
+    let retrieval_ms = (t0.elapsed().as_millis() as u64).saturating_sub(embed_ms);
     bump_note_usage(&state.db, &citations, "retrieval_hits").await;
 
     // Widen prompt excerpts to ordinal neighbors where the model's window
@@ -7230,6 +7267,9 @@ pub async fn send_message(
     let cancel = state.begin_generation(&format!("chat:{}", window.label()));
     let partial = Arc::new(Mutex::new(String::new()));
     let partial_cb = partial.clone();
+    // 0 = no token yet; the first token stores max(elapsed, 1).
+    let first_tok = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let first_tok_cb = first_tok.clone();
     let (answer, kind, stats, cost_usd, model) = {
         let ai = state.ai.read().await.clone();
         let engine = override_engine
@@ -7241,6 +7281,12 @@ pub async fn send_message(
         let app_for_steps = app.clone();
         let streamed = tokio::select! {
             out = engine.chat_stream_steps(&messages, |tok| {
+                let _ = first_tok_cb.compare_exchange(
+                    0,
+                    (t0.elapsed().as_millis() as u64).max(1),
+                    std::sync::atomic::Ordering::Relaxed,
+                    std::sync::atomic::Ordering::Relaxed,
+                );
                 partial_cb.lock().unwrap().push_str(tok);
                 let _ = app_for_cb.emit(
                     "chat://token",
@@ -7279,6 +7325,22 @@ pub async fn send_message(
         }
     };
     state.record_chat_stats(&model, stats);
+    let ttft_ms = first_tok.load(std::sync::atomic::Ordering::Relaxed);
+    if kind == "chat" && ttft_ms > 0 {
+        state.record_chat_ttft(&model, ttft_ms);
+        crate::trace::log(
+            &state.trace_dir,
+            serde_json::json!({
+                "ts": now(),
+                "surface": "chat-timing",
+                "notebookId": notebook_id,
+                "model": model,
+                "ttftMs": ttft_ms,
+                "embedMs": embed_ms,
+                "retrievalMs": retrieval_ms,
+            }),
+        );
+    }
 
     let assistant_msg = Message {
         id: new_id(),

--- a/src-tauri/src/inference/agent_cli.rs
+++ b/src-tauri/src/inference/agent_cli.rs
@@ -546,6 +546,44 @@ fn cli_default_model(kind: AgentKind) -> Option<String> {
         .filter(|v| !v.is_empty())
 }
 
+/// The readable sentence inside an opencode error event.
+///
+/// Shape is `{name, data: {message, statusCode, ...}}`, and `data.message`
+/// often embeds the provider's own JSON body verbatim
+/// (`Payment Required: {"error":{"message":"You have exceeded your monthly
+/// quota"}}`). Splice the inner message in place of the blob so the user
+/// reads one sentence instead of a wire dump.
+fn opencode_error_message(err: &serde_json::Value) -> String {
+    let raw = err["data"]["message"]
+        .as_str()
+        .or_else(|| err["message"].as_str())
+        .or_else(|| err["name"].as_str())
+        .unwrap_or("opencode reported an error");
+    let Some(brace) = raw.find('{') else {
+        return raw.to_string();
+    };
+    let (prefix, body) = raw.split_at(brace);
+    let inner = serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .and_then(|v| {
+            v["error"]["message"]
+                .as_str()
+                .or_else(|| v["message"].as_str())
+                .map(str::to_string)
+        });
+    match inner {
+        Some(msg) => {
+            let prefix = prefix.trim_end_matches([':', ' ']);
+            if prefix.is_empty() {
+                msg
+            } else {
+                format!("{prefix}: {msg}")
+            }
+        }
+        None => raw.to_string(),
+    }
+}
+
 /// Drop ANSI colour/cursor escapes so a CLI's decorated output parses. These
 /// CLIs redraw a "Loading models…" spinner before printing, and the control
 /// bytes otherwise glue themselves to the first model name.
@@ -1169,6 +1207,14 @@ impl AgentCli {
                                 let name = v["part"]["tool"].as_str().unwrap_or("a tool");
                                 emit_step(tool_step_label(name), false);
                             }
+                            // opencode reports provider failures as an event
+                            // on STDOUT and then exits 0-ish with no text.
+                            // Dropping it turned "You have exceeded your
+                            // monthly quota" into "agent produced no output"
+                            // — the cause was on the pipe the whole time.
+                            Some("error") => {
+                                errored = Some(opencode_error_message(&v["error"]));
+                            }
                             _ => {}
                         }
                     }
@@ -1720,6 +1766,29 @@ mod tests {
 
     /// The provider's model field reaches the CLI, and blank still means "the
     /// CLI's own default" — the state every existing entry is saved in.
+    #[test]
+    fn opencode_error_events_surface_the_provider_sentence() {
+        // Real 402 shape from `opencode run --format json` with a spent
+        // Copilot quota: the useful sentence is buried in an embedded body.
+        let ev = serde_json::json!({
+            "name": "APIError",
+            "data": {
+                "message": "Payment Required: {\"error\":{\"message\":\"You have exceeded your monthly quota\",\"code\":\"quota_exceeded\"}}",
+                "statusCode": 402
+            }
+        });
+        assert_eq!(
+            opencode_error_message(&ev),
+            "Payment Required: You have exceeded your monthly quota"
+        );
+        // No embedded body: passed through untouched.
+        let plain = serde_json::json!({ "data": { "message": "session expired" } });
+        assert_eq!(opencode_error_message(&plain), "session expired");
+        // Nothing usable at all still names the source rather than panicking.
+        let empty = serde_json::json!({});
+        assert!(!opencode_error_message(&empty).is_empty());
+    }
+
     #[test]
     fn a_blank_model_stays_unset() {
         assert!(AgentCli::configured(AgentKind::Codex, "", "")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -197,6 +197,8 @@ pub fn run() {
             #[cfg(target_os = "macos")]
             handles.window.set_as_windows_menu_for_nsapp()?;
             app.manage(menu::RecentMenu(handles.recent));
+            app.manage(menu::ThemeMenu(handles.themes));
+            app.manage(menu::GenerateMenu(handles.generate));
 
             let runtime = commands::ai_runtime(app.handle().clone(), data_dir.clone());
             let (mcp_enabled, mcp_port) = (config.mcp_enabled, config.mcp_port);
@@ -400,6 +402,8 @@ pub fn run() {
             commands::live_view_visible,
             commands::live_view_close,
             commands::rebuild_app_menu,
+            commands::fill_menu_lists,
+            commands::list_shortcuts,
             commands::search_everything,
             commands::grep_sources,
             commands::export_notebook_okf_zip,

--- a/src-tauri/src/mcp/settings.rs
+++ b/src-tauri/src/mcp/settings.rs
@@ -173,20 +173,23 @@ impl AlchemyMcp {
         let messages = state.db.message_activity().await.map_err(internal)?;
         let notes = state.db.note_activity().await.map_err(internal)?;
         let sources = state.db.source_activity().await.map_err(internal)?;
-        let titles: std::collections::HashMap<String, String> = state
-            .db
-            .list_notebooks()
-            .await
-            .map_err(internal)?
-            .into_iter()
-            .map(|n| (n.id, n.title))
+        let all_notebooks = state.db.list_notebooks().await.map_err(internal)?;
+        // Same ranking rule the Activity pane uses — an agent asking "what am
+        // I most active in" should not be told about shelved notebooks.
+        let ranked_out: std::collections::HashSet<String> = all_notebooks
+            .iter()
+            .filter(|n| n.status == "archived" || n.status == "system")
+            .map(|n| n.id.clone())
             .collect();
+        let titles: std::collections::HashMap<String, String> =
+            all_notebooks.into_iter().map(|n| (n.id, n.title)).collect();
         let retrievals = crate::activity::trace_times(&state.trace_dir);
         json_result(&crate::activity::aggregate(
             &messages,
             &notes,
             &sources,
             &titles,
+            &ranked_out,
             &retrievals,
             chrono::Local::now().date_naive(),
         ))

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -8,11 +8,312 @@
 //! the Window list. "Open Recent" is refreshed by mutating its items in
 //! place (`fill_recents`).
 
-use tauri::menu::{Menu, MenuItemBuilder, Submenu, SubmenuBuilder};
+use tauri::menu::{Menu, MenuItem, MenuItemBuilder, Submenu, SubmenuBuilder};
 use tauri::{AppHandle, Emitter, Manager, Wry};
 
 /// How many notebooks Open Recent shows.
 const RECENT_LIMIT: usize = 6;
+
+/// One user-facing command — THE single registry the native menu and the
+/// Settings → Shortcuts tab both render from (hand-maintained parallel
+/// lists are how registered shortcuts went missing from the menu).
+///
+/// `accelerator: None` on an item that still shows `keys` means the key is
+/// handled frontend-side on purpose: native key equivalents win over focused
+/// text fields, so context-dependent keys (⌘N) and field-respecting keys
+/// (⌘F, ⌘←/→) must stay with the frontend's shortcutBlocked guard. The menu
+/// item remains for discoverability and mouse use.
+pub struct Command {
+    pub id: &'static str,
+    /// Menu item label; empty = not a menu item (documented gesture only).
+    pub menu_label: &'static str,
+    /// Native key equivalent set on the menu item.
+    pub accelerator: Option<&'static str>,
+    /// Display keys for the Shortcuts tab ("⌘ N"); empty = unkeyed.
+    pub keys: &'static str,
+    /// Shortcuts tab wording; empty = menu-only (not listed in the tab).
+    pub label: &'static str,
+    /// Where the shortcut applies ("" = everywhere).
+    pub context: &'static str,
+}
+
+const CMD: &[Command] = &[
+    // File
+    Command {
+        id: "menu-new-notebook",
+        menu_label: "New Notebook",
+        accelerator: None,
+        keys: "⌘ N",
+        label: "New notebook",
+        context: "Home",
+    },
+    Command {
+        id: "menu-new-note",
+        menu_label: "New Note",
+        accelerator: None,
+        keys: "⌘ N",
+        label: "New note",
+        context: "Notebook",
+    },
+    Command {
+        id: "menu-new-window",
+        menu_label: "New Window",
+        accelerator: Some("CmdOrCtrl+Shift+N"),
+        keys: "⇧ ⌘ N",
+        label: "New window",
+        context: "",
+    },
+    Command {
+        id: "menu-add-files",
+        menu_label: "Add Files…",
+        accelerator: None,
+        keys: "",
+        label: "",
+        context: "",
+    },
+    Command {
+        id: "menu-add-url",
+        menu_label: "Add URL Source…",
+        accelerator: Some("CmdOrCtrl+Shift+U"),
+        keys: "⇧ ⌘ U",
+        label: "Add a URL source",
+        context: "Notebook",
+    },
+    Command {
+        id: "menu-add-clipboard",
+        menu_label: "Add Clipboard Source…",
+        accelerator: Some("CmdOrCtrl+Alt+V"),
+        keys: "⌥ ⌘ V",
+        label: "Add the clipboard as a source",
+        context: "",
+    },
+    // Edit
+    Command {
+        id: "menu-find",
+        menu_label: "Find",
+        accelerator: None,
+        keys: "⌘ F",
+        label: "Find in source, gallery, or home",
+        context: "",
+    },
+    // View
+    Command {
+        id: "menu-search",
+        menu_label: "Search & Commands…",
+        accelerator: Some("CmdOrCtrl+K"),
+        keys: "⌘ K",
+        label: "Open the command menu",
+        context: "",
+    },
+    Command {
+        id: "menu-back",
+        menu_label: "Back",
+        accelerator: None,
+        keys: "⌘ ←",
+        label: "Back",
+        context: "",
+    },
+    Command {
+        id: "menu-forward",
+        menu_label: "Forward",
+        accelerator: None,
+        keys: "⌘ →",
+        label: "Forward",
+        context: "",
+    },
+    Command {
+        id: "menu-toggle-sources",
+        menu_label: "Sources",
+        accelerator: Some("CmdOrCtrl+1"),
+        keys: "⌘ 1",
+        label: "Show or hide Sources",
+        context: "Notebook",
+    },
+    Command {
+        id: "menu-toggle-studio",
+        menu_label: "Studio",
+        accelerator: Some("CmdOrCtrl+2"),
+        keys: "⌘ 2",
+        label: "Show or hide Studio",
+        context: "Notebook",
+    },
+    Command {
+        id: "menu-toggle-gallery",
+        menu_label: "Gallery",
+        accelerator: None,
+        keys: "",
+        label: "",
+        context: "",
+    },
+    Command {
+        id: "menu-toggle-ledger",
+        menu_label: "Ledger",
+        accelerator: None,
+        keys: "",
+        label: "",
+        context: "",
+    },
+    Command {
+        id: "menu-toggle-glass",
+        menu_label: "Liquid Glass",
+        accelerator: None,
+        keys: "",
+        label: "",
+        context: "",
+    },
+    // Notebook
+    Command {
+        id: "menu-export-note",
+        menu_label: "Export Note…",
+        accelerator: None,
+        keys: "",
+        label: "",
+        context: "",
+    },
+    Command {
+        id: "menu-archive-notebook",
+        menu_label: "Archive Notebook",
+        accelerator: None,
+        keys: "",
+        label: "",
+        context: "",
+    },
+    Command {
+        id: "menu-delete-notebook",
+        menu_label: "Delete Notebook…",
+        accelerator: None,
+        keys: "",
+        label: "",
+        context: "",
+    },
+    // Reader-local keys (frontend-owned; documented here)
+    Command {
+        id: "",
+        menu_label: "",
+        accelerator: None,
+        keys: "⌘ [",
+        label: "Reader back",
+        context: "Reader",
+    },
+    Command {
+        id: "",
+        menu_label: "",
+        accelerator: None,
+        keys: "⌘ ]",
+        label: "Reader forward",
+        context: "Reader",
+    },
+    // Selection and composer gestures (no menu items)
+    Command {
+        id: "",
+        menu_label: "",
+        accelerator: None,
+        keys: "⌘ A",
+        label: "Select all sources or notes",
+        context: "Notebook",
+    },
+    Command {
+        id: "",
+        menu_label: "",
+        accelerator: None,
+        keys: "⇧ click",
+        label: "Select a range of rows",
+        context: "Notebook",
+    },
+    Command {
+        id: "",
+        menu_label: "",
+        accelerator: None,
+        keys: "⌘ click",
+        label: "Add or remove a row from the selection",
+        context: "Notebook",
+    },
+    Command {
+        id: "",
+        menu_label: "",
+        accelerator: None,
+        keys: "⌫",
+        label: "Remove the selected rows",
+        context: "Notebook",
+    },
+    Command {
+        id: "",
+        menu_label: "",
+        accelerator: None,
+        keys: "↩",
+        label: "Send message · next find match",
+        context: "",
+    },
+    Command {
+        id: "",
+        menu_label: "",
+        accelerator: None,
+        keys: "⇧ ↩",
+        label: "New line in the composer",
+        context: "",
+    },
+    Command {
+        id: "",
+        menu_label: "",
+        accelerator: None,
+        keys: "esc",
+        label: "Close dialog or menu · clear selection",
+        context: "",
+    },
+    // The global hotkey lived only in the tray until now — this row is its
+    // in-app documentation.
+    Command {
+        id: "",
+        menu_label: "",
+        accelerator: None,
+        keys: "⌥ space",
+        label: "Ask Alchemy from anywhere (works outside the app)",
+        context: "",
+    },
+    // App/settings staples (kept here so the tab lists them from the table)
+    Command {
+        id: "menu-settings",
+        menu_label: "Settings…",
+        accelerator: Some("CmdOrCtrl+,"),
+        keys: "⌘ ,",
+        label: "Open Settings",
+        context: "",
+    },
+];
+
+/// Row shape the Shortcuts tab renders.
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ShortcutRow {
+    pub keys: String,
+    pub label: String,
+    pub context: String,
+}
+
+/// Every command with a Shortcuts-tab label, in registry order.
+pub fn shortcut_rows() -> Vec<ShortcutRow> {
+    CMD.iter()
+        .filter(|c| !c.label.is_empty())
+        .map(|c| ShortcutRow {
+            keys: c.keys.to_string(),
+            label: c.label.to_string(),
+            context: c.context.to_string(),
+        })
+        .collect()
+}
+
+/// Build one registry-backed menu item.
+fn cmd_item(app: &AppHandle, id: &str) -> tauri::Result<MenuItem<Wry>> {
+    let c = CMD
+        .iter()
+        .find(|c| c.id == id)
+        .unwrap_or_else(|| panic!("menu command {id} missing from the registry"));
+    let mut b = MenuItemBuilder::with_id(c.id, c.menu_label);
+    if let Some(a) = c.accelerator {
+        b = b.accelerator(a);
+    }
+    b.build(app)
+}
 
 /// Managed handle to the Open Recent submenu, for in-place refreshes.
 pub struct RecentMenu(pub Submenu<Wry>);
@@ -29,15 +330,21 @@ pub struct AppMenu {
     pub menu: Menu<Wry>,
     pub recent: Submenu<Wry>,
     pub window: Submenu<Wry>,
+    pub themes: Submenu<Wry>,
+    pub generate: Submenu<Wry>,
 }
+
+/// Managed handles for the frontend-filled submenus (theme names and studio
+/// generators live in TypeScript; the frontend pushes them over IPC at
+/// startup, same in-place mutation as Open Recent).
+pub struct ThemeMenu(pub Submenu<Wry>);
+pub struct GenerateMenu(pub Submenu<Wry>);
 
 /// Build the full app menu. NOTE: mark `window` as the NSApp windows menu
 /// only AFTER `app.set_menu` — the underlying NSMenu doesn't exist until the
 /// menu is attached, so marking earlier silently assigns nothing.
 pub fn build(app: &AppHandle, recents: &[(String, String)]) -> tauri::Result<AppMenu> {
-    let settings = MenuItemBuilder::with_id("menu-settings", "Settings…")
-        .accelerator("CmdOrCtrl+,")
-        .build(app)?;
+    let settings = cmd_item(app, "menu-settings")?;
     let check_updates =
         MenuItemBuilder::with_id("menu-check-updates", "Check for Updates…").build(app)?;
     let about = MenuItemBuilder::with_id("menu-about", "About Alchemy").build(app)?;
@@ -66,18 +373,11 @@ pub fn build(app: &AppHandle, recents: &[(String, String)]) -> tauri::Result<App
     let recent_menu = SubmenuBuilder::new(app, "Open Recent").build()?;
     fill_recents(app, &recent_menu, recents)?;
 
-    let new_window = MenuItemBuilder::with_id("menu-new-window", "New Window")
-        .accelerator("CmdOrCtrl+Shift+N")
-        .build(app)?;
-    let add_url = MenuItemBuilder::with_id("menu-add-url", "Add URL Source…")
-        .accelerator("CmdOrCtrl+Shift+U")
-        .build(app)?;
-    // ⌥⌘V, not ⇧⌘V: menu key equivalents win over focused text fields, and
-    // ⇧⌘V is the platform-wide Paste and Match Style — binding it here made
-    // typing users ingest a source instead of pasting.
-    let add_clipboard = MenuItemBuilder::with_id("menu-add-clipboard", "Add Clipboard Source…")
-        .accelerator("CmdOrCtrl+Alt+V")
-        .build(app)?;
+    // ⌥⌘V, not ⇧⌘V, on the clipboard add: menu key equivalents win over
+    // focused text fields, and ⇧⌘V is the platform-wide Paste and Match
+    // Style — binding it here made typing users ingest a source instead of
+    // pasting. (The registry's accelerator column carries this.)
+    //
     // One export verb: the .okf.zip is the notebook's portable form (share
     // it, back it up, unzip it for an OKF folder) — the separate
     // folder-export and "share as zip" items said the same thing twice.
@@ -90,11 +390,14 @@ pub fn build(app: &AppHandle, recents: &[(String, String)]) -> tauri::Result<App
     )
     .build(app)?;
     let file_menu = SubmenuBuilder::new(app, "File")
-        .item(&new_window)
+        .item(&cmd_item(app, "menu-new-notebook")?)
+        .item(&cmd_item(app, "menu-new-note")?)
+        .item(&cmd_item(app, "menu-new-window")?)
         .item(&recent_menu)
         .separator()
-        .item(&add_url)
-        .item(&add_clipboard)
+        .item(&cmd_item(app, "menu-add-files")?)
+        .item(&cmd_item(app, "menu-add-url")?)
+        .item(&cmd_item(app, "menu-add-clipboard")?)
         .separator()
         .item(&import_okf)
         .item(&export_okf)
@@ -103,7 +406,9 @@ pub fn build(app: &AppHandle, recents: &[(String, String)]) -> tauri::Result<App
         .build()?;
 
     // WKWebView routes clipboard shortcuts through the menu on macOS — these
-    // predefined items are what make ⌘C/⌘V/⌘Z work in inputs.
+    // predefined items are what make ⌘C/⌘V/⌘Z work in inputs. Find carries
+    // no accelerator on purpose: ⌘F must respect focused text fields, so the
+    // frontend's shortcutBlocked-guarded handler owns the key.
     let edit_menu = SubmenuBuilder::new(app, "Edit")
         .undo()
         .redo()
@@ -112,26 +417,54 @@ pub fn build(app: &AppHandle, recents: &[(String, String)]) -> tauri::Result<App
         .copy()
         .paste()
         .select_all()
+        .separator()
+        .item(&cmd_item(app, "menu-find")?)
         .build()?;
 
-    let search = MenuItemBuilder::with_id("menu-search", "Search & Commands…")
-        .accelerator("CmdOrCtrl+K")
-        .build(app)?;
-    // No ⌘←/⌘→ accelerators here: the menu's key equivalents actually WIN
-    // over a focused text field (regression: ⌘→ stopped jumping to line end
-    // while editing), so the frontend keydown handler in App.tsx owns the
-    // shortcut — it guards with shortcutBlocked so text fields keep the
-    // line-start/line-end meaning. The menu items stay for discoverability
-    // and mouse use.
-    let back = MenuItemBuilder::with_id("menu-back", "Back").build(app)?;
-    let forward = MenuItemBuilder::with_id("menu-forward", "Forward").build(app)?;
+    // Filled from the frontend (theme names live in themes.ts).
+    let theme_menu = SubmenuBuilder::new(app, "Theme").build()?;
+    theme_menu.append(
+        &MenuItemBuilder::new("Loading themes…")
+            .enabled(false)
+            .build(app)?,
+    )?;
+    // No ⌘←/⌘→ accelerators on Back/Forward: the menu's key equivalents
+    // actually WIN over a focused text field (regression: ⌘→ stopped jumping
+    // to line end while editing), so the frontend keydown handler in App.tsx
+    // owns the shortcut — it guards with shortcutBlocked so text fields keep
+    // the line-start/line-end meaning. The menu items stay for
+    // discoverability and mouse use.
     let view_menu = SubmenuBuilder::new(app, "View")
-        .item(&back)
-        .item(&forward)
+        .item(&cmd_item(app, "menu-back")?)
+        .item(&cmd_item(app, "menu-forward")?)
         .separator()
-        .item(&search)
+        .item(&cmd_item(app, "menu-search")?)
+        .separator()
+        .item(&cmd_item(app, "menu-toggle-sources")?)
+        .item(&cmd_item(app, "menu-toggle-studio")?)
+        .item(&cmd_item(app, "menu-toggle-gallery")?)
+        .item(&cmd_item(app, "menu-toggle-ledger")?)
+        .separator()
+        .item(&theme_menu)
+        .item(&cmd_item(app, "menu-toggle-glass")?)
         .separator()
         .fullscreen()
+        .build()?;
+
+    // Filled from the frontend (the generator roster lives in
+    // studioArtifacts.tsx).
+    let generate_menu = SubmenuBuilder::new(app, "Generate").build()?;
+    generate_menu.append(
+        &MenuItemBuilder::new("Loading generators…")
+            .enabled(false)
+            .build(app)?,
+    )?;
+    let notebook_menu = SubmenuBuilder::new(app, "Notebook")
+        .item(&generate_menu)
+        .item(&cmd_item(app, "menu-export-note")?)
+        .separator()
+        .item(&cmd_item(app, "menu-archive-notebook")?)
+        .item(&cmd_item(app, "menu-delete-notebook")?)
         .build()?;
 
     let window_menu = SubmenuBuilder::new(app, "Window")
@@ -151,6 +484,7 @@ pub fn build(app: &AppHandle, recents: &[(String, String)]) -> tauri::Result<App
             &file_menu,
             &edit_menu,
             &view_menu,
+            &notebook_menu,
             &window_menu,
             &help_menu,
         ],
@@ -159,7 +493,44 @@ pub fn build(app: &AppHandle, recents: &[(String, String)]) -> tauri::Result<App
         menu,
         recent: recent_menu,
         window: window_menu,
+        themes: theme_menu,
+        generate: generate_menu,
     })
+}
+
+/// Replace the Theme submenu's items (frontend pushes the theme list at
+/// startup — same in-place mutation as Open Recent). `current` gets a
+/// leading dot; a click re-fills with the new selection.
+pub fn fill_themes(
+    app: &AppHandle,
+    submenu: &Submenu<Wry>,
+    themes: &[(String, String)],
+    current: &str,
+) -> tauri::Result<()> {
+    while submenu.remove_at(0)?.is_some() {}
+    for (id, label) in themes {
+        let text = if id == current {
+            format!("● {label}")
+        } else {
+            label.clone()
+        };
+        submenu.append(&MenuItemBuilder::with_id(format!("theme:{id}"), text).build(app)?)?;
+    }
+    Ok(())
+}
+
+/// Replace the Generate submenu's items (the studio generator roster,
+/// pushed from the frontend at startup).
+pub fn fill_generators(
+    app: &AppHandle,
+    submenu: &Submenu<Wry>,
+    generators: &[(String, String)],
+) -> tauri::Result<()> {
+    while submenu.remove_at(0)?.is_some() {}
+    for (kind, label) in generators {
+        submenu.append(&MenuItemBuilder::with_id(format!("generate:{kind}"), label).build(app)?)?;
+    }
+    Ok(())
 }
 
 /// Replace the Open Recent items in place (the menu itself is never rebuilt).

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -156,6 +156,9 @@ pub struct ModelStat {
     pub last_tokens_per_sec: f64,
     pub avg_tokens_per_sec: f64,
     pub samples: u64,
+    /// Chat time-to-first-token, wall-clock ms (0 = never measured).
+    pub last_ttft_ms: u64,
+    pub avg_ttft_ms: f64,
 }
 
 /// One anchor pinning a ledger entry to verbatim source text. The quote is

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -157,6 +157,9 @@ pub struct ModelStat {
     pub avg_tokens_per_sec: f64,
     pub samples: u64,
     /// Chat time-to-first-token, wall-clock ms (0 = never measured).
+    /// The count is its own: throughput and TTFT are recorded separately
+    /// (a stopped or errored turn contributes neither).
+    pub ttft_samples: u64,
     pub last_ttft_ms: u64,
     pub avg_ttft_ms: f64,
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,9 @@ import { Toaster } from "@/components/ui";
 import { FatalOverlay } from "@/components/ErrorBoundary";
 import { shortcutBlocked } from "@/lib/utils";
 import { isTauri } from "@tauri-apps/api/core";
+import { api } from "@/lib/api";
+import { THEME_LIST, SYSTEM_THEME } from "@/lib/themes";
+import { ARTIFACTS, AUDIO_OVERVIEW } from "@/components/studioArtifacts";
 
 function App() {
   const init = useStore((s) => s.init);
@@ -37,6 +40,24 @@ function App() {
   useEffect(() => {
     void init();
   }, [init]);
+
+  // The native menu's Theme and Generate submenus render TypeScript-owned
+  // lists (themes.ts, studioArtifacts.tsx) — push them over IPC at startup,
+  // and again when the theme changes so the selection dot tracks.
+  const theme = useStore((s) => s.theme);
+  useEffect(() => {
+    if (!isTauri()) return;
+    const themes: [string, string][] = [
+      [SYSTEM_THEME, "System"],
+      ...THEME_LIST.map((t): [string, string] => [t.id, t.label]),
+    ];
+    const generators: [string, string][] = [AUDIO_OVERVIEW, ...ARTIFACTS].map(
+      (a): [string, string] => [a.kind, a.label],
+    );
+    void api.fillMenuLists(themes, generators, theme).catch(() => {
+      /* older backend without the command — menu just keeps its placeholder */
+    });
+  }, [theme]);
 
   // Cmd/Ctrl+, opens Settings (standard desktop convention); Cmd/Ctrl+K
   // toggles the command menu — from anywhere, including inputs.

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,5 +1,4 @@
 import { Fragment, memo, useEffect, useMemo, useRef, useState } from "react";
-import { listen } from "@tauri-apps/api/event";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useStore } from "@/lib/store";
 import { api } from "@/lib/api";
@@ -86,6 +85,10 @@ function fuzzyScore(query: string, title: string): number | null {
   return score;
 }
 
+/** Stable empty array for the steps selector — a fresh [] per call would
+ *  fail zustand's equality check every render. */
+const EMPTY_STEPS: string[] = [];
+
 /** Draft @mentions saved beside the draft text (chatDraftMentions:<nb>). */
 function loadDraftMentions(
   notebookId: string | null,
@@ -107,9 +110,21 @@ export function ChatPanel() {
   const loadOlderMessages = useStore((s) => s.loadOlderMessages);
   const sources = useStore((s) => s.sources);
   const sending = useStore((s) => s.sending);
-  const streamingText = useStore((s) => s.streamingText);
-  const steps = useStore((s) => s.steps);
-  const waiting = useStore((s) => s.waiting);
+  // A stream keeps running when the user navigates elsewhere (the backend
+  // persists the turn either way) — but its tokens belong to ONE notebook.
+  // Paint them only there; other notebooks see a quiet composer.
+  const streamingHere = useStore(
+    (s) => s.sendingFor === null || s.sendingFor === s.currentId,
+  );
+  const streamingText = useStore((s) =>
+    s.sendingFor === s.currentId ? s.streamingText : "",
+  );
+  const steps = useStore((s) =>
+    s.sendingFor === s.currentId ? s.steps : EMPTY_STEPS,
+  );
+  const waiting = useStore((s) =>
+    s.sendingFor === s.currentId ? s.waiting : "",
+  );
   const agentMode = useStore((s) => s.agentMode);
   const toggleAgentMode = useStore((s) => s.toggleAgentMode);
   // Hosted-agent mode (docs/RFC-acp-agents.md) swaps the RAG transcript for
@@ -129,8 +144,6 @@ export function ChatPanel() {
   const cancelGeneration = useStore((s) => s.cancelGeneration);
   const reading = useStore((s) => s.reading);
   const clearChat = useStore((s) => s.clearChat);
-  const appendToken = useStore((s) => s.appendToken);
-  const appendStep = useStore((s) => s.appendStep);
   const theme = useStore((s) => s.theme);
   // Under glass the material is the ambience — the shader must not mount
   // (display:none alone leaves its rAF/WebGL loop running invisibly).
@@ -235,41 +248,9 @@ export function ChatPanel() {
     el.style.height = `${Math.min(el.scrollHeight, COMPOSER_MAX_H)}px`;
   }, [draft]);
 
-  // Subscribe once to streaming tokens + agent progress steps from the backend.
-  // Events broadcast to every window — only the one with a send in flight
-  // should accumulate them.
-  useEffect(() => {
-    const unToken = listen<{ content: string }>("chat://token", (e) => {
-      if (useStore.getState().sending) appendToken(e.payload.content);
-    });
-    const unStep = listen<{ label: string; transient: boolean }>(
-      "chat://step",
-      (e) => {
-        if (useStore.getState().sending)
-          appendStep(e.payload.label, e.payload.transient);
-      },
-    );
-    // Verify-and-repair swaps a revised answer under the same message id
-    // (backend spawn_answer_verify). Events reach every window — apply
-    // only when the message is in this window's transcript.
-    const unRevised = listen<{ id: string; content: string }>(
-      "chat://revised",
-      (e) => {
-        const { messages } = useStore.getState();
-        if (!messages.some((m) => m.id === e.payload.id)) return;
-        useStore.setState({
-          messages: messages.map((m) =>
-            m.id === e.payload.id ? { ...m, content: e.payload.content } : m,
-          ),
-        });
-      },
-    );
-    return () => {
-      unToken.then((fn) => fn());
-      unStep.then((fn) => fn());
-      unRevised.then((fn) => fn());
-    };
-  }, [appendToken, appendStep]);
+  // Streaming token/step listeners live in the store's global listeners now
+  // (bindGlobalListeners): they must keep accumulating while the user is on
+  // Home or in another notebook, and this component unmounts there.
 
   // "Focus the chat composer" command from the Cmd+K menu.
   useEffect(() => {
@@ -809,7 +790,12 @@ export function ChatPanel() {
             <ChatMessage key={m.id} message={m} />
           ))}
 
-          {sending && (
+          {sending && !streamingHere && (
+            <div className="text-caption text-muted-foreground">
+              Answering in another notebook…
+            </div>
+          )}
+          {sending && streamingHere && (
             <div className="flex flex-col gap-2">
               <RoleLabel role="assistant" />
               {steps.length > 0 && (

--- a/src/components/GalleryPane.tsx
+++ b/src/components/GalleryPane.tsx
@@ -217,6 +217,18 @@ export function GalleryPane() {
     return () => window.removeEventListener("keydown", onKey);
   }, []);
 
+  // Edit > Find (menu.rs): the menu item has no accelerator, so it bumps
+  // findBump; the mounted find surface (here, the gallery) answers.
+  const findBump = useStore((s) => s.findBump);
+  useEffect(() => {
+    if (findBump === 0) return;
+    setFindOpen(true);
+    requestAnimationFrame(() => {
+      findRef.current?.focus();
+      findRef.current?.select();
+    });
+  }, [findBump]);
+
   // Closing clears the query, so the grid is never left silently filtered.
   useEffect(() => {
     if (!findOpen) setFindQuery("");

--- a/src/components/HomeViewControls.tsx
+++ b/src/components/HomeViewControls.tsx
@@ -57,6 +57,14 @@ export function HomeViewControls({
     return () => window.removeEventListener("keydown", onKey);
   }, []);
 
+  // Edit > Find (menu.rs): accelerator-less menu item, routed via findBump.
+  const findBump = useStore((s) => s.findBump);
+  useEffect(() => {
+    if (findBump === 0) return;
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, [findBump]);
+
   const setView = (v: "grid" | "table") => {
     localStorage.setItem("homeView", v);
     useStore.setState({ homeView: v });

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -104,10 +104,22 @@ export function Onboarding({ onOpenSettings }: { onOpenSettings: () => void }) {
   }, [aiConfig]);
 
   const provider = aiConfig?.provider ?? "ollama";
+  // Which setup path the tiles show. Apple Intelligence rides the modern
+  // chatProvider field; the flat provider string still drives the two
+  // original paths (normalize mirrors them either way).
+  const mode =
+    aiConfig?.chatProvider === "on-device"
+      ? "fm"
+      : provider === "openai"
+        ? "openai"
+        : "ollama";
 
-  async function setProvider(p: string) {
+  async function setMode(m: "fm" | "ollama" | "openai") {
     if (!aiConfig) return;
-    await save({ ...aiConfig, provider: p });
+    if (m === "fm") await save({ ...aiConfig, chatProvider: "on-device" });
+    else if (m === "ollama")
+      await save({ ...aiConfig, provider: "ollama", chatProvider: "ollama" });
+    else await save({ ...aiConfig, provider: "openai", chatProvider: "" });
     await refresh();
   }
 
@@ -169,10 +181,15 @@ export function Onboarding({ onOpenSettings }: { onOpenSettings: () => void }) {
             Set up Alchemy
           </h1>
           <p className="max-w-sm text-body leading-relaxed text-muted-foreground">
-            {provider === "openai" ? (
+            {mode === "openai" ? (
               <>
                 Connect an OpenAI-compatible gateway. Your sources are indexed
                 locally; only your chat prompts are sent to the gateway.
+              </>
+            ) : mode === "fm" ? (
+              <>
+                Answers come from Apple Intelligence, on this Mac. Nothing to
+                install; nothing leaves your computer.
               </>
             ) : (
               <>
@@ -189,17 +206,20 @@ export function Onboarding({ onOpenSettings }: { onOpenSettings: () => void }) {
           </p>
         </div>
 
-        <div className="grid grid-cols-2 gap-1.5">
-          {[
-            { id: "ollama", label: "Ollama", note: "Local & private" },
-            { id: "openai", label: "OpenAI-compatible", note: "Cloud or enterprise gateway" },
-          ].map((pv) => (
+        <div className="grid grid-cols-3 gap-1.5">
+          {(
+            [
+              { id: "fm", label: "Apple Intelligence", note: "On-device · zero setup" },
+              { id: "ollama", label: "Ollama", note: "Local models · private" },
+              { id: "openai", label: "OpenAI-compatible", note: "Your API key · 30+ services" },
+            ] as const
+          ).map((pv) => (
             <button
               key={pv.id}
-              onClick={() => void setProvider(pv.id)}
+              onClick={() => void setMode(pv.id)}
               className={cn(
                 "flex flex-col items-start gap-0.5 rounded-lg border px-3 py-2 text-left transition-colors",
-                provider === pv.id
+                mode === pv.id
                   ? "border-primary/60 bg-primary/10 text-foreground"
                   : "border-border bg-surface text-muted-foreground hover:text-foreground",
               )}
@@ -209,8 +229,18 @@ export function Onboarding({ onOpenSettings }: { onOpenSettings: () => void }) {
             </button>
           ))}
         </div>
+        {/* The full roster (Claude Code and other signed-in subscriptions,
+            per-provider keys) lives in Settings — the overlay stays the
+            three broadest doors. */}
+        <button
+          className="-mt-3 text-center text-caption text-subtle-foreground hover:text-muted-foreground"
+          onClick={onOpenSettings}
+        >
+          Already pay for Claude or ChatGPT? Connect a subscription in
+          Settings → Models…
+        </button>
 
-        {provider === "openai" && (
+        {mode === "openai" && (
           <div className="flex flex-col gap-1.5 rounded-lg border border-border-strong bg-surface px-4 py-3">
             <span className="text-body font-medium text-foreground">Gateway</span>
             <Input
@@ -281,10 +311,19 @@ export function Onboarding({ onOpenSettings }: { onOpenSettings: () => void }) {
         )}
 
         <div className="flex flex-col gap-2">
-          {!(provider === "openai" && aiConfig?.embedder === "builtin") && (
+          {/* Only when something actually needs Ollama — chat in Ollama mode,
+              or the Ollama embedder. A goal-form title while unchecked: a red
+              ✗ beside "Ollama is running" read as the app asserting a lie. */}
+          {(mode === "ollama" || aiConfig?.embedder === "ollama") && (
           <Step
             ok={health.reachable}
-            title={provider === "openai" ? "Ollama is running (for source indexing)" : "Ollama is running"}
+            title={
+              health.reachable
+                ? "Ollama is running"
+                : mode === "ollama"
+                  ? "Start Ollama"
+                  : "Start Ollama (for source indexing)"
+            }
             detail="Install Ollama, then start it. Alchemy connects to it locally."
           >
             <CommandChip command="brew install ollama" />
@@ -299,20 +338,30 @@ export function Onboarding({ onOpenSettings }: { onOpenSettings: () => void }) {
           )}
 
           <Step
-            ok={provider === "openai" ? chat.working : health.reachable && chat.working}
-            title={provider === "openai" ? "Gateway connected" : "Chat model"}
+            ok={mode === "ollama" ? health.reachable && chat.working : chat.working}
+            title={
+              mode === "openai"
+                ? chat.working
+                  ? "Gateway connected"
+                  : "Connect a gateway"
+                : mode === "fm"
+                  ? "Apple Intelligence"
+                  : chat.working
+                    ? "Chat model ready"
+                    : "Get a chat model"
+            }
             detail={
-              provider === "openai"
+              mode === "openai" || mode === "fm"
                 ? chat.detail
                 : health.reachable
                   ? `Answers questions and generates documents. ${chat.detail}`
                   : "Waiting for Ollama."
             }
           >
-            {provider !== "openai" && health.reachable && (
+            {mode === "ollama" && health.reachable && (
               <CommandChip command={`ollama pull ${chat.name}`} />
             )}
-            {provider !== "openai" && health.reachable && (
+            {mode === "ollama" && health.reachable && (
               <button className="text-caption text-citation hover:underline" onClick={onOpenSettings}>
                 or pick a smaller model
               </button>
@@ -336,16 +385,16 @@ export function Onboarding({ onOpenSettings }: { onOpenSettings: () => void }) {
           </Step>
 
           <Step
-            ok={provider === "openai" ? vision.working : health.reachable && vision.working}
+            ok={mode === "openai" ? vision.working : health.reachable && vision.working}
             optional
             title="Vision model"
             detail={
-              provider === "openai"
+              mode === "openai"
                 ? "Enables OCR for images and scanned PDFs. Set a vision-capable model (e.g. gpt-4o) in the Gateway box above."
                 : "Enables OCR for images and scanned PDFs. Skip it if you don't need that."
             }
           >
-            {provider !== "openai" && health.reachable && (
+            {mode !== "openai" && health.reachable && (
               <CommandChip command={`ollama pull ${vision.name || "glm-ocr"}`} />
             )}
           </Step>

--- a/src/components/ReaderPane.tsx
+++ b/src/components/ReaderPane.tsx
@@ -1982,6 +1982,20 @@ function SourceReader({
     return () => window.removeEventListener("keydown", onKey);
   }, [onFindOpen]);
 
+  // Edit > Find (menu.rs) lands here too — the menu can't carry the ⌘F
+  // accelerator (it would override focused text fields), so it bumps
+  // findBump and whichever find surface is mounted answers.
+  const findBump = useStore((s) => s.findBump);
+  useEffect(() => {
+    if (findBump === 0) return;
+    onFindOpen();
+    requestAnimationFrame(() => {
+      searchRef.current?.focus();
+      searchRef.current?.select();
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [findBump]);
+
   // The bar opening (via toolbar button) grabs focus; closing clears the
   // query so highlights drop back to the citation passage.
   useEffect(() => {

--- a/src/components/StudioPanel.tsx
+++ b/src/components/StudioPanel.tsx
@@ -130,8 +130,16 @@ export function StudioPanel() {
   const currentId = useStore((s) => s.currentId);
   const sources = useStore((s) => s.sources);
   const notes = useStore((s) => s.notes);
+  // A generation keeps running when the user navigates elsewhere; its live
+  // preview belongs to ONE notebook. Other notebooks keep the tiles disabled
+  // (the backend runs one generation per window) but paint no stream.
   const generatingKind = useStore((s) => s.generatingKind);
-  const artifactStreamText = useStore((s) => s.artifactStreamText);
+  const generatingHere = useStore(
+    (s) => s.generatingFor === null || s.generatingFor === s.currentId,
+  );
+  const artifactStreamText = useStore((s) =>
+    s.generatingFor === s.currentId ? s.artifactStreamText : "",
+  );
   const audioProgress = useStore((s) => s.audioProgress);
   const kokoroReady = useStore((s) => !!s.kokoroStatus?.verified);
   const generate = useStore((s) => s.generateArtifact);
@@ -367,7 +375,12 @@ export function StudioPanel() {
         <div className="p-3">
           <div className="flex items-center gap-2 text-micro font-medium uppercase tracking-wide text-subtle-foreground">
             <span>Generate</span>
-            {generatingKind && (
+            {generatingKind && !generatingHere && (
+              <span className="text-badge normal-case text-subtle-foreground">
+                generating in another notebook…
+              </span>
+            )}
+            {generatingKind && generatingHere && (
               <button
                 onClick={() => cancelGeneration("artifact")}
                 className="flex items-center gap-1 rounded px-1.5 py-0.5 text-destructive hover:bg-destructive/10"
@@ -377,7 +390,7 @@ export function StudioPanel() {
                 Stop
               </button>
             )}
-            {audioProgress && (
+            {audioProgress && generatingHere && (
               <span className="text-badge normal-case tabular-nums text-subtle-foreground">
                 voicing {audioProgress.done}/{audioProgress.total}
               </span>
@@ -426,7 +439,7 @@ export function StudioPanel() {
                     <GenTile
                       key={a.kind}
                       icon={
-                        generatingKind === a.kind ? (
+                        generatingKind === a.kind && generatingHere ? (
                           <Spinner className="h-3.5 w-3.5" />
                         ) : (
                           a.icon

--- a/src/components/StudioPanel.tsx
+++ b/src/components/StudioPanel.tsx
@@ -17,6 +17,7 @@ import {
   useMarquee,
 } from "./ui";
 import { Reports } from "./Reports";
+import { exportNote, exportTargets } from "@/lib/noteExport";
 import { RichEditor } from "./RichEditor";
 import { StreamingBody } from "./StudioNoteViewer";
 import {
@@ -48,79 +49,6 @@ import {
   ChevronDown,
   ChevronUp,
 } from "lucide-react";
-import { save } from "@tauri-apps/plugin-dialog";
-import { revealItemInDir } from "@tauri-apps/plugin-opener";
-
-/** True when the note body is essentially one markdown table. */
-function isTabular(content: string): boolean {
-  const lines = content
-    .split("\n")
-    .map((line) => line.trim())
-    .filter(Boolean);
-  const tableLines = lines.filter((line) => line.startsWith("|")).length;
-  return tableLines >= 2 && tableLines >= lines.length - 2;
-}
-
-interface ExportTarget {
-  label: string;
-  format: string;
-  ext: string;
-  name: string;
-}
-
-const PDF_TARGET: ExportTarget = {
-  label: "Export PDF",
-  format: "pdf",
-  ext: "pdf",
-  name: "PDF",
-};
-
-/** The export formats matched to the note's shape (docs/RFC-note-export.md):
- *  a kind-true primary — poster image, slide deck, workbook, episode audio,
- *  Word document — plus a PDF of the note's own render for everything the
- *  print pipeline covers (audio stays audio). */
-function exportTargets(n: Note): ExportTarget[] {
-  if (n.kind === "infographic" || n.kind === "mind_map")
-    return [
-      { label: "Export PNG", format: "png", ext: "png", name: "PNG image" },
-      PDF_TARGET,
-    ];
-  if (n.kind === "slide_deck" || n.kind === "flashcards")
-    return [
-      { label: "Export PowerPoint", format: "pptx", ext: "pptx", name: "PowerPoint" },
-      PDF_TARGET,
-    ];
-  if (n.kind === "audio_overview")
-    return [{ label: "Export audio", format: "m4a", ext: "m4a", name: "Audio" }];
-  if (n.kind === "data_table" || isTabular(n.content))
-    return [
-      { label: "Export Excel", format: "xlsx", ext: "xlsx", name: "Excel workbook" },
-      PDF_TARGET,
-    ];
-  return [
-    { label: "Export Word", format: "docx", ext: "docx", name: "Word document" },
-    PDF_TARGET,
-  ];
-}
-
-/** Pick a destination in the native save dialog, export, reveal in Finder. */
-async function exportNote(n: Note, t: ExportTarget): Promise<void> {
-  const safe = n.title.replace(/[/\\:]/g, "-").trim() || "Note";
-  const dest = await save({
-    defaultPath: `${safe}.${t.ext}`,
-    filters: [{ name: t.name, extensions: [t.ext] }],
-  });
-  if (!dest) return;
-  const { pushToast } = useStore.getState();
-  pushToast("info", "Exporting…");
-  try {
-    const path = await api.exportNote(n.id, t.format, dest);
-    pushToast("success", "Exported");
-    void revealItemInDir(path);
-  } catch (e) {
-    pushToast("error", e instanceof Error ? e.message : String(e));
-  }
-}
 
 /** Generator families carry a quiet color identity: the icon takes the family
  *  accent (tokens in index.css) and the tile gets a faint matching wash that

--- a/src/components/settings/ActivityTab.tsx
+++ b/src/components/settings/ActivityTab.tsx
@@ -120,45 +120,73 @@ function fmtMs(ms: number): string {
   return ms < 1000 ? `${Math.round(ms)} ms` : `${(ms / 1000).toFixed(1)}s`;
 }
 
-/** Chat responsiveness per model, quickest first — average time to first
- *  token plus throughput, from the running stats send_message records. */
-function SpeedList({
-  rows,
-}: {
-  rows: { name: string; avgTtftMs: number; avgTokensPerSec: number }[];
-}) {
+/** The fastest-models ranking: which model answers soonest, ordered.
+ *
+ *  Time to first token is the metric because it is the wait the user
+ *  actually feels — throughput rides along as a secondary number, since a
+ *  model can be quick to start and slow to finish. Bars are wait time
+ *  (shorter = faster), so the ranking reads as a descending staircase, and
+ *  each row shows how many runs it averages: a model measured once has no
+ *  business silently outranking one measured fifty times. */
+function SpeedRanking({ rows }: { rows: ModelStat[] }) {
   if (rows.length === 0) return null;
+  const slowest = Math.max(...rows.map((r) => r.avgTtftMs));
   return (
     <div className="min-w-0">
-      <div className="pb-1.5 text-caption font-medium text-muted-foreground">
-        Time to first token
+      <div className="flex items-baseline justify-between gap-3 pb-1.5">
+        <span className="text-caption font-medium text-muted-foreground">
+          Fastest models
+        </span>
+        <span className="text-micro text-subtle-foreground">
+          average time to first token
+        </span>
       </div>
       <div className="flex flex-col gap-1">
-        {rows.map((r, i) => (
-          <div
-            key={r.name}
-            className="flex items-baseline justify-between gap-3 text-body"
-          >
-            <span className="flex min-w-0 items-baseline gap-1.5 truncate">
-              {i === 0 && (
-                <Zap
-                  className="h-3 w-3 shrink-0 self-center text-success"
-                  aria-label="Fastest"
+        {rows.map((r, i) => {
+          const lead = i === 0;
+          return (
+            <div
+              key={r.name}
+              className="grid grid-cols-[1rem_minmax(0,1fr)_5rem_auto] items-center gap-2.5 text-body"
+            >
+              <span className="text-caption tabular-nums text-subtle-foreground">
+                {i + 1}
+              </span>
+              <span className="flex min-w-0 items-center gap-1.5">
+                <span className="truncate">{r.name}</span>
+                {lead && (
+                  <Zap
+                    className="h-3 w-3 shrink-0 text-success"
+                    aria-label="Fastest"
+                  />
+                )}
+              </span>
+              {/* Wait-time bar, scaled to the slowest model in the list. */}
+              <span
+                className="h-1 overflow-hidden rounded-full bg-muted-foreground/15"
+                aria-hidden
+              >
+                <span
+                  className={cn(
+                    "block h-full rounded-full",
+                    lead ? "bg-success" : "bg-muted-foreground/50",
+                  )}
+                  style={{
+                    width: `${slowest > 0 ? Math.max((r.avgTtftMs / slowest) * 100, 4) : 100}%`,
+                  }}
                 />
-              )}
-              <span className="truncate">{r.name}</span>
-            </span>
-            <span className="shrink-0 tabular-nums text-muted-foreground">
-              {fmtMs(r.avgTtftMs)}
-              {r.avgTokensPerSec > 0 && (
+              </span>
+              <span className="shrink-0 tabular-nums text-caption text-muted-foreground">
+                {fmtMs(r.avgTtftMs)}
                 <span className="text-subtle-foreground">
-                  {" "}
-                  · {Math.round(r.avgTokensPerSec)} tok/s
+                  {r.avgTokensPerSec > 0 &&
+                    ` \u00b7 ${Math.round(r.avgTokensPerSec)} tok/s`}
+                  {` \u00b7 ${r.ttftSamples} run${r.ttftSamples === 1 ? "" : "s"}`}
                 </span>
-              )}
-            </span>
-          </div>
-        ))}
+              </span>
+            </div>
+          );
+        })}
       </div>
     </div>
   );
@@ -482,8 +510,9 @@ export function ActivityTab() {
       <div className="grid grid-cols-2 gap-5">
         <CountList title="Most used models" rows={stats.models} />
         <CountList title="Most active notebooks" rows={stats.notebooks} />
-        <SpeedList rows={speed} />
       </div>
+
+      <SpeedRanking rows={speed} />
 
       {stats.sourceTypes.length > 0 && (
         <div>

--- a/src/components/settings/ActivityTab.tsx
+++ b/src/components/settings/ActivityTab.tsx
@@ -129,8 +129,7 @@ function fmtMs(ms: number): string {
  *  each row shows how many runs it averages: a model measured once has no
  *  business silently outranking one measured fifty times. */
 function SpeedRanking({ rows }: { rows: ModelStat[] }) {
-  if (rows.length === 0) return null;
-  const slowest = Math.max(...rows.map((r) => r.avgTtftMs));
+  const slowest = Math.max(...rows.map((r) => r.avgTtftMs), 0);
   return (
     <div className="min-w-0">
       <div className="flex items-baseline justify-between gap-3 pb-1.5">
@@ -141,6 +140,15 @@ function SpeedRanking({ rows }: { rows: ModelStat[] }) {
           average time to first token
         </span>
       </div>
+      {/* Says why it is empty rather than vanishing: a section that hides
+          itself is indistinguishable from one that failed to load. */}
+      {rows.length === 0 && (
+        <p className="text-caption leading-relaxed text-subtle-foreground">
+          No timings yet. Each chat records how long its model took to start
+          answering; models you have already used appear here after their
+          next reply.
+        </p>
+      )}
       <div className="flex flex-col gap-1">
         {rows.map((r, i) => {
           const lead = i === 0;

--- a/src/components/settings/ActivityTab.tsx
+++ b/src/components/settings/ActivityTab.tsx
@@ -3,13 +3,14 @@ import { api } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { Spinner } from "../ui";
 import { TileShader } from "./TileShader";
-import type { ActivityStats } from "@/lib/types";
+import type { ActivityStats, ModelStat } from "@/lib/types";
 import {
   CalendarDays,
   Clock,
   Flame,
   Library,
   MessageSquare,
+  Zap,
   Moon,
   Search,
   StickyNote,
@@ -109,6 +110,55 @@ function Tile({
       </div>
       <div className="relative mt-0.5 text-[1.0625rem] font-semibold tabular-nums">
         {value}
+      </div>
+    </div>
+  );
+}
+
+/** Sub-second TTFTs read in ms, the rest in seconds. */
+function fmtMs(ms: number): string {
+  return ms < 1000 ? `${Math.round(ms)} ms` : `${(ms / 1000).toFixed(1)}s`;
+}
+
+/** Chat responsiveness per model, quickest first — average time to first
+ *  token plus throughput, from the running stats send_message records. */
+function SpeedList({
+  rows,
+}: {
+  rows: { name: string; avgTtftMs: number; avgTokensPerSec: number }[];
+}) {
+  if (rows.length === 0) return null;
+  return (
+    <div className="min-w-0">
+      <div className="pb-1.5 text-caption font-medium text-muted-foreground">
+        Time to first token
+      </div>
+      <div className="flex flex-col gap-1">
+        {rows.map((r, i) => (
+          <div
+            key={r.name}
+            className="flex items-baseline justify-between gap-3 text-body"
+          >
+            <span className="flex min-w-0 items-baseline gap-1.5 truncate">
+              {i === 0 && (
+                <Zap
+                  className="h-3 w-3 shrink-0 self-center text-success"
+                  aria-label="Fastest"
+                />
+              )}
+              <span className="truncate">{r.name}</span>
+            </span>
+            <span className="shrink-0 tabular-nums text-muted-foreground">
+              {fmtMs(r.avgTtftMs)}
+              {r.avgTokensPerSec > 0 && (
+                <span className="text-subtle-foreground">
+                  {" "}
+                  · {Math.round(r.avgTokensPerSec)} tok/s
+                </span>
+              )}
+            </span>
+          </div>
+        ))}
       </div>
     </div>
   );
@@ -247,6 +297,7 @@ function Heatmap({ stats }: { stats: ActivityStats }) {
 
 export function ActivityTab() {
   const [stats, setStats] = useState<ActivityStats | null>(null);
+  const [modelStats, setModelStats] = useState<ModelStat[]>([]);
   const [error, setError] = useState(false);
   const [range, setRange] = useState<RangeId>("all");
 
@@ -255,7 +306,20 @@ export function ActivityTab() {
       .activityStats()
       .then(setStats)
       .catch(() => setError(true));
+    api
+      .getModelStats()
+      .then(setModelStats)
+      .catch(() => {});
   }, []);
+
+  // Chat models with a measured time-to-first-token, quickest first.
+  const speed = useMemo(
+    () =>
+      modelStats
+        .filter((m) => m.avgTtftMs > 0)
+        .sort((a, b) => a.avgTtftMs - b.avgTtftMs),
+    [modelStats],
+  );
 
   const ranged = useMemo(() => {
     if (!stats) return null;
@@ -418,6 +482,7 @@ export function ActivityTab() {
       <div className="grid grid-cols-2 gap-5">
         <CountList title="Most used models" rows={stats.models} />
         <CountList title="Most active notebooks" rows={stats.notebooks} />
+        <SpeedList rows={speed} />
       </div>
 
       {stats.sourceTypes.length > 0 && (

--- a/src/components/settings/SettingsTabs.tsx
+++ b/src/components/settings/SettingsTabs.tsx
@@ -291,30 +291,25 @@ export function AppearanceTab() {
   );
 }
 
-const SHORTCUTS: { keys: string[]; label: string; context?: string }[] = [
-  { keys: ["⌘", "N"], label: "New notebook", context: "Home" },
-  { keys: ["⌘", "N"], label: "New note", context: "Notebook" },
-  { keys: ["⌘", "K"], label: "Open the command menu" },
-  { keys: ["⌘", "F"], label: "Find in source", context: "Reader" },
-  { keys: ["⌘", "1"], label: "Show or hide Sources", context: "Notebook" },
-  { keys: ["⌘", "2"], label: "Show or hide Studio", context: "Notebook" },
-  { keys: ["⌘", ","], label: "Open Settings" },
-  { keys: ["⌘", "A"], label: "Select all sources or notes", context: "Notebook" },
-  { keys: ["⇧", "click"], label: "Select a range of rows", context: "Notebook" },
-  { keys: ["⌘", "click"], label: "Add or remove a row from the selection", context: "Notebook" },
-  { keys: ["⌫"], label: "Remove the selected rows", context: "Notebook" },
-  { keys: ["↩"], label: "Send message · next find match" },
-  { keys: ["⇧", "↩"], label: "New line in the composer" },
-  { keys: ["esc"], label: "Close dialog or menu · clear selection" },
-];
-
 export function ShortcutsTab() {
+  // The rows come from the menu's command registry (menu.rs::CMD) — one
+  // source of truth for the native menu and this tab, so a shortcut can no
+  // longer be registered in one and missing from the other.
+  const [shortcuts, setShortcuts] = useState<
+    { keys: string; label: string; context: string }[]
+  >([]);
+  useEffect(() => {
+    api
+      .listShortcuts()
+      .then(setShortcuts)
+      .catch(() => setShortcuts([]));
+  }, []);
   return (
     <div className="flex flex-col gap-1">
-      {SHORTCUTS.map((shortcut) => (
-        <div key={`${shortcut.label}-${shortcut.context ?? "global"}`} className="flex items-center gap-3 rounded-md px-1 py-1.5">
+      {shortcuts.map((shortcut) => (
+        <div key={`${shortcut.label}-${shortcut.context || "global"}`} className="flex items-center gap-3 rounded-md px-1 py-1.5">
           <div className="flex w-20 shrink-0 items-center gap-1">
-            {shortcut.keys.map((key) => <Kbd key={key}>{key}</Kbd>)}
+            {shortcut.keys.split(" ").map((key) => <Kbd key={key}>{key}</Kbd>)}
           </div>
           <span className="text-body text-foreground/90">{shortcut.label}</span>
           {shortcut.context && <span className="ml-auto text-micro text-subtle-foreground">{shortcut.context}</span>}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -408,6 +408,22 @@ export const api = {
   kokoroStatus: () => run(query<KokoroStatus>("kokoro_status")),
   setupKokoro: () => run(slow<KokoroStatus>("setup_kokoro")),
   removeKokoro: () => run(cmd<KokoroStatus>("remove_kokoro")),
+  /** Push the frontend-owned menu lists (themes, studio generators) into
+   *  the native menu; re-called on theme change to move the selection dot. */
+  fillMenuLists: (
+    themes: [string, string][],
+    generators: [string, string][],
+    currentTheme: string,
+  ) =>
+    run(cmd<void>("fill_menu_lists", { themes, generators, currentTheme })),
+  /** Settings → Shortcuts rows from the menu's command registry. */
+  listShortcuts: () =>
+    run(
+      query<{ keys: string; label: string; context: string }[]>(
+        "list_shortcuts",
+        {},
+      ),
+    ),
   exportNotebookOkfZip: (notebookId: string, destPath: string) =>
     run(slow<string>("export_notebook_okf_zip", { notebookId, destPath })),
   probeOkf: (path: string) => run(query<boolean>("probe_okf", { path })),

--- a/src/lib/noteExport.ts
+++ b/src/lib/noteExport.ts
@@ -1,0 +1,80 @@
+import { save } from "@tauri-apps/plugin-dialog";
+import { revealItemInDir } from "@tauri-apps/plugin-opener";
+import { api } from "./api";
+import { useStore } from "./store";
+import type { Note } from "./types";
+
+/* Per-note export (docs/RFC-note-export.md), shared by the Studio panel and
+ * the Notebook menu's Export Note… — lifted out of StudioPanel so lib code
+ * can drive it without importing a component module. */
+
+/** True when the note body is essentially one markdown table. */
+export function isTabular(content: string): boolean {
+  const lines = content
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const tableLines = lines.filter((line) => line.startsWith("|")).length;
+  return tableLines >= 2 && tableLines >= lines.length - 2;
+}
+
+export interface ExportTarget {
+  label: string;
+  format: string;
+  ext: string;
+  name: string;
+}
+
+const PDF_TARGET: ExportTarget = {
+  label: "Export PDF",
+  format: "pdf",
+  ext: "pdf",
+  name: "PDF",
+};
+
+/** The export formats matched to the note's shape (docs/RFC-note-export.md):
+ *  a kind-true primary — poster image, slide deck, workbook, episode audio,
+ *  Word document — plus a PDF of the note's own render for everything the
+ *  print pipeline covers (audio stays audio). */
+export function exportTargets(n: Note): ExportTarget[] {
+  if (n.kind === "infographic" || n.kind === "mind_map")
+    return [
+      { label: "Export PNG", format: "png", ext: "png", name: "PNG image" },
+      PDF_TARGET,
+    ];
+  if (n.kind === "slide_deck" || n.kind === "flashcards")
+    return [
+      { label: "Export PowerPoint", format: "pptx", ext: "pptx", name: "PowerPoint" },
+      PDF_TARGET,
+    ];
+  if (n.kind === "audio_overview")
+    return [{ label: "Export audio", format: "m4a", ext: "m4a", name: "Audio" }];
+  if (n.kind === "data_table" || isTabular(n.content))
+    return [
+      { label: "Export Excel", format: "xlsx", ext: "xlsx", name: "Excel workbook" },
+      PDF_TARGET,
+    ];
+  return [
+    { label: "Export Word", format: "docx", ext: "docx", name: "Word document" },
+    PDF_TARGET,
+  ];
+}
+
+/** Pick a destination in the native save dialog, export, reveal in Finder. */
+export async function exportNote(n: Note, t: ExportTarget): Promise<void> {
+  const safe = n.title.replace(/[/\\:]/g, "-").trim() || "Note";
+  const dest = await save({
+    defaultPath: `${safe}.${t.ext}`,
+    filters: [{ name: t.name, extensions: [t.ext] }],
+  });
+  if (!dest) return;
+  const { pushToast } = useStore.getState();
+  pushToast("info", "Exporting…");
+  try {
+    const path = await api.exportNote(n.id, t.format, dest);
+    pushToast("success", "Exported");
+    void revealItemInDir(path);
+  } catch (e) {
+    pushToast("error", e instanceof Error ? e.message : String(e));
+  }
+}

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -370,6 +370,7 @@ export const useStore = create<AppState>((set, get) => {
     reading: loadReadingPrefs(),
 
     sending: false,
+    sendingFor: null,
     streamingText: "",
     steps: [],
     waiting: "",
@@ -379,6 +380,7 @@ export const useStore = create<AppState>((set, get) => {
     summary: "",
     summaryLoading: false,
     generatingKind: null,
+    generatingFor: null,
     generatingTemplateId: null,
     ingestQueue: [],
     migration: null,
@@ -595,6 +597,30 @@ export const useStore = create<AppState>((set, get) => {
     },
 
     bindGlobalListeners: () => {
+      // Chat streaming tokens + agent progress steps. Store-level, not in
+      // ChatPanel: the stream keeps running when the user navigates to Home
+      // or another notebook (where ChatPanel is unmounted), and returning
+      // mid-stream must show the whole accumulated text, not a gap. Events
+      // broadcast to every window — only the one with a send in flight
+      // accumulates them.
+      void listen<{ content: string }>("chat://token", (e) => {
+        if (get().sending) get().appendToken(e.payload.content);
+      });
+      void listen<{ label: string; transient: boolean }>("chat://step", (e) => {
+        if (get().sending) get().appendStep(e.payload.label, e.payload.transient);
+      });
+      // Verify-and-repair swaps a revised answer under the same message id
+      // (backend spawn_answer_verify) — apply only when the message is in
+      // this window's transcript.
+      void listen<{ id: string; content: string }>("chat://revised", (e) => {
+        const { messages } = get();
+        if (!messages.some((m) => m.id === e.payload.id)) return;
+        set({
+          messages: messages.map((m) =>
+            m.id === e.payload.id ? { ...m, content: e.payload.content } : m,
+          ),
+        });
+      });
       // Built-in embedder first-use download progress (one-time ~30 MB).
       void listen<{ label: string; done: number; total: number }>(
         "embedder://progress",
@@ -1055,9 +1081,6 @@ export const useStore = create<AppState>((set, get) => {
         messagesLoadingOlder: false,
         notes: [],
         reportSchedules: [],
-        streamingText: "",
-        steps: [],
-        waiting: "",
         followups: [],
         chatConfig,
         summary: localStorage.getItem(`summary:${id}`) ?? "",
@@ -1742,6 +1765,7 @@ export const useStore = create<AppState>((set, get) => {
       set({
         messages: [...get().messages, optimistic],
         sending: true,
+        sendingFor: id,
         streamingText: "",
         steps: [],
         waiting: "",
@@ -1797,6 +1821,16 @@ export const useStore = create<AppState>((set, get) => {
           });
           playDone();
           void get().loadFollowups();
+        } else {
+          // Finished while the user was elsewhere — the answer is persisted;
+          // the toast is the way back (selectNotebook re-lists on arrival).
+          const title = get().notebooks.find((n) => n.id === id)?.title ?? "notebook";
+          playDone();
+          get().pushToast(
+            "success",
+            `Answer ready in “${title}” — click to open`,
+            () => void get().selectNotebook(id),
+          );
         }
         await get().refreshNotebooks();
       } catch (e) {
@@ -1812,7 +1846,13 @@ export const useStore = create<AppState>((set, get) => {
       } finally {
         // sending/steps are global in-flight flags — always clear them, even if
         // the user switched notebooks while the request ran.
-        set({ sending: false, streamingText: "", steps: [], waiting: "" });
+        set({
+          sending: false,
+          sendingFor: null,
+          streamingText: "",
+          steps: [],
+          waiting: "",
+        });
         void get().refreshModelStats();
       }
     },
@@ -2069,7 +2109,12 @@ export const useStore = create<AppState>((set, get) => {
     generateArtifact: async (kind, prompt) => {
       const id = get().currentId;
       if (!id || get().generatingKind) return;
-      set({ generatingKind: kind, artifactStreamText: "", error: null });
+      set({
+        generatingKind: kind,
+        generatingFor: id,
+        artifactStreamText: "",
+        error: null,
+      });
       try {
         const note = await api.generateArtifact(
           id,
@@ -2083,12 +2128,26 @@ export const useStore = create<AppState>((set, get) => {
         // upserted this note already, and an unfiltered prepend rendered the
         // same note twice (deleting "one" then removed both cards — they were
         // one row shown twice).
-        set({
-          notes: [note, ...get().notes.filter((n) => n.id !== note.id)],
-          justCreatedNoteId: note.id,
-        });
+        // The user may have navigated away while it generated — never write
+        // another notebook's note into the open one. The note is persisted;
+        // the toast is the way back.
+        if (get().currentId === id) {
+          set({
+            notes: [note, ...get().notes.filter((n) => n.id !== note.id)],
+            justCreatedNoteId: note.id,
+          });
+          get().pushToast("success", `${note.title} ready`);
+        } else {
+          get().pushToast(
+            "success",
+            `${note.title} ready — click to open`,
+            () =>
+              void get()
+                .selectNotebook(id)
+                .then(() => set({ justCreatedNoteId: note.id })),
+          );
+        }
         void get().refreshModelStats();
-        get().pushToast("success", `${note.title} ready`);
         playDone();
         void notify("Document ready", `“${note.title}” finished generating.`);
       } catch (e) {
@@ -2100,6 +2159,7 @@ export const useStore = create<AppState>((set, get) => {
       } finally {
         set({
           generatingKind: null,
+          generatingFor: null,
           artifactStreamText: "",
           audioProgress: null,
         });
@@ -2111,6 +2171,7 @@ export const useStore = create<AppState>((set, get) => {
       if (!id || get().generatingKind) return;
       set({
         generatingKind: "template",
+        generatingFor: id,
         generatingTemplateId: t.id,
         artifactStreamText: "",
         error: null,
@@ -2120,12 +2181,23 @@ export const useStore = create<AppState>((set, get) => {
         // The backend titles unknown kinds "Report" — rename to the template's name.
         await api.updateNote(note.id, t.name, note.content);
         const titled = { ...note, title: t.name };
-        set({
-          notes: [titled, ...get().notes.filter((n) => n.id !== note.id)],
-          justCreatedNoteId: note.id,
-        });
+        if (get().currentId === id) {
+          set({
+            notes: [titled, ...get().notes.filter((n) => n.id !== note.id)],
+            justCreatedNoteId: note.id,
+          });
+          get().pushToast("success", `${t.name} ready`);
+        } else {
+          get().pushToast(
+            "success",
+            `${t.name} ready — click to open`,
+            () =>
+              void get()
+                .selectNotebook(id)
+                .then(() => set({ justCreatedNoteId: note.id })),
+          );
+        }
         void get().refreshModelStats();
-        get().pushToast("success", `${t.name} ready`);
         playDone();
         void notify("Document ready", `“${t.name}” finished generating.`);
       } catch (e) {
@@ -2136,6 +2208,7 @@ export const useStore = create<AppState>((set, get) => {
       } finally {
         set({
           generatingKind: null,
+          generatingFor: null,
           generatingTemplateId: null,
           artifactStreamText: "",
           audioProgress: null,

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -5,7 +5,7 @@ import {
   getCurrentWebviewWindow,
   WebviewWindow,
 } from "@tauri-apps/api/webviewWindow";
-import { open, save } from "@tauri-apps/plugin-dialog";
+import { ask, open, save } from "@tauri-apps/plugin-dialog";
 import { api } from "./api";
 import { isWebUrl, SUPPORTED_EXTENSIONS, visibleTitle } from "./utils";
 import { applyTheme, SYSTEM_THEME, themeIsDark } from "./themes";
@@ -409,6 +409,7 @@ export const useStore = create<AppState>((set, get) => {
     failedInput: null,
     pendingInput: null,
     pendingAsk: null,
+    findBump: 0,
     importOkfOpen: false,
     pendingImportPath: null,
     error: null,
@@ -805,6 +806,85 @@ export const useStore = create<AppState>((set, get) => {
           set({ importOkfOpen: true });
         else if (e.payload.id === "menu-back") s.navBack();
         else if (e.payload.id === "menu-forward") s.navForward();
+        else if (e.payload.id === "menu-new-notebook") {
+          // Same auto-title the palette's New Notebook uses.
+          const taken = new Set(get().notebooks.map((n) => n.title));
+          let title = "Untitled notebook";
+          for (let i = 2; taken.has(title); i++) title = `Untitled notebook ${i}`;
+          void s.createNotebook(title);
+        } else if (e.payload.id === "menu-new-note") {
+          if (!get().currentId) {
+            s.pushToast("info", "Open a notebook first, then add a note");
+            return;
+          }
+          // Open the panel; StudioPanel opens the composer when it mounts.
+          set({ pendingNewNote: true });
+          if (!get().studioOpen) s.toggleStudio();
+        } else if (e.payload.id === "menu-add-files") {
+          if (get().currentId) s.openAddSource();
+          else s.pushToast("info", "Open a notebook first, then add sources");
+        } else if (e.payload.id === "menu-find") {
+          set({ findBump: get().findBump + 1 });
+        } else if (e.payload.id === "menu-toggle-sources") {
+          if (get().currentId) s.toggleSources();
+        } else if (e.payload.id === "menu-toggle-studio") {
+          if (get().currentId) s.toggleStudio();
+        } else if (e.payload.id === "menu-toggle-gallery") {
+          if (get().currentId)
+            set({ galleryOpen: !get().galleryOpen, ledgerOpen: false });
+          else s.pushToast("info", "Open a notebook to browse its gallery");
+        } else if (e.payload.id === "menu-toggle-ledger") {
+          if (get().currentId)
+            set({ ledgerOpen: !get().ledgerOpen, galleryOpen: false });
+          else s.pushToast("info", "Open a notebook to read its ledger");
+        } else if (e.payload.id === "menu-toggle-glass") {
+          s.setReading({ glass: !get().reading.glass });
+        } else if (e.payload.id.startsWith("theme:")) {
+          s.setTheme(e.payload.id.slice("theme:".length));
+        } else if (e.payload.id.startsWith("generate:")) {
+          if (get().currentId)
+            void s.generateArtifact(
+              e.payload.id.slice("generate:".length) as Note["kind"],
+            );
+          else s.pushToast("info", "Open a notebook first, then generate");
+        } else if (e.payload.id === "menu-export-note") {
+          const r = get().reader;
+          const doc = r.open ? r.history[r.index] : undefined;
+          const note =
+            doc?.type === "note"
+              ? get().notes.find((n) => n.id === doc.id)
+              : undefined;
+          if (!note) {
+            s.pushToast("info", "Open a note in the reader to export it");
+            return;
+          }
+          void (async () => {
+            const { exportNote, exportTargets } = await import("./noteExport");
+            await exportNote(note, exportTargets(note)[0]);
+          })();
+        } else if (e.payload.id === "menu-archive-notebook") {
+          const id = get().currentId;
+          if (!id) {
+            s.pushToast("info", "Open a notebook to archive it");
+            return;
+          }
+          void s.setNotebookStatus(id, "archived").then(() => s.closeNotebook());
+        } else if (e.payload.id === "menu-delete-notebook") {
+          const id = get().currentId;
+          const nb = get().notebooks.find((n) => n.id === id);
+          if (!id || !nb) {
+            s.pushToast("info", "Open a notebook to delete it");
+            return;
+          }
+          // Native confirm: this is the one delete no toast can undo, and
+          // the menu has no in-app dialog host.
+          void ask(
+            `This permanently deletes "${nb.title}" and all of its sources.`,
+            { title: `Delete "${nb.title}"?`, kind: "warning" },
+          ).then((ok) => {
+            if (ok) void s.deleteNotebook(id);
+          });
+        }
       });
       void listen<{ target: string; id: string }>(
         "menu://open-notebook",

--- a/src/lib/storeTypes.ts
+++ b/src/lib/storeTypes.ts
@@ -125,6 +125,10 @@ export interface AppState {
   reading: ReadingPrefs;
 
   sending: boolean;
+  /** Notebook the in-flight send belongs to. Streams keep running when the
+   *  user navigates away — this is what stops their tokens painting into
+   *  whichever notebook is open instead. */
+  sendingFor: string | null;
   streamingText: string;
   steps: string[];
   /** The live "still waiting" line, if the backend is counting down toward a
@@ -137,6 +141,8 @@ export interface AppState {
   summary: string;
   summaryLoading: boolean;
   generatingKind: NoteKind | null;
+  /** Notebook the in-flight generation belongs to (see sendingFor). */
+  generatingFor: string | null;
   generatingTemplateId: string | null;
   ingestQueue: QueueItem[];
   migration: Migration | null;

--- a/src/lib/storeTypes.ts
+++ b/src/lib/storeTypes.ts
@@ -251,6 +251,9 @@ export interface AppState {
 
   /** Omit the id to export the currently open notebook (palette/menu). */
   exportNotebookOkf: (notebookId?: string) => Promise<void>;
+  /** Bumped by Edit > Find; whichever find-capable surface is mounted
+   *  (reader, gallery, home) opens its find bar. */
+  findBump: number;
   importOkfOpen: boolean;
   pendingImportPath: string | null;
   importOkf: (path: string, notebookId?: string | null) => Promise<void>;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -362,6 +362,9 @@ export interface ModelStat {
   lastTokensPerSec: number;
   avgTokensPerSec: number;
   samples: number;
+  /** How many chats contributed a TTFT measurement (its own count —
+   *  throughput and TTFT are recorded separately). */
+  ttftSamples: number;
   /** Chat time-to-first-token, wall-clock ms (0 = never measured). */
   lastTtftMs: number;
   avgTtftMs: number;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -362,6 +362,9 @@ export interface ModelStat {
   lastTokensPerSec: number;
   avgTokensPerSec: number;
   samples: number;
+  /** Chat time-to-first-token, wall-clock ms (0 = never measured). */
+  lastTtftMs: number;
+  avgTtftMs: number;
 }
 
 export interface ReportSchedule {


### PR DESCRIPTION
Continues the Reminders backlog (follow-on to #8), plus fixes found while hand-testing.

## P1 — Make the menu bar the app's command index
One command registry (`menu.rs::CMD`) drives both the native menu and Settings → Shortcuts (`list_shortcuts`) — the hand-maintained parallel lists were how five registered shortcuts went missing from the menu. New surface: File > New Notebook / New Note / Add Files…, Edit > Find, View > Sources ⌘1 / Studio ⌘2 / Gallery / Ledger / Theme / Liquid Glass, Notebook > Generate / Export Note… / Archive / Delete…. Theme and Generate render TypeScript-owned lists pushed over IPC (`fill_menu_lists`, mutated in place like Open Recent, since the menu is built once).

Field-sensitive keys (⌘N, ⌘F, ⌘←→) deliberately carry no native accelerator — menu key equivalents win over focused text fields, so the frontend's `shortcutBlocked`-guarded handlers keep them. Edit > Find routes through a `findBump` signal answered by whichever find surface is mounted. ⌥Space is finally documented in-app.

## Chat and generation survive navigation
`sendingFor` / `generatingFor` scope live paint to the owning notebook — tokens no longer bleed into whichever notebook is open, and a finished artifact no longer lands in the wrong note list. Token/step listeners moved to `bindGlobalListeners` so the buffer accumulates while the user is on Home; returning mid-stream shows the whole partial answer. Completions elsewhere raise a click-to-open toast.

## Time to first token, on every answering surface
The first cut only covered `send_message` — but with deep research on, chat routes to `send_message_agentic`, so nothing was ever recorded. A shared `TtftClock` plus `AppState::record_ttft` now covers:

| path | surface |
|---|---|
| `send_message` | direct chat — keeps its embed/retrieval phase split |
| `send_message_agentic` → `agent::run` | deep research (clock threaded into the loop) |
| `ask_everything` | the ⌘K meta answer |
| `acp_prompt` → session updates | the hosted-agent pane |

The agent pane stops on the turn's first `agent_message_chunk`: thoughts and tool calls stream earlier, but "first answer token" is what the chat surfaces measure, so agents rank on the same basis. Each sample also writes a `chat-timing` trace line naming the path.

**Metrics identity** carries what actually moves latency: `chat_metrics_key` appends the model an agent CLI routes to and the configured reasoning effort, so `Codex · high` and `Codex · minimal` rank separately instead of pooling into one meaningless average. Transcript captions stay plain.

**Settings → Activity** gains a fastest-models ranking: numbered positions, quickest first, wait-time bars scaled to the slowest entry, and a run count per row (`ttftSamples`) so a model measured once can't silently outrank one measured fifty times. It explains itself when empty rather than vanishing.

## Fixes found while testing
- **Health banner followed Ollama regardless of provider** — "Chat model: Ollama not reachable" showed while chat answered happily on Apple FM, a gateway key, or an agent CLI. `check_models` now resolves the active chat provider entry and takes its own readiness probe.
- **Onboarding predated today's providers** — offered only Ollama vs OpenAI-compatible, and asserted states that weren't true (a red ✗ beside "Ollama is running"). Now three doors (Apple Intelligence / Ollama / OpenAI-compatible) plus a pointer to Settings → Models for signed-in subscriptions; unchecked steps read as goals; the Ollama step only appears when something actually needs Ollama.
- **opencode failed as "agent produced no output"** — it reports provider failures as a JSON event on stdout and exits with no text, and the parser's catch-all swallowed `type: "error"`. The real message was on the pipe all along: `Payment Required: You have exceeded your monthly quota`. Error events now surface, with the readable sentence dug out of the nested body. Unit-tested against the real 402 payload.

## Gates
`cargo fmt` ✓ · `clippy -D warnings` ✓ · `cargo test` 347 passed ✓ · `pnpm build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)