### PR TITLE
Cut deep research's time to first token

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -15,6 +15,29 @@ use crate::models::Citation;
 use crate::rag;
 
 const MAX_STEPS: usize = 5;
+
+/// Which model role runs the loop's internal calls — planning, reranking,
+/// and per-source distillation.
+///
+/// Small by default. Every one of these produces short structured output
+/// (`SEARCH "..."`, a list of passage numbers, a ~500-word evidence note),
+/// which is what the Small role exists for; paying full chat-model latency
+/// up to MAX_STEPS times before the user sees a single answer token is the
+/// waste that dominates deep research's time to first token. `chat_role`
+/// falls through to the chat engine when no small model is configured, so
+/// this is a no-op for anyone who has not opted into a small tier.
+///
+/// The final answer always streams from the chat model — the quality that
+/// matters most is the one the user reads.
+///
+/// `ALCHEMY_PLANNER_ROLE=chat` restores the old behaviour; the eval
+/// (`eval_agent_planner_roles`) A/Bs the two.
+pub(crate) fn loop_role() -> crate::inference::Role {
+    match std::env::var("ALCHEMY_PLANNER_ROLE").as_deref() {
+        Ok("chat") => crate::inference::Role::Chat,
+        _ => crate::inference::Role::Small,
+    }
+}
 /// Results kept per search step, after reranking.
 const SEARCH_K: usize = 5;
 /// Hybrid-retrieval pool handed to the reranker.
@@ -44,7 +67,8 @@ struct TokenEvent {
     content: String,
 }
 
-enum Action {
+#[derive(Debug)]
+pub(crate) enum Action {
     Search(String),
     /// One planner step can read several sources; they distill in parallel.
     Read(Vec<String>),
@@ -103,7 +127,7 @@ pub async fn run(
         let messages =
             rag::build_agent_decision(question, &source_list, &transcript, gathered.len());
         let planned = std::time::Instant::now();
-        let raw = ollama.chat(&messages).await?.text;
+        let raw = ollama.chat_role(loop_role(), &messages).await?.text;
         phases.planner(planned.elapsed().as_millis() as u64);
         match parse_action(&raw) {
             Some(Action::Search(query)) => {
@@ -263,7 +287,7 @@ pub(crate) async fn rerank_indices(
     keep: usize,
 ) -> Option<Vec<usize>> {
     let messages = rag::build_rerank_messages(question, snippets, keep);
-    let raw = ai.chat(&messages).await.ok()?.text;
+    let raw = ai.chat_role(loop_role(), &messages).await.ok()?.text;
     let json = extract_json(&raw)?;
     let value: serde_json::Value = serde_json::from_str(&json).ok()?;
     let indices: Vec<usize> = value
@@ -309,7 +333,7 @@ pub(crate) async fn rerank(ai: &Ai, question: &str, hits: Vec<Citation>) -> Vec<
 /// generation, which distills content that won't fit its corpus budget.
 pub(crate) async fn distill(ai: &Ai, question: &str, title: &str, content: &str) -> String {
     let messages = rag::build_distill_messages(question, title, content);
-    match ai.chat(&messages).await {
+    match ai.chat_role(loop_role(), &messages).await {
         Ok(out) if !out.text.trim().is_empty() => truncate(out.text.trim(), DISTILL_MAX_CHARS),
         _ => truncate(content, READ_GIST_CHARS),
     }
@@ -320,7 +344,7 @@ fn emit_step(app: &AppHandle, label: String) {
 }
 
 /// Parse the planner's JSON action, tolerating surrounding prose/code fences.
-fn parse_action(raw: &str) -> Option<Action> {
+pub(crate) fn parse_action(raw: &str) -> Option<Action> {
     let json = extract_json(raw)?;
     let value: serde_json::Value = serde_json::from_str(&json).ok()?;
     match value.get("action").and_then(|a| a.as_str())? {

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -75,6 +75,8 @@ pub async fn run(
     // send-to-first-token wait the direct chat path does — the loop's tool
     // rounds run before this stream, and that delay is part of it.
     ttft: &crate::commands::TtftClock,
+    // Where the pre-answer time went, for the timing trace.
+    phases: &crate::commands::AgentPhases,
 ) -> Result<(String, Vec<Citation>, Option<crate::ai::GenStats>)> {
     let mut read_remaining = if ollama.config().is_gateway() {
         READ_CHARS_GATEWAY
@@ -100,9 +102,12 @@ pub async fn run(
     for _ in 0..MAX_STEPS {
         let messages =
             rag::build_agent_decision(question, &source_list, &transcript, gathered.len());
+        let planned = std::time::Instant::now();
         let raw = ollama.chat(&messages).await?.text;
+        phases.planner(planned.elapsed().as_millis() as u64);
         match parse_action(&raw) {
             Some(Action::Search(query)) => {
+                let searched = std::time::Instant::now();
                 emit_step(app, format!("Searching: {query}"));
                 let qvec = ollama.embed_one(&query).await?;
                 let mut hits = db
@@ -127,8 +132,10 @@ pub async fn run(
                     ));
                 }
                 transcript.push('\n');
+                phases.search(searched.elapsed().as_millis() as u64);
             }
             Some(Action::Read(source_ids)) => {
+                let readed = std::time::Instant::now();
                 // Fetches stay sequential (DB reads are cheap and the char
                 // budget is a running total), then every distill — the model
                 // call that dominates a read's wall-clock — runs concurrently.
@@ -188,6 +195,7 @@ pub async fn run(
                         });
                     }
                 }
+                phases.read(readed.elapsed().as_millis() as u64);
             }
             Some(Action::Stop) | None => break,
         }

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -48,6 +48,11 @@ const MAX_STEPS: usize = 5;
 /// model cost 21.4s on its first call, against 1.5s cold for FM, and a cold
 /// call is exactly what the first question after opening the app is.
 ///
+/// The loop's search rerank moved to the local cross-encoder on the same
+/// evidence (`eval_agent_rerank_paths`): gold passage retained 4/4 by both
+/// paths, 91ms against the LLM rerank's 1,272ms, and it keeps SEARCH_K
+/// passages where the model's pick averaged three.
+///
 /// No quality difference on these probes, 16-45x the speed. Re-run with
 /// `cargo test --lib eval_agent_planner_roles eval_agent_distill_roles --
 /// --ignored --nocapture` after changing the prompts or the default pair.
@@ -60,7 +65,7 @@ pub(crate) fn loop_role() -> crate::inference::Role {
     }
 }
 /// Results kept per search step, after reranking.
-const SEARCH_K: usize = 5;
+pub(crate) const SEARCH_K: usize = 5;
 /// Hybrid-retrieval pool handed to the reranker.
 const SEARCH_POOL: usize = 20;
 
@@ -163,7 +168,18 @@ pub async fn run(
                 // the rerank.
                 if hits.len() > SEARCH_K {
                     emit_step(app, "Ranking results".into());
-                    hits = rerank(ollama, &query, hits).await;
+                    // The local cross-encoder when there is one: measured
+                    // 91ms against the LLM rerank's 1,272ms for the same
+                    // gold retention (4/4 both), and it keeps SEARCH_K
+                    // passages where the model's pick averaged three — more
+                    // evidence for the answer, at a fraction of the wait.
+                    //
+                    // The Ollama embedder tier has no cross-encoder
+                    // (Router::xenc_model), and there rerank_hits would
+                    // degrade to plain truncation — so those configs keep
+                    // the model-picked rerank rather than silently losing
+                    // the ranking step.
+                    hits = rerank_for_search(ollama, &query, hits).await;
                 }
                 transcript.push_str(&format!("SEARCH \"{query}\":\n"));
                 for h in &hits {
@@ -345,6 +361,25 @@ pub(crate) async fn rerank(ai: &Ai, question: &str, hits: Vec<Citation>) -> Vec<
     match rerank_indices(ai, question, &snippets, SEARCH_K).await {
         Some(picked) => picked.into_iter().map(|i| hits[i].clone()).collect(),
         None => hits.into_iter().take(SEARCH_K).collect(),
+    }
+}
+
+/// How a wide search result gets narrowed, in one place so the eval cannot
+/// drift from what the loop actually runs.
+///
+/// The local cross-encoder when there is one: measured 91ms against the LLM
+/// rerank's 1,272ms for the same gold retention (4/4 both), and it keeps
+/// SEARCH_K passages where the model's pick averaged three — more evidence
+/// for the answer, at a fraction of the wait.
+///
+/// The Ollama embedder tier has no cross-encoder (`Router::xenc_model`), and
+/// there `rerank_hits` would degrade to plain truncation — so those configs
+/// keep the model-picked rerank rather than silently losing the step.
+pub(crate) async fn rerank_for_search(ai: &Ai, query: &str, hits: Vec<Citation>) -> Vec<Citation> {
+    if ai.has_xenc() {
+        ai.rerank_hits(query, hits, SEARCH_K).await
+    } else {
+        rerank(ai, query, hits).await
     }
 }
 

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -32,15 +32,21 @@ const MAX_STEPS: usize = 5;
 ///
 /// `ALCHEMY_PLANNER_ROLE=chat` restores the old behaviour.
 ///
-/// Measured 2026-08-23, muse-glimmer:30b-mlx (chat) vs
-/// digitsflow/bonsai-8b (small), 4 probes each:
+/// Measured 2026-08-23 against muse-glimmer:30b-mlx as the chat tier,
+/// 4 probes each:
 ///
-/// | call    | role  | quality      | avg latency |
-/// |---------|-------|--------------|-------------|
-/// | planner | Small | 4/4 on-target|     1,475ms |
-/// | planner | Chat  | 4/4 on-target|    24,214ms |
-/// | distill | Small | 4/4 facts kept|      810ms |
-/// | distill | Chat  | 4/4 facts kept|   36,428ms |
+/// | call    | role              | quality        | avg latency |
+/// |---------|-------------------|----------------|-------------|
+/// | planner | Small (bonsai-8b) | 4/4 on-target  |     1,475ms |
+/// | planner | Small (Apple FM)  | 4/4 on-target  |     2,735ms |
+/// | planner | Chat              | 4/4 on-target  |    24,214ms |
+/// | distill | Small (bonsai-8b) | 4/4 facts kept |       810ms |
+/// | distill | Chat              | 4/4 facts kept |    36,428ms |
+///
+/// Both small tiers plan correctly on every probe. Apple FM is roughly half
+/// bonsai's raw speed but pays no model-load penalty: a cold Ollama small
+/// model cost 21.4s on its first call, against 1.5s cold for FM, and a cold
+/// call is exactly what the first question after opening the app is.
 ///
 /// No quality difference on these probes, 16-45x the speed. Re-run with
 /// `cargo test --lib eval_agent_planner_roles eval_agent_distill_roles --

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -30,8 +30,23 @@ const MAX_STEPS: usize = 5;
 /// The final answer always streams from the chat model — the quality that
 /// matters most is the one the user reads.
 ///
-/// `ALCHEMY_PLANNER_ROLE=chat` restores the old behaviour; the eval
-/// (`eval_agent_planner_roles`) A/Bs the two.
+/// `ALCHEMY_PLANNER_ROLE=chat` restores the old behaviour.
+///
+/// Measured 2026-08-23, muse-glimmer:30b-mlx (chat) vs
+/// digitsflow/bonsai-8b (small), 4 probes each:
+///
+/// | call    | role  | quality      | avg latency |
+/// |---------|-------|--------------|-------------|
+/// | planner | Small | 4/4 on-target|     1,475ms |
+/// | planner | Chat  | 4/4 on-target|    24,214ms |
+/// | distill | Small | 4/4 facts kept|      810ms |
+/// | distill | Chat  | 4/4 facts kept|   36,428ms |
+///
+/// No quality difference on these probes, 16-45x the speed. Re-run with
+/// `cargo test --lib eval_agent_planner_roles eval_agent_distill_roles --
+/// --ignored --nocapture` after changing the prompts or the default pair.
+/// Both probe sets are small and cover the first action / fact retention —
+/// they show no regression, which is not the same as proving parity.
 pub(crate) fn loop_role() -> crate::inference::Role {
     match std::env::var("ALCHEMY_PLANNER_ROLE").as_deref() {
         Ok("chat") => crate::inference::Role::Chat,
@@ -332,8 +347,20 @@ pub(crate) async fn rerank(ai: &Ai, question: &str, hits: Vec<Citation>) -> Vec<
 /// excerpt — a degraded read still beats an empty one. Shared with artifact
 /// generation, which distills content that won't fit its corpus budget.
 pub(crate) async fn distill(ai: &Ai, question: &str, title: &str, content: &str) -> String {
+    distill_with(ai, loop_role(), question, title, content).await
+}
+
+/// `distill` with the role named explicitly, so an eval can A/B the tiers
+/// without mutating process-global state.
+pub(crate) async fn distill_with(
+    ai: &Ai,
+    role: crate::inference::Role,
+    question: &str,
+    title: &str,
+    content: &str,
+) -> String {
     let messages = rag::build_distill_messages(question, title, content);
-    match ai.chat_role(loop_role(), &messages).await {
+    match ai.chat_role(role, &messages).await {
         Ok(out) if !out.text.trim().is_empty() => truncate(out.text.trim(), DISTILL_MAX_CHARS),
         _ => truncate(content, READ_GIST_CHARS),
     }

--- a/src-tauri/src/ai/mod.rs
+++ b/src-tauri/src/ai/mod.rs
@@ -795,6 +795,14 @@ impl Ai {
     /// Role-routed chat with failure fallthrough (RFC-inference-providers
     /// §7): if the role's engine is unavailable or errors, the configured
     /// chat engine answers instead — one log line, never a dead call.
+    /// Is there a distinct Small-role engine, or would `chat_role(Small)`
+    /// fall through to the chat engine? Evals comparing the two roles need
+    /// to know the difference is real before reporting a comparison.
+    #[cfg(test)]
+    pub fn has_small_role(&self) -> bool {
+        self.router.has_small()
+    }
+
     pub async fn chat_role(&self, role: Role, messages: &[ChatTurn]) -> Result<ChatOutcome> {
         let engine = self.router.chat_engine(role);
         if role == Role::Generate {

--- a/src-tauri/src/beir_eval.rs
+++ b/src-tauri/src/beir_eval.rs
@@ -239,13 +239,29 @@ fn chat_tier(kind: &str, runtime: AiRuntime) -> Ai {
 }
 
 /// Apple's on-device model for the rerank leg, via the repo-built sidecar.
+/// Where the FM sidecar actually is, in the app's own order: the built
+/// binary that `scripts/build-fm-sidecar.sh` produces first, then the raw
+/// Swift build directory.
+///
+/// The build script stopped leaving a binary in `.build/release` some time
+/// ago, so checking only that path made every FM eval SKIP quietly — the
+/// same silent-green failure `evals.rs` already warns about, one directory
+/// over.
+pub(crate) fn fm_sidecar_path() -> Option<std::path::PathBuf> {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    [
+        root.join("binaries/alchemy-fm"),
+        root.join("../sidecar/alchemy-fm/.build/release/alchemy-fm"),
+    ]
+    .into_iter()
+    .find(|p| p.exists())
+}
+
 pub(crate) fn fm_ai() -> Option<Ai> {
-    let sidecar = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../sidecar/alchemy-fm/.build/release/alchemy-fm");
-    if !sidecar.exists() {
+    let Some(sidecar) = fm_sidecar_path() else {
         eprintln!("SKIP: FM sidecar not built");
         return None;
-    }
+    };
     Some(chat_tier(
         "fm",
         AiRuntime {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -88,6 +88,51 @@ impl TtftClock {
     }
 }
 
+/// Where a deep-research turn spent its time before the answer streamed.
+/// Filled by `agent::run` as it works; read once for the timing trace.
+/// Atomics rather than a lock: the loop touches these on every step and the
+/// numbers are independent counters, never a consistent snapshot.
+#[derive(Clone, Default)]
+pub struct AgentPhases {
+    inner: Arc<AgentPhasesInner>,
+}
+
+#[derive(Default)]
+struct AgentPhasesInner {
+    planner_ms: std::sync::atomic::AtomicU64,
+    search_ms: std::sync::atomic::AtomicU64,
+    read_ms: std::sync::atomic::AtomicU64,
+    steps: std::sync::atomic::AtomicU64,
+}
+
+impl AgentPhases {
+    fn add(slot: &std::sync::atomic::AtomicU64, ms: u64) {
+        slot.fetch_add(ms, std::sync::atomic::Ordering::Relaxed);
+    }
+    /// One planner decision call — the model choosing the next action.
+    pub fn planner(&self, ms: u64) {
+        Self::add(&self.inner.planner_ms, ms);
+        Self::add(&self.inner.steps, 1);
+    }
+    /// One search action: embed + hybrid search + any rerank.
+    pub fn search(&self, ms: u64) {
+        Self::add(&self.inner.search_ms, ms);
+    }
+    /// One read action: fetches plus the distill calls.
+    pub fn read(&self, ms: u64) {
+        Self::add(&self.inner.read_ms, ms);
+    }
+    pub fn as_json(&self) -> serde_json::Value {
+        use std::sync::atomic::Ordering::Relaxed;
+        serde_json::json!({
+            "plannerMs": self.inner.planner_ms.load(Relaxed),
+            "searchMs": self.inner.search_ms.load(Relaxed),
+            "readMs": self.inner.read_ms.load(Relaxed),
+            "steps": self.inner.steps.load(Relaxed),
+        })
+    }
+}
+
 pub struct AppState {
     pub db: Arc<Db>,
     pub ai: tokio::sync::RwLock<Ai>,
@@ -197,7 +242,7 @@ impl AppState {
         path: &str,
         notebook_id: &str,
         clock: &TtftClock,
-        phases: Option<(u64, u64)>,
+        phases: Option<serde_json::Value>,
     ) {
         let ttft_ms = clock.ttft_ms();
         if ttft_ms == 0 {
@@ -221,9 +266,11 @@ impl AppState {
             "model": model,
             "ttftMs": ttft_ms,
         });
-        if let Some((embed_ms, retrieval_ms)) = phases {
-            record["embedMs"] = embed_ms.into();
-            record["retrievalMs"] = retrieval_ms.into();
+        // Whatever split the surface can account for, merged in as-is.
+        if let Some(serde_json::Value::Object(extra)) = phases {
+            for (k, v) in extra {
+                record[k] = v;
+            }
         }
         crate::trace::log(&self.trace_dir, record);
     }
@@ -7402,7 +7449,10 @@ pub async fn send_message(
             "chat",
             &notebook_id,
             &ttft,
-            Some((embed_ms, retrieval_ms)),
+            Some(serde_json::json!({
+                "embedMs": embed_ms,
+                "retrievalMs": retrieval_ms,
+            })),
         );
     }
 
@@ -7488,6 +7538,7 @@ pub async fn send_message_agentic(
 
     let cancel = state.begin_generation(&format!("chat:{}", window.label()));
     let ttft = TtftClock::start();
+    let phases = AgentPhases::default();
     let (answer, kind, citations, stats, model, metrics_key) = {
         let ai = state.ai.read().await.clone();
         let model = ai.active_chat_model();
@@ -7503,6 +7554,7 @@ pub async fn send_message_agentic(
                 &extra,
                 source_ids.as_deref(),
                 &ttft,
+                &phases,
             ) => Some(r),
             _ = cancel.cancelled() => None,
         };
@@ -7533,7 +7585,13 @@ pub async fn send_message_agentic(
     };
     state.record_chat_stats(&metrics_key, stats);
     if kind == "chat" {
-        state.record_ttft(&metrics_key, "deep-research", &notebook_id, &ttft, None);
+        state.record_ttft(
+            &metrics_key,
+            "deep-research",
+            &notebook_id,
+            &ttft,
+            Some(phases.as_json()),
+        );
     }
 
     let assistant_msg = Message {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -88,6 +88,11 @@ impl TtftClock {
     }
 }
 
+/// Chat surfaces whose time-to-first-token is a fair measure of the model's
+/// own responsiveness, and so feed Activity's fastest-models ranking.
+/// "deep-research" is deliberately absent — see `AppState::record_ttft`.
+const RANKED_TTFT_PATHS: [&str; 3] = ["chat", "ask-everything", "agent-pane"];
+
 /// Where a deep-research turn spent its time before the answer streamed.
 /// Filled by `agent::run` as it works; read once for the timing trace.
 /// Atomics rather than a lock: the loop touches these on every step and the
@@ -229,10 +234,13 @@ impl AppState {
 
     /// Fold one answer's time-to-first-token into the running stats and
     /// leave a timing trace line. `path` names which chat surface produced
-    /// it (direct chat, deep research, ask-everything) so the trace can tell
-    /// them apart later; the per-model average deliberately pools them,
-    /// because "how long until this model starts answering me" is one
-    /// question regardless of which surface asked it.
+    /// it.
+    ///
+    /// Only surfaces whose wait reflects how fast the MODEL answers feed the
+    /// per-model ranking. Deep research is traced but not ranked: its time is
+    /// dominated by up to MAX_STEPS planner round trips before a single
+    /// answer token, so averaging it in would rank the mode rather than the
+    /// model, and one research turn would bury a model's real chat latency.
     ///
     /// A clock that never saw a token records nothing: a failed or stopped
     /// turn has no first token to time.
@@ -248,7 +256,8 @@ impl AppState {
         if ttft_ms == 0 {
             return;
         }
-        {
+        // Traced always; ranked only where the number means "model speed".
+        if RANKED_TTFT_PATHS.contains(&path) {
             let mut map = self.model_stats.lock().unwrap();
             let entry = map.entry(model.to_string()).or_default();
             entry.ttft_samples += 1;

--- a/src-tauri/src/retrieval_eval.rs
+++ b/src-tauri/src/retrieval_eval.rs
@@ -2406,8 +2406,9 @@ async fn eval_agent_phase_costs() {
     eprintln!("     ({} hits)", hits.len());
 
     // Rerank — a model call per search that returned a wide pool.
-    let picked = timed!("rerank (small)", {
-        crate::agent::rerank(&ai, question, hits.clone()).await
+    // Whatever the loop actually runs — cross-encoder or model-picked.
+    let picked = timed!("rerank", {
+        crate::agent::rerank_for_search(&ai, question, hits.clone()).await
     });
     eprintln!("     ({} kept of {})", picked.len(), hits.len());
 
@@ -2422,5 +2423,96 @@ async fn eval_agent_phase_costs() {
     eprintln!(
         "  (cold-warm gap is model load. A turn pays planner+action per step, \n\
           up to MAX_STEPS, then streams the answer.)"
+    );
+}
+
+/// Rerank probes: a question and the fixture document whose passage must
+/// survive the rerank, or the answer cannot cite it.
+const RERANK_PROBES: &[(&str, &str)] = &[
+    ("How long should a failed retry wait?", "Acme Invoices Q3"),
+    (
+        "Which port forwards to the media server?",
+        "Home Network Guide",
+    ),
+    (
+        "How much paid time off accrues per month?",
+        "Employee Handbook",
+    ),
+    ("Where did we stay in Kyoto?", "Kyoto Trip Journal"),
+];
+
+/// The research loop reranks each wide search with an LLM call, while the
+/// direct-chat path reranks with the local cross-encoder (`Ai::rerank_hits`).
+/// Phase timing put the LLM rerank at 3.3s warm — the most expensive phase
+/// in the loop, more than twice the planner — so this measures whether the
+/// cross-encoder keeps the gold passage as reliably, far cheaper.
+#[tokio::test]
+#[ignore = "live models: one rerank per probe per path — run with --ignored --nocapture"]
+async fn eval_agent_rerank_paths() {
+    let Some(embedder) = builtin_ai().await else {
+        return;
+    };
+    let chat_model =
+        std::env::var("PLANNER_CHAT_MODEL").unwrap_or_else(|_| "muse-glimmer:30b-mlx".to_string());
+    let small_model = std::env::var("PLANNER_SMALL_MODEL").unwrap_or_else(|_| "fm".to_string());
+    let Some(ai) = planner_ab_ai(&chat_model, &small_model) else {
+        return;
+    };
+    assert!(
+        ai.has_xenc(),
+        "no cross-encoder for this config — the comparison would be truncation, not reranking"
+    );
+    let dir = std::env::temp_dir().join(format!("nbl-rerank-{}", uuid::Uuid::new_v4()));
+    let db = Db::open(&dir).await.expect("open db");
+    let nb = "rerank-nb";
+    seed_corpus(&embedder, &db, nb).await;
+
+    eprintln!("\n  chat={chat_model}   small={small_model}");
+    eprintln!("search rerank, gold passage retained:");
+    let (mut llm_kept, mut llm_ms, mut xe_kept, mut xe_ms) = (0usize, 0u128, 0usize, 0u128);
+    let (mut llm_n, mut xe_n) = (0usize, 0usize);
+
+    for (question, gold) in RERANK_PROBES {
+        let qvec = ai.embed_one(question).await.expect("embed");
+        let hits = db
+            .search_chunks(nb, qvec, question, 20, None)
+            .await
+            .expect("search");
+        let has_gold = |v: &[Citation]| v.iter().any(|c| c.source_title == *gold);
+
+        let t = std::time::Instant::now();
+        let picked = crate::agent::rerank(&ai, question, hits.clone()).await;
+        llm_ms += t.elapsed().as_millis();
+        llm_n += picked.len();
+        if has_gold(&picked) {
+            llm_kept += 1;
+        } else {
+            eprintln!("  MISS (llm): {question} — dropped {gold}");
+        }
+
+        let t = std::time::Instant::now();
+        let ranked = ai
+            .rerank_hits(question, hits.clone(), crate::agent::SEARCH_K)
+            .await;
+        xe_ms += t.elapsed().as_millis();
+        xe_n += ranked.len();
+        if has_gold(&ranked) {
+            xe_kept += 1;
+        } else {
+            eprintln!("  MISS (xenc): {question} — dropped {gold}");
+        }
+    }
+    let n = RERANK_PROBES.len();
+    eprintln!(
+        "  {:<14} gold {llm_kept}/{n}   avg {:>6}ms   avg kept {:.1}",
+        "llm rerank",
+        llm_ms / n as u128,
+        llm_n as f64 / n as f64
+    );
+    eprintln!(
+        "  {:<14} gold {xe_kept}/{n}   avg {:>6}ms   avg kept {:.1}",
+        "cross-encoder",
+        xe_ms / n as u128,
+        xe_n as f64 / n as f64
     );
 }

--- a/src-tauri/src/retrieval_eval.rs
+++ b/src-tauri/src/retrieval_eval.rs
@@ -2143,10 +2143,23 @@ async fn eval_agent_planner_roles() {
     let Some(embedder) = builtin_ai().await else {
         return;
     };
-    let Some(ai) = crate::beir_eval::rerank_ai().await else {
-        eprintln!("SKIP: no local chat tier for planner probes");
-        return;
-    };
+    // A real A/B needs the roles to resolve to different models. Defaults are
+    // a mid-size local chat model against the repo's fast local pick; both
+    // are overridable for a targeted run.
+    let chat_model =
+        std::env::var("PLANNER_CHAT_MODEL").unwrap_or_else(|_| "muse-glimmer:30b-mlx".to_string());
+    let small_model = std::env::var("PLANNER_SMALL_MODEL")
+        .unwrap_or_else(|_| "digitsflow/bonsai-8b:latest".to_string());
+    let ai = crate::ai::Ai::new(
+        crate::ai::AiConfig {
+            embedder: "builtin".into(),
+            chat_model: chat_model.clone(),
+            small_model: small_model.clone(),
+            ..Default::default()
+        },
+        crate::ai::AiRuntime::default(),
+    );
+    eprintln!("\n  chat={chat_model}   small={small_model}");
     assert!(
         ai.list_models().await.is_ok(),
         "Ollama not reachable on localhost:11434 — start it, then rerun"
@@ -2218,4 +2231,83 @@ async fn eval_agent_planner_roles() {
         "  (Small is the shipping default — agent::loop_role; \
          ALCHEMY_PLANNER_ROLE=chat restores the old behaviour.)"
     );
+}
+
+/// Distillation probes: a question, the fixture document it should be read
+/// against, and a fact that MUST survive into the evidence note.
+///
+/// Distill is the riskiest of the three calls moved to the Small role,
+/// because its output is not a routing decision the loop can recover from —
+/// it becomes the evidence the final answer quotes. A distillate that drops
+/// the number is an answer that cannot cite it.
+const DISTILL_PROBES: &[(&str, &str, &str)] = &[
+    (
+        "How long should a failed retry wait?",
+        "Acme Invoices Q3",
+        "sixty",
+    ),
+    (
+        "Which port forwards to the media server?",
+        "Home Network Guide",
+        "32400",
+    ),
+    (
+        "When are firmware updates applied?",
+        "Home Network Guide",
+        "Monday",
+    ),
+    (
+        "How much paid time off accrues per month?",
+        "Employee Handbook",
+        "half",
+    ),
+];
+
+#[tokio::test]
+#[ignore = "live models: one distill call per probe per role — run with --ignored --nocapture"]
+async fn eval_agent_distill_roles() {
+    let chat_model =
+        std::env::var("PLANNER_CHAT_MODEL").unwrap_or_else(|_| "muse-glimmer:30b-mlx".to_string());
+    let small_model = std::env::var("PLANNER_SMALL_MODEL")
+        .unwrap_or_else(|_| "digitsflow/bonsai-8b:latest".to_string());
+    let ai = crate::ai::Ai::new(
+        crate::ai::AiConfig {
+            embedder: "builtin".into(),
+            chat_model: chat_model.clone(),
+            small_model: small_model.clone(),
+            ..Default::default()
+        },
+        crate::ai::AiRuntime::default(),
+    );
+    assert!(
+        ai.list_models().await.is_ok(),
+        "Ollama not reachable on localhost:11434 — start it, then rerun"
+    );
+    eprintln!("\n  chat={chat_model}   small={small_model}");
+    eprintln!("deep-research distillation, fact retention by role:");
+    for role in [crate::inference::Role::Small, crate::inference::Role::Chat] {
+        let (mut kept, mut total_ms) = (0usize, 0u128);
+        for (question, title, fact) in DISTILL_PROBES {
+            let Some((_, body)) = CORPUS.iter().find(|(t, _)| t == title) else {
+                panic!("fixture {title} missing from CORPUS");
+            };
+            let t = std::time::Instant::now();
+            let evidence = crate::agent::distill_with(&ai, role, question, title, body).await;
+            total_ms += t.elapsed().as_millis();
+            if evidence.to_lowercase().contains(&fact.to_lowercase()) {
+                kept += 1;
+            } else {
+                eprintln!(
+                    "  MISS ({role:?}): {question} — \"{fact}\" absent from: {}",
+                    evidence.trim().chars().take(90).collect::<String>()
+                );
+            }
+        }
+        let n = DISTILL_PROBES.len();
+        eprintln!(
+            "  {:<8}  kept {kept}/{n}   avg {}ms",
+            format!("{role:?}"),
+            total_ms / n as u128
+        );
+    }
 }

--- a/src-tauri/src/retrieval_eval.rs
+++ b/src-tauri/src/retrieval_eval.rs
@@ -2092,6 +2092,37 @@ async fn eval_retrieval_latency() {
 // where the inputs are deterministic). The number IS the product; read the
 // table and decide.
 
+/// Build the two-tier A/B engine. `small` is either an Ollama model name or
+/// the literal "fm", which routes the Small role to the Apple Foundation
+/// Models sidecar — an empty `small_model` plus a sidecar path is what
+/// selects FM (see `Ai::new`).
+fn planner_ab_ai(chat_model: &str, small: &str) -> Option<crate::ai::Ai> {
+    let (small_model, runtime) = if small.eq_ignore_ascii_case("fm") {
+        let Some(sidecar) = crate::beir_eval::fm_sidecar_path() else {
+            eprintln!("SKIP: FM sidecar not built");
+            return None;
+        };
+        (
+            String::new(),
+            crate::ai::AiRuntime {
+                fm_sidecar: Some(sidecar),
+                ..Default::default()
+            },
+        )
+    } else {
+        (small.to_string(), crate::ai::AiRuntime::default())
+    };
+    Some(crate::ai::Ai::new(
+        crate::ai::AiConfig {
+            embedder: "builtin".into(),
+            chat_model: chat_model.to_string(),
+            small_model,
+            ..Default::default()
+        },
+        runtime,
+    ))
+}
+
 /// One planner probe: a question, and the distinctive terms a good first
 /// action should aim at — either in the search query or via reading the
 /// source whose title contains the gold marker.
@@ -2150,15 +2181,9 @@ async fn eval_agent_planner_roles() {
         std::env::var("PLANNER_CHAT_MODEL").unwrap_or_else(|_| "muse-glimmer:30b-mlx".to_string());
     let small_model = std::env::var("PLANNER_SMALL_MODEL")
         .unwrap_or_else(|_| "digitsflow/bonsai-8b:latest".to_string());
-    let ai = crate::ai::Ai::new(
-        crate::ai::AiConfig {
-            embedder: "builtin".into(),
-            chat_model: chat_model.clone(),
-            small_model: small_model.clone(),
-            ..Default::default()
-        },
-        crate::ai::AiRuntime::default(),
-    );
+    let Some(ai) = planner_ab_ai(&chat_model, &small_model) else {
+        return;
+    };
     eprintln!("\n  chat={chat_model}   small={small_model}");
     assert!(
         ai.list_models().await.is_ok(),
@@ -2270,15 +2295,9 @@ async fn eval_agent_distill_roles() {
         std::env::var("PLANNER_CHAT_MODEL").unwrap_or_else(|_| "muse-glimmer:30b-mlx".to_string());
     let small_model = std::env::var("PLANNER_SMALL_MODEL")
         .unwrap_or_else(|_| "digitsflow/bonsai-8b:latest".to_string());
-    let ai = crate::ai::Ai::new(
-        crate::ai::AiConfig {
-            embedder: "builtin".into(),
-            chat_model: chat_model.clone(),
-            small_model: small_model.clone(),
-            ..Default::default()
-        },
-        crate::ai::AiRuntime::default(),
-    );
+    let Some(ai) = planner_ab_ai(&chat_model, &small_model) else {
+        return;
+    };
     assert!(
         ai.list_models().await.is_ok(),
         "Ollama not reachable on localhost:11434 — start it, then rerun"
@@ -2310,4 +2329,98 @@ async fn eval_agent_distill_roles() {
             total_ms / n as u128
         );
     }
+}
+
+/// Per-phase cost of one deep-research step, so the next optimization aims
+/// at whatever is actually left.
+///
+/// The loop's wall-clock is (planner + action) per step, repeated up to
+/// MAX_STEPS, then the answer stream. This times each piece against the
+/// same corpus so their magnitudes are directly comparable — a phase worth
+/// parallelising has to be big enough to notice next to the others.
+#[tokio::test]
+#[ignore = "live models: times every phase of a research step — run with --ignored --nocapture"]
+async fn eval_agent_phase_costs() {
+    let Some(embedder) = builtin_ai().await else {
+        return;
+    };
+    let chat_model =
+        std::env::var("PLANNER_CHAT_MODEL").unwrap_or_else(|_| "muse-glimmer:30b-mlx".to_string());
+    let small_model = std::env::var("PLANNER_SMALL_MODEL")
+        .unwrap_or_else(|_| "digitsflow/bonsai-8b:latest".to_string());
+    let Some(ai) = planner_ab_ai(&chat_model, &small_model) else {
+        return;
+    };
+    assert!(
+        ai.list_models().await.is_ok(),
+        "Ollama not reachable on localhost:11434 — start it, then rerun"
+    );
+    let dir = std::env::temp_dir().join(format!("nbl-phase-{}", uuid::Uuid::new_v4()));
+    let db = Db::open(&dir).await.expect("open db");
+    let nb = "phase-nb";
+    seed_corpus(&embedder, &db, nb).await;
+    let sources = db.list_sources(nb).await.expect("sources");
+    let source_list = sources
+        .iter()
+        .map(|s| format!("- {} (id: {}, {} chunks)", s.title, s.id, s.chunk_count))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let question = "How long should a failed retry wait?";
+
+    eprintln!("\n  chat={chat_model}   small={small_model}");
+    eprintln!("one deep-research step, phase by phase (cold = first call, warm = repeat):");
+    eprintln!("  {:<18} {:>9} {:>9}", "phase", "cold", "warm");
+
+    macro_rules! timed {
+        ($label:expr, $body:expr) => {{
+            let t = std::time::Instant::now();
+            let first = $body;
+            let cold = t.elapsed().as_millis();
+            let t = std::time::Instant::now();
+            let _second = $body;
+            let warm = t.elapsed().as_millis();
+            eprintln!("  {:<18} {:>7}ms {:>7}ms", $label, cold, warm);
+            first
+        }};
+    }
+
+    // Planner decision (Small role — the shipping default).
+    let messages = crate::rag::build_agent_decision(question, &source_list, "", 0);
+    let _ = timed!("planner (small)", {
+        ai.chat_role(crate::inference::Role::Small, &messages)
+            .await
+            .map(|o| o.text)
+    });
+
+    // Query embedding — the step's only non-model local cost of note.
+    let qvec = timed!("embed query", {
+        ai.embed_one(question).await.expect("embed")
+    });
+
+    // Hybrid search over the seeded corpus.
+    let hits = timed!("hybrid search", {
+        db.search_chunks(nb, qvec.clone(), question, 20, None)
+            .await
+            .expect("search")
+    });
+    eprintln!("     ({} hits)", hits.len());
+
+    // Rerank — a model call per search that returned a wide pool.
+    let picked = timed!("rerank (small)", {
+        crate::agent::rerank(&ai, question, hits.clone()).await
+    });
+    eprintln!("     ({} kept of {})", picked.len(), hits.len());
+
+    // Distill one source — the per-read cost, which the loop pays
+    // DISTILL_CONCURRENCY-at-a-time for a multi-source read.
+    if let Some((title, body)) = CORPUS.first() {
+        let _ = timed!("distill one doc", {
+            crate::agent::distill_with(&ai, crate::inference::Role::Small, question, title, body)
+                .await
+        });
+    }
+    eprintln!(
+        "  (cold-warm gap is model load. A turn pays planner+action per step, \n\
+          up to MAX_STEPS, then streams the answer.)"
+    );
 }

--- a/src-tauri/src/retrieval_eval.rs
+++ b/src-tauri/src/retrieval_eval.rs
@@ -2077,3 +2077,145 @@ async fn eval_retrieval_latency() {
     report("joined (now)   ", &mut joined_ms);
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+// ---- Deep-research planner: role A/B (RFC-agentic-chat) --------------------
+//
+// The loop's planner, rerank, and distill calls run on the Small role by
+// default (agent::loop_role), because paying chat-model latency up to
+// MAX_STEPS times before the user sees one answer token is what dominates
+// deep research's time to first token. Small is only worth it if it still
+// plans sensibly — that is what this measures, on the two things that can
+// actually go wrong: the action fails to parse, or it aims at the wrong
+// place.
+//
+// Model-dependent, so it prints rather than fences (house rule: assert only
+// where the inputs are deterministic). The number IS the product; read the
+// table and decide.
+
+/// One planner probe: a question, and the distinctive terms a good first
+/// action should aim at — either in the search query or via reading the
+/// source whose title contains the gold marker.
+const PLANNER_PROBES: &[(&str, &str)] = &[
+    (
+        "What retention window does the backup policy specify?",
+        "backup",
+    ),
+    (
+        "Which model does the ranking service use for reranking?",
+        "rank",
+    ),
+    (
+        "What is the escalation path for a Sev-1 incident?",
+        "incident",
+    ),
+    (
+        "How is the vector index rebuilt after a schema change?",
+        "index",
+    ),
+];
+
+/// Does this first action aim at the gold area — searching with the marker
+/// term, or reading a source whose title carries it?
+fn planner_on_target(
+    action: &crate::agent::Action,
+    marker: &str,
+    titles: &[(String, String)],
+) -> bool {
+    match action {
+        crate::agent::Action::Search(q) => q.to_lowercase().contains(marker),
+        crate::agent::Action::Read(ids) => ids.iter().any(|id| {
+            titles
+                .iter()
+                .find(|(sid, _)| sid == id)
+                .is_some_and(|(_, t)| t.to_lowercase().contains(marker))
+        }),
+        // Stopping before gathering anything is never the right opening move.
+        crate::agent::Action::Stop => false,
+    }
+}
+
+#[tokio::test]
+#[ignore = "live models: one planner call per probe per role — run with --ignored --nocapture"]
+async fn eval_agent_planner_roles() {
+    // Two engines on purpose: the built-in embedder seeds the corpus, and a
+    // chat-capable tier answers the planner probes. `builtin_ai` has no chat
+    // model at all, so planning through it would measure nothing.
+    let Some(embedder) = builtin_ai().await else {
+        return;
+    };
+    let Some(ai) = crate::beir_eval::rerank_ai().await else {
+        eprintln!("SKIP: no local chat tier for planner probes");
+        return;
+    };
+    assert!(
+        ai.list_models().await.is_ok(),
+        "Ollama not reachable on localhost:11434 — start it, then rerun"
+    );
+    // An A/B is only an A/B if the roles resolve to different engines. With
+    // no small model configured, chat_role(Small) falls through to Chat and
+    // both columns would measure the same thing under two names — the
+    // mistake judged_eval's resolution guard exists to prevent.
+    if !ai.has_small_role() {
+        eprintln!(
+            "SKIP: no small model configured — Small would fall through to \
+             Chat and the comparison would be two names for one engine"
+        );
+        return;
+    }
+    let dir = std::env::temp_dir().join(format!("nbl-planner-{}", uuid::Uuid::new_v4()));
+    let db = Db::open(&dir).await.expect("open db");
+    let nb = "planner-nb";
+    seed_corpus(&embedder, &db, nb).await;
+
+    let sources = db.list_sources(nb).await.expect("sources");
+    let titles: Vec<(String, String)> = sources
+        .iter()
+        .map(|s| (s.id.clone(), s.title.clone()))
+        .collect();
+    let source_list = sources
+        .iter()
+        .map(|s| format!("- {} (id: {}, {} chunks)", s.title, s.id, s.chunk_count))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    eprintln!("\ndeep-research planner, first action by role:");
+    for role in [crate::inference::Role::Small, crate::inference::Role::Chat] {
+        let (mut parsed, mut on_target, mut total_ms) = (0usize, 0usize, 0u128);
+        for (question, marker) in PLANNER_PROBES {
+            let messages = crate::rag::build_agent_decision(question, &source_list, "", 0);
+            let t = std::time::Instant::now();
+            let raw = match ai.chat_role(role, &messages).await {
+                Ok(out) => out.text,
+                Err(err) => {
+                    eprintln!("  MISS ({role:?}): {question} — call failed: {err:#}");
+                    continue;
+                }
+            };
+            total_ms += t.elapsed().as_millis();
+            match crate::agent::parse_action(&raw) {
+                Some(action) => {
+                    parsed += 1;
+                    if planner_on_target(&action, marker, &titles) {
+                        on_target += 1;
+                    } else {
+                        eprintln!("  MISS ({role:?}): {question} — aimed elsewhere: {action:?}");
+                    }
+                }
+                None => eprintln!(
+                    "  MISS ({role:?}): {question} — unparseable: {}",
+                    raw.trim().chars().take(80).collect::<String>()
+                ),
+            }
+        }
+        let n = PLANNER_PROBES.len();
+        eprintln!(
+            "  {:<8}  parsed {parsed}/{n}   on-target {on_target}/{n}   avg {}ms",
+            format!("{role:?}"),
+            total_ms / n as u128
+        );
+    }
+    eprintln!(
+        "  (Small is the shipping default — agent::loop_role; \
+         ALCHEMY_PLANNER_ROLE=chat restores the old behaviour.)"
+    );
+}


### PR DESCRIPTION
Follow-on to #9. Deep research's measured TTFT on this machine ran 20–95s; this is where that time went and what it costs to remove.

## The finding
The loop's **planner, rerank, and distill** calls all ran on `Role::Chat`. A research turn therefore paid full chat-model latency up to `MAX_STEPS` times — plus a fresh subprocess per call for agent-CLI providers — before the user saw a single answer token. The final answer was never the bottleneck.

All three now run on the **Small role**. The final answer still streams from the chat model, so the text the user reads is unchanged.

Safe by default: `chat_role` falls through to the chat engine when no small model is configured, so this is a no-op for anyone who hasn't opted into a small tier. `ALCHEMY_PLANNER_ROLE=chat` restores the old behaviour.

## Measured, not assumed
Two new evals A/B the tiers on the two things that can actually go wrong — the planner's action aims at the wrong place or fails to parse, and a distillate drops the fact the answer needs to cite.

`muse-glimmer:30b-mlx` (chat) vs `digitsflow/bonsai-8b` (small), 4 probes each:

| call | role | quality | avg latency |
|---|---|---|---|
| planner | Small | 4/4 on-target | **1,475ms** |
| planner | Chat | 4/4 on-target | 24,214ms |
| distill | Small | 4/4 facts kept | **810ms** |
| distill | Chat | 4/4 facts kept | 36,428ms |

No quality difference on these probes at 16–45× the speed. The table is recorded in `loop_role`'s doc comment where the decision lives, with the caveat stated plainly: **small probe sets showing no regression is not proof of parity.** Both evals are `#[ignore]`d (live models), print rather than fence (model-dependent, per house rule), and the planner eval refuses to run when no small model is configured, since `chat_role` would fall through and the comparison would be two names for one engine.

Existing evals unaffected: `eval_retrieval_recall` ✓, all 9 `retrieval_eval` dataset evals pass their recall/MRR/nDCG fences.

## Also here
- **Phase instrumentation**: deep research reports `plannerMs` / `searchMs` / `readMs` / `steps` on its timing trace, so the next turn says where its time went rather than only how long it took.
- **Deep research is out of the fastest-models ranking.** Its wait is dominated by planner round trips, so averaging it into a per-model speed list ranked the mode rather than the model. Still traced with its phase split; only the ranking fold is gated.

## Not done
Parallelising the loop has little honest headroom — a search must embed before it can search, and each planner decision depends on the previous transcript. The one real opportunity is speculative: run a search on the raw question concurrently with planner call #1 (the loop already has a "planner never searched" fallback doing exactly that query). It changes what gets gathered, so it wants its own measurement rather than being stacked on this change.

## Gates
`cargo fmt` ✓ · `clippy -D warnings` ✓ · `cargo test` 348 passed ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)