### PR TITLE
Reminders backlog: UML artifact, update notice, five bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ two-host podcast voiced on-device.*
   **Data table**, **Round table** (product, engineering, and design critique the
   sources from their own risk lenses, then close on agreements and open
   questions), **Problems** (finds errors/gaps/contradictions), **Flashcards**,
-  **Quiz**, **Slide deck**, and a **Mind map**, plus HashiCorp-style
+  **Quiz**, **Slide deck**, a **Mind map**, and a **UML diagram**, plus HashiCorp-style
   **PRD**, **PR/FAQ**, **RFC**, and a **Skill** (SKILL.md) generator. Add custom
   instructions, and **rebuild** any document against the latest sources.
 - **Artifacts are real, not text dumps** — **flashcards** are a flippable deck
@@ -161,7 +161,9 @@ two-host podcast voiced on-device.*
   axis (both switchable, persisted in front-matter), a fullscreen **Present**
   mode, and **one-click PDF export** (landscape 16:9 pages; flashcards export
   a study sheet) — all local via the native print system; **mind maps** are a
-  native SVG on a **pannable canvas** (drag or scroll, Photoshop-style).
+  native SVG on a **pannable canvas** (drag or scroll, Photoshop-style), and
+  **UML diagrams** render class, sequence, state, ER, and component views on
+  that same canvas, with the model's source one click away.
 - **Notes** — a **WYSIWYG** editor (Markdown under the hood), copy to clipboard,
   **Convert to source** to fold a note into the retrievable source set, and
   **Open in window** for a full-size reader (mind maps especially).

--- a/docs/RFC-artifact-renderers.md
+++ b/docs/RFC-artifact-renderers.md
@@ -96,3 +96,33 @@ Each parses its spec and falls back to `<Markdown>` when it can't
 - Full SM-2 ease factors and cross-device sync of flashcard review state
   (localStorage is per-machine); quiz attempt history.
 - Retrofitting other kinds (timeline, data_table already read fine as prose).
+
+## Addendum: UML diagrams (`uml`)
+
+The UML kind breaks the rule at the top of this RFC on purpose, and it is
+worth writing down why.
+
+The rule is: don't ask a model for Mermaid, ask for a rigid text format and
+lay it out natively. That holds when the native layout is tractable — a mind
+map is a tree, and `MindMap.tsx` is 400 lines. UML is five different
+grammars with five different layout algorithms (class boxes with typed
+edges, sequence lifelines with activation bars, state machines, ER
+cardinalities, component graphs). Writing those is a project, not a
+renderer, and mermaid — already a dependency, already sanitized and
+theme-mapped in `lib/mermaid.ts` — implements all five.
+
+So the generator emits Mermaid source and `UmlDiagram.tsx` renders it. The
+contract this RFC actually cares about — *an artifact never arrives broken* —
+is kept a different way: a diagram that will not parse shows its source with
+mermaid's own error message, so a near-miss model is a two-word fix rather
+than a blank box and a Rebuild. The source view is always one click away
+even when the diagram is fine.
+
+- Content is bare Mermaid (`classDiagram` / `sequenceDiagram` /
+  `stateDiagram-v2` / `erDiagram` / `flowchart TD`); `umlSource()` tolerates
+  a stray ```mermaid fence or a prose preamble, since that is the failure
+  models actually make.
+- The diagram fills the pane on a shared `PanCanvas` (exported from
+  `MindMap.tsx`) — UML grows wider than any reading column.
+- Export follows the mind-map path: PNG primary via the print pipeline,
+  rasterized at 2200px so class-box labels stay crisp.

--- a/docs/RFC-note-export.md
+++ b/docs/RFC-note-export.md
@@ -14,6 +14,7 @@ script is already in the note).
 | -------------------------------------------------- | ------- | ---- | ------------------------------------------------------------------ |
 | infographic                                        | .png    | .pdf | Export window renders the poster print sheet → PDF → pdfium raster |
 | mind_map                                           | .png    | .pdf | Same pipeline; fixed-ink SVG scaled to one page, rasterized wide   |
+| uml                                                | .png    | .pdf | Same pipeline; the mermaid SVG on a white sheet, rasterized wide   |
 | slide_deck                                         | .pptx   | .pdf | Hand-rolled OOXML writer (below); PDF prints the 16:9 slide pages  |
 | flashcards                                         | .pptx   | .pdf | Q/A slide pairs (below); PDF prints the study sheet                |
 | data_table (or one-table markdown)                 | .xlsx   | .pdf | Markdown tables → `rust_xlsxwriter` worksheets                     |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,13 +4,16 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  lightningcss: ^1.33.0
+
 importers:
 
   .:
     dependencies:
       '@tailwindcss/vite':
         specifier: ^4.3.3
-        version: 4.3.3(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))
+        version: 4.3.3(vite@7.3.6(jiti@2.7.0)(lightningcss@1.33.0))
       '@tauri-apps/api':
         specifier: ^2.11.1
         version: 2.11.1
@@ -110,7 +113,7 @@ importers:
         version: 19.2.4(@types/react@19.2.18)
       '@vitejs/plugin-react':
         specifier: ^4.7.0
-        version: 4.7.0(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))
+        version: 4.7.0(vite@7.3.6(jiti@2.7.0)(lightningcss@1.33.0))
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
@@ -119,10 +122,10 @@ importers:
         version: 5.8.3
       vite:
         specifier: ^7.3.6
-        version: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
+        version: 7.3.6(jiti@2.7.0)(lightningcss@1.33.0)
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))
+        version: 4.1.11(vite@7.3.6(jiti@2.7.0)(lightningcss@1.33.0))
 
 packages:
 
@@ -1592,78 +1595,78 @@ packages:
   layout-base@2.0.1:
     resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
-  lightningcss-android-arm64@1.32.0:
-    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [android]
 
-  lightningcss-darwin-arm64@1.32.0:
-    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
 
-  lightningcss-darwin-x64@1.32.0:
-    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [darwin]
 
-  lightningcss-freebsd-x64@1.32.0:
-    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
 
-  lightningcss-linux-arm-gnueabihf@1.32.0:
-    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm]
     os: [linux]
 
-  lightningcss-linux-arm64-gnu@1.32.0:
-    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  lightningcss-linux-arm64-musl@1.32.0:
-    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  lightningcss-linux-x64-gnu@1.32.0:
-    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  lightningcss-linux-x64-musl@1.32.0:
-    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  lightningcss-win32-arm64-msvc@1.32.0:
-    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
 
-  lightningcss-win32-x64-msvc@1.32.0:
-    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [win32]
 
-  lightningcss@1.32.0:
-    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
     engines: {node: '>= 12.0.0'}
 
   linkify-it@5.0.2:
@@ -2157,7 +2160,7 @@ packages:
       '@types/node': ^20.19.0 || >=22.12.0
       jiti: '>=1.21.0'
       less: ^4.0.0
-      lightningcss: ^1.21.0
+      lightningcss: ^1.33.0
       sass: ^1.70.0
       sass-embedded: ^1.70.0
       stylus: '>=0.54.8'
@@ -2638,7 +2641,7 @@ snapshots:
       '@jridgewell/remapping': 2.3.5
       enhanced-resolve: 5.24.5
       jiti: 2.7.0
-      lightningcss: 1.32.0
+      lightningcss: 1.33.0
       magic-string: 0.30.21
       source-map-js: 1.2.1
       tailwindcss: 4.3.3
@@ -2694,12 +2697,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.3
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.3
 
-  '@tailwindcss/vite@4.3.3(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))':
+  '@tailwindcss/vite@4.3.3(vite@7.3.6(jiti@2.7.0)(lightningcss@1.33.0))':
     dependencies:
       '@tailwindcss/node': 4.3.3
       '@tailwindcss/oxide': 4.3.3
       tailwindcss: 4.3.3
-      vite: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
+      vite: 7.3.6(jiti@2.7.0)(lightningcss@1.33.0)
 
   '@tauri-apps/api@2.11.1': {}
 
@@ -3165,7 +3168,7 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vitejs/plugin-react@4.7.0(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))':
+  '@vitejs/plugin-react@4.7.0(vite@7.3.6(jiti@2.7.0)(lightningcss@1.33.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
@@ -3173,7 +3176,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
+      vite: 7.3.6(jiti@2.7.0)(lightningcss@1.33.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3186,13 +3189,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.11(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))':
+  '@vitest/mocker@4.1.11(vite@7.3.6(jiti@2.7.0)(lightningcss@1.33.0))':
     dependencies:
       '@vitest/spy': 4.1.11
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
+      vite: 7.3.6(jiti@2.7.0)(lightningcss@1.33.0)
 
   '@vitest/pretty-format@4.1.11':
     dependencies:
@@ -3708,54 +3711,54 @@ snapshots:
 
   layout-base@2.0.1: {}
 
-  lightningcss-android-arm64@1.32.0:
+  lightningcss-android-arm64@1.33.0:
     optional: true
 
-  lightningcss-darwin-arm64@1.32.0:
+  lightningcss-darwin-arm64@1.33.0:
     optional: true
 
-  lightningcss-darwin-x64@1.32.0:
+  lightningcss-darwin-x64@1.33.0:
     optional: true
 
-  lightningcss-freebsd-x64@1.32.0:
+  lightningcss-freebsd-x64@1.33.0:
     optional: true
 
-  lightningcss-linux-arm-gnueabihf@1.32.0:
+  lightningcss-linux-arm-gnueabihf@1.33.0:
     optional: true
 
-  lightningcss-linux-arm64-gnu@1.32.0:
+  lightningcss-linux-arm64-gnu@1.33.0:
     optional: true
 
-  lightningcss-linux-arm64-musl@1.32.0:
+  lightningcss-linux-arm64-musl@1.33.0:
     optional: true
 
-  lightningcss-linux-x64-gnu@1.32.0:
+  lightningcss-linux-x64-gnu@1.33.0:
     optional: true
 
-  lightningcss-linux-x64-musl@1.32.0:
+  lightningcss-linux-x64-musl@1.33.0:
     optional: true
 
-  lightningcss-win32-arm64-msvc@1.32.0:
+  lightningcss-win32-arm64-msvc@1.33.0:
     optional: true
 
-  lightningcss-win32-x64-msvc@1.32.0:
+  lightningcss-win32-x64-msvc@1.33.0:
     optional: true
 
-  lightningcss@1.32.0:
+  lightningcss@1.33.0:
     dependencies:
       detect-libc: 2.1.2
     optionalDependencies:
-      lightningcss-android-arm64: 1.32.0
-      lightningcss-darwin-arm64: 1.32.0
-      lightningcss-darwin-x64: 1.32.0
-      lightningcss-freebsd-x64: 1.32.0
-      lightningcss-linux-arm-gnueabihf: 1.32.0
-      lightningcss-linux-arm64-gnu: 1.32.0
-      lightningcss-linux-arm64-musl: 1.32.0
-      lightningcss-linux-x64-gnu: 1.32.0
-      lightningcss-linux-x64-musl: 1.32.0
-      lightningcss-win32-arm64-msvc: 1.32.0
-      lightningcss-win32-x64-msvc: 1.32.0
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
 
   linkify-it@5.0.2:
     dependencies:
@@ -4574,7 +4577,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0):
+  vite@7.3.6(jiti@2.7.0)(lightningcss@1.33.0):
     dependencies:
       esbuild: 0.28.2
       fdir: 6.5.0(picomatch@4.0.5)
@@ -4585,12 +4588,12 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
       jiti: 2.7.0
-      lightningcss: 1.32.0
+      lightningcss: 1.33.0
 
-  vitest@4.1.11(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0)):
+  vitest@4.1.11(vite@7.3.6(jiti@2.7.0)(lightningcss@1.33.0)):
     dependencies:
       '@vitest/expect': 4.1.11
-      '@vitest/mocker': 4.1.11(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))
+      '@vitest/mocker': 4.1.11(vite@7.3.6(jiti@2.7.0)(lightningcss@1.33.0))
       '@vitest/pretty-format': 4.1.11
       '@vitest/runner': 4.1.11
       '@vitest/snapshot': 4.1.11
@@ -4607,7 +4610,7 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
+      vite: 7.3.6(jiti@2.7.0)(lightningcss@1.33.0)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - msw

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,9 @@
 allowBuilds:
   esbuild: true
 verifyDepsBeforeRun: false
+overrides:
+  # Vite pulls lightningcss transitively; 1.32 doesn't know the CSS Custom
+  # Highlight API's ::highlight() pseudo-element and warns on every build
+  # (three times, for the citation/find/find-active rules in index.css).
+  # 1.33 parses it.
+  lightningcss: '^1.33.0'

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -674,6 +674,68 @@ pub fn open_in_terminal(command: String) -> Result<(), String> {
     Ok(())
 }
 
+/// Start Ollama, detached from Alchemy's lifetime.
+///
+/// The old path asked Terminal.app to run `ollama serve` over AppleScript.
+/// That is an Apple Event, and a build without `NSAppleEventsUsageDescription`
+/// in its Info.plist (every `tauri dev` binary — a bare executable has no
+/// plist at all) is killed outright by TCC the moment it sends one. So: the
+/// Mac app first, via LaunchServices; otherwise the CLI, backgrounded through
+/// `sh` so the server outlives Alchemy and leaves no zombie behind.
+/// Returns which route ran, for the toast.
+#[tauri::command]
+pub fn start_ollama() -> Result<String, String> {
+    if ollama_app_path().is_some() {
+        let status = std::process::Command::new("/usr/bin/open")
+            .args(["-a", "Ollama"])
+            .status()
+            .map_err(|e| e.to_string())?;
+        if status.success() {
+            return Ok("app".into());
+        }
+    }
+    let bin = ollama_binary().ok_or(
+        "Ollama isn't installed. Get the app from ollama.com/download, or `brew install ollama`.",
+    )?;
+    // `&` inside sh: the server gets its own life, sh returns at once (so
+    // nothing is left for Alchemy to reap), and nothing inherits our stdio.
+    // `bin` is a path this process discovered, never user input.
+    let status = std::process::Command::new("/bin/sh")
+        .arg("-c")
+        .arg(format!(
+            "exec nohup '{}' serve >/dev/null 2>&1 &",
+            bin.display()
+        ))
+        .status()
+        .map_err(|e| e.to_string())?;
+    if !status.success() {
+        return Err("Couldn't start `ollama serve`.".into());
+    }
+    Ok("cli".into())
+}
+
+/// The Ollama Mac app, if it's installed. It runs its own server and menu-bar
+/// item, so launching it beats spawning a bare `ollama serve`.
+fn ollama_app_path() -> Option<std::path::PathBuf> {
+    let home = std::env::var("HOME").unwrap_or_default();
+    [
+        std::path::PathBuf::from("/Applications/Ollama.app"),
+        std::path::PathBuf::from(format!("{home}/Applications/Ollama.app")),
+    ]
+    .into_iter()
+    .find(|p| p.exists())
+}
+
+/// The `ollama` CLI: the agent-CLI resolver's well-known dirs and login-shell
+/// `which`, plus the binary the Mac app ships inside its bundle.
+fn ollama_binary() -> Option<std::path::PathBuf> {
+    if let Some(found) = crate::inference::find_binary_cached("ollama") {
+        return Some(found);
+    }
+    let bundled = ollama_app_path()?.join("Contents/Resources/ollama");
+    bundled.exists().then_some(bundled)
+}
+
 /// Validate a Notion integration token against the API (Settings field's live
 /// check). Returns the workspace/bot label on success; a human error string
 /// on failure. Standalone — no app state needed.
@@ -10515,6 +10577,7 @@ fn note_kind_from_label(label: &str) -> String {
         "flashcards",
         "quiz",
         "mind_map",
+        "uml",
         "data_table",
         "round_table",
         "problems",

--- a/src-tauri/src/export.rs
+++ b/src-tauri/src/export.rs
@@ -103,9 +103,14 @@ pub async fn export_note_file(
         }
         "png" => {
             let tmp = print_note_pdf(app, &note).await?;
-            // Mind maps scale to fit one sheet, so rasterize them wider to
-            // keep node labels crisp; posters get poster width.
-            let width = if note.kind == "mind_map" { 2200 } else { 1600 };
+            // Mind maps and UML diagrams scale to fit one sheet, so
+            // rasterize them wider to keep node labels crisp; posters get
+            // poster width.
+            let width = if note.kind == "mind_map" || note.kind == "uml" {
+                2200
+            } else {
+                1600
+            };
             blocking(move || {
                 let pages = crate::pdf::render_pdf_pages(&tmp.to_string_lossy(), 8, width)?;
                 let png = stitch_png_pages(&pages)?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -440,6 +440,7 @@ pub fn run() {
             commands::send_message_agentic,
             commands::cancel_generation,
             commands::open_in_terminal,
+            commands::start_ollama,
             commands::suggest_notebook,
             commands::pdf_page_count,
             commands::pdf_page_image,

--- a/src-tauri/src/rag.rs
+++ b/src-tauri/src/rag.rs
@@ -593,6 +593,7 @@ pub const ARTIFACT_KINDS: &[&str] = &[
     "slide_deck",
     "infographic",
     "mind_map",
+    "uml",
     "problems",
     "evidence",
     "prd",
@@ -841,6 +842,32 @@ pub fn artifact_spec(kind: &str) -> Option<(&'static str, &'static str)> {
              below the root. Keep every label short — 5 words or fewer, telegraphic style. \
              Output ONLY the outline: no prose before or after, no headings, no code fences, \
              no bold or other formatting.",
+        )),
+        "uml" => Some((
+            "UML Diagram",
+            "Model the system the sources below describe as a single UML diagram, written as \
+             Mermaid source. Choose the ONE diagram type that fits what the corpus actually \
+             documents:\n\
+             - `classDiagram` — entities, their fields and methods, and how they relate \
+               (inheritance `<|--`, composition `*--`, aggregation `o--`, association `-->`). \
+               Use this for data models, domain objects, and type hierarchies.\n\
+             - `sequenceDiagram` — an interaction over time between participants \
+               (`A->>B: message`, `B-->>A: reply`, `activate`/`deactivate`). Use this for \
+               protocols, request flows, and call chains.\n\
+             - `stateDiagram-v2` — the states of one thing and the transitions between them \
+               (`[*] --> Idle`, `Idle --> Running: start`). Use this for lifecycles, status \
+               machines, and workflows with named states.\n\
+             - `erDiagram` — entities and their cardinalities (`CUSTOMER ||--o{ ORDER : places`). \
+               Use this for database schemas and record relationships.\n\
+             - `flowchart TD` — components and the paths between them. Use this only when \
+               none of the above fit: component, deployment, and activity views.\n\
+             Rules: 8-20 nodes or participants — enough to be useful, few enough to read. \
+             Label every relationship. Name things exactly as the sources name them; never \
+             invent a class, message, state, or table the corpus does not describe, and leave \
+             out anything you would have to guess at. Keep identifiers free of spaces and \
+             punctuation (Mermaid rejects them); put the prose in the labels. Output ONLY the \
+             Mermaid source, starting with the diagram-type keyword: no code fences, no \
+             headings, no prose before or after.",
         )),
         "problems" => Some((
             "Problems",

--- a/src/components/HealthBanner.tsx
+++ b/src/components/HealthBanner.tsx
@@ -106,7 +106,26 @@ export function HealthBanner({
           {
             label: "Start Ollama",
             primary: true,
-            run: () => api.openInTerminal("ollama serve").catch(() => {}),
+            run: async () => {
+              const store = useStore.getState();
+              try {
+                const via = await api.startOllama();
+                store.pushToast(
+                  "info",
+                  via === "app"
+                    ? "Starting the Ollama app…"
+                    : "Started `ollama serve` in the background.",
+                );
+                // The server needs a moment to bind before a probe means
+                // anything; "Check again" is still there if it misses.
+                window.setTimeout(() => void check(), 2500);
+              } catch (err) {
+                store.pushToast(
+                  "error",
+                  err instanceof Error ? err.message : String(err),
+                );
+              }
+            },
           },
           { label: "Check again", run: check },
         ],

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useStore } from "@/lib/store";
 import { usePickList } from "@/lib/pick";
 import { DevBadge } from "./DevBadge";
+import { UpdateBadge } from "./UpdateBadge";
 import { HealthBanner } from "./HealthBanner";
 import {
   Badge,
@@ -35,6 +36,7 @@ import {
   FileDown,
   ChevronRight,
   PanelRight,
+  PanelRightClose,
   Plus,
   Search,
   Settings,
@@ -625,6 +627,7 @@ export function HomeView({ onOpenSettings }: { onOpenSettings: () => void }) {
         </div>
         <div className="ml-auto flex items-center gap-3">
           <DevBadge />
+          <UpdateBadge />
           <Button
             variant="ghost"
             size="icon"
@@ -1212,35 +1215,61 @@ export function HomeView({ onOpenSettings }: { onOpenSettings: () => void }) {
                         fallbackColor={NOTEBOOK_PALETTE[0]}
                         onOpen={openNote}
                       />
-                    ) : activityLoading ? (
-              <div
-                role="status"
-                className="flex flex-1 items-center justify-center p-8 text-caption text-muted-foreground"
-              >
-                Loading reports…
-              </div>
-            ) : (
-              <div className="flex flex-1 items-center justify-center p-8">
-                <EmptyState
-                  icon={<Newspaper className="h-7 w-7" />}
-                  title={activityError ? "Reports unavailable" : "Reports appear here"}
-                  hint={
-                    activityError
-                      ? "Alchemy couldn’t load recent reports."
-                      : "Schedule a recurring report from a notebook’s Studio panel."
-                  }
-                >
-                  {activityError && (
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      onClick={() => void refreshActivity()}
-                    >
-                      Retry
-                    </Button>
-                  )}
-                </EmptyState>
-              </div>
+                    ) : (
+                      // Empty and loading states carry their own header:
+                      // ReportsFeed owns the collapse control, so without one
+                      // here an empty feed can never be closed again.
+                      <>
+                        <div className="flex min-h-12 shrink-0 items-center gap-2 border-b border-border px-6 py-2">
+                          <span className="whitespace-nowrap text-caption font-semibold uppercase tracking-wide text-muted-foreground">
+                            Latest reports
+                          </span>
+                          <button
+                            type="button"
+                            onClick={toggleReports}
+                            title="Collapse reports"
+                            aria-label="Collapse the reports feed"
+                            aria-expanded
+                            className="ml-auto rounded p-1 text-muted-foreground transition-colors hover:bg-surface-2 hover:text-foreground"
+                          >
+                            <PanelRightClose className="h-4 w-4" />
+                          </button>
+                        </div>
+                        {activityLoading ? (
+                          <div
+                            role="status"
+                            className="flex flex-1 items-center justify-center p-8 text-caption text-muted-foreground"
+                          >
+                            Loading reports…
+                          </div>
+                        ) : (
+                          <div className="flex flex-1 items-center justify-center p-8">
+                            <EmptyState
+                              icon={<Newspaper className="h-7 w-7" />}
+                              title={
+                                activityError
+                                  ? "Reports unavailable"
+                                  : "Reports appear here"
+                              }
+                              hint={
+                                activityError
+                                  ? "Alchemy couldn’t load recent reports."
+                                  : "Schedule a recurring report from a notebook’s Studio panel."
+                              }
+                            >
+                              {activityError && (
+                                <Button
+                                  variant="secondary"
+                                  size="sm"
+                                  onClick={() => void refreshActivity()}
+                                >
+                                  Retry
+                                </Button>
+                              )}
+                            </EmptyState>
+                          </div>
+                        )}
+                      </>
                     )
                   ) : (
                     <div className="flex h-12 shrink-0 items-center gap-2 px-6">

--- a/src/components/MermaidBlock.tsx
+++ b/src/components/MermaidBlock.tsx
@@ -39,14 +39,17 @@ function loadMermaid() {
 /** Ids must be unique per render — mermaid keys internal state on them. */
 let diagramSeq = 0;
 
-export function MermaidBlock({ code }: { code: string }) {
+/** Render `code` to sanitized SVG, re-running on theme changes. `error` holds
+ *  mermaid's own parse message so callers can show it (the UML viewer does);
+ *  MermaidBlock only cares that it failed. Both null while loading. */
+export function useMermaidSvg(code: string) {
   const theme = useStore((s) => s.theme);
   const [svg, setSvg] = useState("");
-  const [failed, setFailed] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let stale = false;
-    setFailed(false);
+    setError(null);
     void loadMermaid()
       .then(async (mermaid) => {
         mermaid.initialize(mermaidConfig());
@@ -57,8 +60,8 @@ export function MermaidBlock({ code }: { code: string }) {
         const { svg: out } = await mermaid.render(id, code);
         if (!stale) setSvg(sanitizeSvg(out));
       })
-      .catch(() => {
-        if (!stale) setFailed(true);
+      .catch((e) => {
+        if (!stale) setError(e instanceof Error ? e.message : String(e));
       });
     return () => {
       stale = true;
@@ -66,6 +69,13 @@ export function MermaidBlock({ code }: { code: string }) {
     // `theme` is a dependency on purpose: a theme switch re-reads the tokens
     // and re-renders every diagram on screen.
   }, [code, theme]);
+
+  return { svg, error };
+}
+
+export function MermaidBlock({ code }: { code: string }) {
+  const { svg, error } = useMermaidSvg(code);
+  const failed = error !== null;
 
   if (failed || (!svg && !code.trim())) {
     return (

--- a/src/components/MindMap.tsx
+++ b/src/components/MindMap.tsx
@@ -210,8 +210,8 @@ export function MindMap({ content }: { content: string }) {
 
 /** Infinite-canvas panning and zooming (Photoshop-style): drag with a grab
  *  cursor or two-finger scroll to move; pinch (ctrl+wheel on macOS) or the
- *  corner buttons to zoom around the cursor. */
-function PanCanvas({ children }: { children: React.ReactNode }) {
+ *  corner buttons to zoom around the cursor. Shared with the UML viewer. */
+export function PanCanvas({ children }: { children: React.ReactNode }) {
   const viewportRef = useRef<HTMLDivElement>(null);
   const [view, setView] = useState({ x: 0, y: 0, scale: 1 });
   const drag = useRef<{ x: number; y: number; ox: number; oy: number } | null>(null);

--- a/src/components/NoteWindow.tsx
+++ b/src/components/NoteWindow.tsx
@@ -5,6 +5,7 @@ import { Flashcards } from "./Flashcards";
 import { Infographic } from "./Infographic";
 import { Markdown } from "./Markdown";
 import { MindMap } from "./MindMap";
+import { UmlDiagram } from "./UmlDiagram";
 import { QuizView } from "./QuizView";
 import { SlideDeck } from "./SlideDeck";
 import { AudioPlayer, DialogueScript } from "./AudioNote";
@@ -25,6 +26,12 @@ export function NoteWindow({ noteId }: { noteId: string }) {
   // The store clears notes on selectNotebook, so "loaded but missing" is only
   // trustworthy once the notebook is current and the notes list settled.
   const loading = !note && (!currentId || notes.length === 0);
+  // Canvas artifacts size themselves to the window instead of scrolling in a
+  // reading column.
+  const fillsWindow =
+    note?.kind === "slide_deck" ||
+    note?.kind === "mind_map" ||
+    note?.kind === "uml";
 
   useEffect(() => {
     if (note) void getCurrentWebviewWindow().setTitle(`${note.title} — Alchemy`);
@@ -45,19 +52,15 @@ export function NoteWindow({ noteId }: { noteId: string }) {
         className={cn(
           "flex-1",
           // Slides size themselves to the window; everything else scrolls.
-          note?.kind === "slide_deck" || note?.kind === "mind_map"
-            ? "min-h-0 overflow-hidden"
-            : "overflow-y-auto",
+          fillsWindow ? "min-h-0 overflow-hidden" : "overflow-y-auto",
         )}
       >
         <div
           className={cn(
             "mx-auto px-8 py-8",
-            // Mind maps and slide decks want the full window; prose reads
-            // best at column width.
-            (note?.kind === "mind_map" || note?.kind === "slide_deck") &&
-              "h-full max-w-none py-6",
-            note?.kind !== "mind_map" && note?.kind !== "slide_deck" && "max-w-[760px]",
+            // Canvas artifacts want the full window; prose reads best at
+            // column width.
+            fillsWindow ? "h-full max-w-none py-6" : "max-w-[760px]",
           )}
         >
           {loading ? (
@@ -73,6 +76,8 @@ export function NoteWindow({ noteId }: { noteId: string }) {
             </div>
           ) : note.kind === "mind_map" ? (
             <MindMap content={note.content} />
+          ) : note.kind === "uml" ? (
+            <UmlDiagram content={note.content} />
           ) : note.kind === "flashcards" ? (
             <Flashcards content={note.content} noteId={note.id} />
           ) : note.kind === "quiz" ? (

--- a/src/components/PrintExportView.tsx
+++ b/src/components/PrintExportView.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { useStore } from "@/lib/store";
 import { Markdown } from "./Markdown";
 import { PrintPortal } from "./printExport";
 import { parseInfographic, PrintInfographic } from "./Infographic";
 import { PrintMindMap } from "./MindMap";
+import { PrintUml } from "./UmlDiagram";
 import { parseDeck, PrintDeck } from "./SlideDeck";
 import { parseCards, PrintCards } from "./Flashcards";
 
@@ -30,9 +31,22 @@ export function PrintExportView({
   // Slide pages print edge-to-edge on 16:9 landscape paper (print_webview).
   const deck =
     note?.kind === "slide_deck" ? parseDeck(note.content, appTheme) : null;
+  // UML sheets are the one kind whose ink isn't there on the first frame:
+  // mermaid is a lazily-imported chunk, and printing before it answers ships
+  // a blank page. The sheet says when it has settled (diagram or error) and
+  // the timeout keeps a wedged render from leaving the window open forever.
+  const asyncSheet = note?.kind === "uml";
+  const [sheetReady, setSheetReady] = useState(false);
+  useEffect(() => {
+    if (!asyncSheet) return;
+    const t = window.setTimeout(() => setSheetReady(true), 8000);
+    return () => window.clearTimeout(t);
+  }, [asyncSheet]);
+
   const fired = useRef(false);
   useEffect(() => {
     if (!note || fired.current) return;
+    if (asyncSheet && !sheetReady) return;
     fired.current = true;
     const landscape = !!deck;
     // Two frames: one for the print portal to mount, one for layout.
@@ -41,10 +55,14 @@ export function PrintExportView({
         void invoke("print_webview", { landscape, savePath: pdfPath });
       });
     });
-  }, [note, deck, pdfPath]);
+  }, [note, deck, pdfPath, asyncSheet, sheetReady]);
   if (!note) return null;
 
   if (note.kind === "mind_map") return <PrintMindMap content={note.content} />;
+  if (note.kind === "uml")
+    return (
+      <PrintUml content={note.content} onReady={() => setSheetReady(true)} />
+    );
   if (deck) return <PrintDeck deck={deck} />;
   if (note.kind === "flashcards") {
     const cards = parseCards(note.content);

--- a/src/components/ReaderPane.tsx
+++ b/src/components/ReaderPane.tsx
@@ -19,6 +19,7 @@ import { Flashcards } from "./Flashcards";
 import { Infographic } from "./Infographic";
 import { Markdown } from "./Markdown";
 import { MindMap } from "./MindMap";
+import { UmlDiagram } from "./UmlDiagram";
 import { QuizView } from "./QuizView";
 import { SlideDeck } from "./SlideDeck";
 import { RichEditor } from "./RichEditor";
@@ -846,6 +847,7 @@ export function ReaderPane() {
               "slide_deck",
               "infographic",
               "mind_map",
+              "uml",
               "quiz",
               "flashcards",
               "audio_overview",
@@ -1872,7 +1874,9 @@ function SourceReader({
 
   // Live web view: a native child webview positioned over the placeholder
   // below (see live_view_* commands). Bounds track the placeholder; in-app
-  // overlays (palette, modals) hide it so they are never painted over.
+  // overlays (palette, modals, hover cards, row menus) hide it so they are
+  // never painted over — a native child webview sits above every HTML
+  // layer, so z-index cannot win this fight.
   const liveRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (!live) return;
@@ -1888,7 +1892,9 @@ function SourceReader({
     ro.observe(el);
     window.addEventListener("resize", update);
     const overlayCheck = () =>
-      void api.liveViewVisible(!document.querySelector('[role="dialog"]'));
+      void api.liveViewVisible(
+        !document.querySelector('[role="dialog"],[data-overlay]'),
+      );
     const mo = new MutationObserver(overlayCheck);
     mo.observe(document.body, { childList: true, subtree: true });
     return () => {
@@ -2043,6 +2049,11 @@ function SourceReader({
     source.sourceType === "markdown" ||
     ((source.sourceType === "text" ||
       source.sourceType === "url" ||
+      // Apple integrations (Notes, Calendar, Reminders, Stocks) come out of
+      // mac.rs as Markdown — Stocks is a GFM table, and reading it as flat
+      // text showed the pipes instead of a table. Reminders keeps its own
+      // checkbox view, which is checked before this one.
+      source.sourceType === "mac" ||
       // PDFs extract to Markdown now (pdf-inspector reconstructs headings,
       // lists and tables) — but older sources were ingested as flat text, so
       // this still asks the content rather than trusting the type.
@@ -2532,9 +2543,13 @@ function SourceReader({
           {backlinks.length > 0 && (
             <span className="group ml-auto flex shrink-0 items-center">
               <RowMenu
-                // The text link is the visible affordance; the RowMenu's own
-                // trigger only anchors the dropdown.
-                className="!flex [&>button:first-child]:hidden"
+                // The text link IS the trigger: a hidden ⋯ button clicked
+                // from outside measures 0x0, which parks the dropdown in the
+                // window's top-left corner instead of beside the link.
+                alwaysVisible
+                className="!flex"
+                triggerClassName="text-citation hover:underline"
+                trigger={<>← linked from {backlinks.length}</>}
                 label={`Linked from ${backlinks.length} ${
                   backlinks.length === 1 ? "document" : "documents"
                 }`}
@@ -2547,17 +2562,6 @@ function SourceReader({
                       .openInReader({ type: b.kind, id: b.id }),
                 }))}
               />
-              <button
-                type="button"
-                className="text-citation hover:underline"
-                onClick={(e) => {
-                  const menu = (e.currentTarget.previousElementSibling as HTMLElement)
-                    ?.querySelector("button");
-                  (menu as HTMLButtonElement | null)?.click();
-                }}
-              >
-                ← linked from {backlinks.length}
-              </button>
             </span>
           )}
         </div>
@@ -2729,11 +2733,13 @@ function NoteReader({
 
   const rebuilding = !!generatingKind && note.kind !== "note";
   // Kinds that size themselves to the pane and bring their own controls.
-  const fillsPane = note.kind === "slide_deck" || note.kind === "mind_map";
+  const fillsPane =
+    note.kind === "slide_deck" || note.kind === "mind_map" || note.kind === "uml";
   const artifact =
     note.kind === "slide_deck" ||
     note.kind === "infographic" ||
     note.kind === "mind_map" ||
+    note.kind === "uml" ||
     note.kind === "quiz" ||
     note.kind === "flashcards" ||
     note.kind === "audio_overview";
@@ -2792,6 +2798,8 @@ function NoteReader({
             <StreamingBody text={artifactStreamText} />
           ) : note.kind === "mind_map" ? (
             <MindMap content={note.content} />
+          ) : note.kind === "uml" ? (
+            <UmlDiagram content={note.content} />
           ) : note.kind === "flashcards" ? (
             <Flashcards content={note.content} noteId={note.id} />
           ) : note.kind === "quiz" ? (

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -345,6 +345,11 @@ function GeneralTab() {
     const flow = await checkForUpdates();
     setUpdate(flow);
     setChecking(false);
+    // Keep the title-bar notice (UpdateBadge) honest: an explicit check is
+    // the freshest answer there is, in both directions.
+    if (flow.status === "available")
+      useStore.setState({ updateAvailable: flow.version });
+    if (flow.status === "none") useStore.setState({ updateAvailable: null });
     if (flow.status === "none")
       pushToast("success", "You're on the latest version.");
     if (flow.status === "error")

--- a/src/components/StudioNoteViewer.tsx
+++ b/src/components/StudioNoteViewer.tsx
@@ -7,6 +7,7 @@ import { Flashcards } from "./Flashcards";
 import { Infographic } from "./Infographic";
 import { Markdown } from "./Markdown";
 import { MindMap } from "./MindMap";
+import { UmlDiagram } from "./UmlDiagram";
 import { QuizView } from "./QuizView";
 import { SlideDeck } from "./SlideDeck";
 import { RichEditor } from "./RichEditor";
@@ -132,6 +133,8 @@ export function StudioNoteViewer({
                 <StreamingBody text={artifactStreamText} />
               ) : live.kind === "mind_map" ? (
                 <MindMap content={live.content} />
+              ) : live.kind === "uml" ? (
+                <UmlDiagram content={live.content} />
               ) : live.kind === "flashcards" ? (
                 <Flashcards content={live.content} noteId={live.id} />
               ) : live.kind === "quiz" ? (

--- a/src/components/UmlDiagram.tsx
+++ b/src/components/UmlDiagram.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useMemo, useState } from "react";
+import { Code2, Image as ImageIcon } from "lucide-react";
+import { useMermaidSvg } from "./MermaidBlock";
+import { PanCanvas } from "./MindMap";
+import { PrintPortal } from "./printExport";
+
+/**
+ * Native UML viewer for the `uml` artifact.
+ *
+ * The generator emits bare Mermaid source (one `classDiagram`,
+ * `sequenceDiagram`, `stateDiagram-v2`, `erDiagram` or `flowchart`), so the
+ * whole note IS the diagram — unlike a ```mermaid fence inside a document,
+ * which MermaidBlock handles inline. That difference is what this component
+ * is for: the diagram gets the pane, an infinite pan/zoom canvas (UML grows
+ * wider than any column), and a source view for reading or copying the
+ * model out.
+ *
+ * A model that will not parse shows the source with mermaid's own error
+ * rather than an empty box — the generator's text is still the useful part,
+ * and a diagram is easier to hand-fix than to regenerate.
+ */
+
+/** Diagram-type keyword → the UML name a reader knows it by. */
+const UML_TYPES: [RegExp, string][] = [
+  [/^classDiagram/, "Class diagram"],
+  [/^sequenceDiagram/, "Sequence diagram"],
+  [/^stateDiagram(-v2)?/, "State diagram"],
+  [/^erDiagram/, "Entity relationship"],
+  [/^(flowchart|graph)\b/, "Component diagram"],
+  [/^journey/, "User journey"],
+  [/^C4(Context|Container|Component|Dynamic)/, "C4 model"],
+];
+
+/** The note's Mermaid source: models sometimes wrap it in a fence despite
+ *  the instruction, and a stray prose preamble should not break the parse. */
+export function umlSource(content: string): string {
+  const fenced = /```(?:mermaid)?\s*\n([\s\S]*?)```/.exec(content);
+  const body = (fenced ? fenced[1] : content).trim();
+  const lines = body.split("\n");
+  const start = lines.findIndex((l) => UML_TYPES.some(([re]) => re.test(l.trim())));
+  return (start > 0 ? lines.slice(start).join("\n") : body).trim();
+}
+
+/** What kind of UML this is, for the chip beside the diagram. */
+export function umlKindLabel(code: string): string {
+  const first = code.trimStart().split("\n")[0]?.trim() ?? "";
+  return UML_TYPES.find(([re]) => re.test(first))?.[1] ?? "Diagram";
+}
+
+/** The model as text — readable, selectable, and copyable straight out. */
+function UmlSource({ code }: { code: string }) {
+  return (
+    <pre className="selectable whitespace-pre rounded-md border border-border bg-surface-2/40 p-4 font-mono text-caption leading-relaxed text-foreground/90">
+      {code}
+    </pre>
+  );
+}
+
+export function UmlDiagram({ content }: { content: string }) {
+  const code = useMemo(() => umlSource(content), [content]);
+  const [showSource, setShowSource] = useState(false);
+  const { svg, error } = useMermaidSvg(code);
+
+  // A broken model is a source-reading problem: show the text and say why.
+  if (error !== null) {
+    return (
+      <div className="flex h-full min-h-0 flex-col gap-3">
+        <p className="shrink-0 text-caption text-destructive">
+          This diagram doesn’t parse: {error.split("\n")[0]}
+        </p>
+        <div className="min-h-0 flex-1 overflow-auto">
+          <UmlSource code={code} />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-2">
+      <div className="flex shrink-0 items-center gap-2">
+        <span className="rounded-full border border-border px-2 py-0.5 text-micro uppercase tracking-wide text-muted-foreground">
+          {umlKindLabel(code)}
+        </span>
+        <button
+          type="button"
+          onClick={() => setShowSource((s) => !s)}
+          title={showSource ? "Show the diagram" : "Show the Mermaid source"}
+          aria-pressed={showSource}
+          className="ml-auto flex items-center gap-1.5 rounded px-2 py-1 text-caption text-muted-foreground transition-colors hover:bg-surface-2 hover:text-foreground"
+        >
+          {showSource ? (
+            <>
+              <ImageIcon aria-hidden className="h-3.5 w-3.5" />
+              Diagram
+            </>
+          ) : (
+            <>
+              <Code2 aria-hidden className="h-3.5 w-3.5" />
+              Source
+            </>
+          )}
+        </button>
+      </div>
+      {showSource ? (
+        <div className="min-h-0 flex-1 overflow-auto">
+          <UmlSource code={code} />
+        </div>
+      ) : !svg ? (
+        <div
+          className="min-h-0 flex-1 rounded-md border border-border bg-surface-2/40"
+          aria-busy="true"
+        />
+      ) : (
+        <div className="min-h-0 flex-1 rounded-md border border-border bg-surface-2/30">
+          <PanCanvas>
+            <div
+              className="p-6 [&_svg]:h-auto [&_svg]:max-w-none"
+              // Sanitized in useMermaidSvg before it ever reaches here.
+              dangerouslySetInnerHTML={{ __html: svg }}
+            />
+          </PanCanvas>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Print sheet for PDF/PNG export: the diagram at natural size, no pan/zoom
+ * viewport to crop it. Mermaid's SVG carries its own theme colors, which on
+ * a dark theme means light-on-dark ink — so the sheet keeps a white ground
+ * behind it rather than pretending the export is a document.
+ */
+export function PrintUml({
+  content,
+  onReady,
+}: {
+  content: string;
+  /** Fires once the sheet has settled — a rendered diagram or a parse
+   *  failure. The export window waits for it before printing. */
+  onReady?: () => void;
+}) {
+  const code = useMemo(() => umlSource(content), [content]);
+  const { svg, error } = useMermaidSvg(code);
+  const settled = !!svg || error !== null;
+  useEffect(() => {
+    if (settled) onReady?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [settled]);
+  return (
+    <PrintPortal pageCss="@page { size: auto; margin: 16mm; }">
+      <div
+        style={{
+          background: "#fff",
+          WebkitPrintColorAdjust: "exact",
+          display: "flex",
+          justifyContent: "center",
+        }}
+      >
+        {svg ? (
+          <div
+            style={{ maxWidth: 620 }}
+            className="[&_svg]:h-auto [&_svg]:max-w-full"
+            // Sanitized in useMermaidSvg before it ever reaches here.
+            dangerouslySetInnerHTML={{ __html: svg }}
+          />
+        ) : (
+          // Mermaid hasn't answered yet (or won't): the source is still the
+          // model, and a blank sheet would be worse than a printed listing.
+          <pre style={{ color: "#111", fontSize: 11, maxWidth: 620 }}>{code}</pre>
+        )}
+      </div>
+    </PrintPortal>
+  );
+}

--- a/src/components/UpdateBadge.tsx
+++ b/src/components/UpdateBadge.tsx
@@ -1,0 +1,27 @@
+import { ArrowUpCircle } from "lucide-react";
+import { useStore } from "@/lib/store";
+
+/** Title-bar update notice, beside the DEV chip: the quiet startup check
+ *  (`checkForUpdatesQuietly`) sets `updateAvailable`, and this is the notice
+ *  that stays put after the launch toast has gone. Clicking it opens
+ *  Settings → General with the check already queued, so the Install button
+ *  is right there. Renders nothing when the app is current. */
+export function UpdateBadge() {
+  const version = useStore((s) => s.updateAvailable);
+  if (!version) return null;
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        useStore.setState({ pendingUpdateCheck: true });
+        useStore.getState().openSettings("general");
+      }}
+      title={`Alchemy ${version} is available — click to review and install`}
+      aria-label={`Update to Alchemy ${version}`}
+      className="mr-1 flex select-none items-center gap-1 rounded-full border border-primary/40 bg-primary/10 px-2 py-0.5 text-badge font-semibold tracking-wide text-citation transition-colors hover:bg-primary/20"
+    >
+      <ArrowUpCircle aria-hidden className="h-3 w-3" />
+      {version}
+    </button>
+  );
+}

--- a/src/components/Workspace.tsx
+++ b/src/components/Workspace.tsx
@@ -14,6 +14,7 @@ import { shortcutBlocked } from "@/lib/utils";
 import { ChevronLeft, Search, Settings } from "lucide-react";
 import { notebookIcon } from "@/lib/notebookIcons";
 import { DevBadge } from "./DevBadge";
+import { UpdateBadge } from "./UpdateBadge";
 
 export function Workspace({ onOpenSettings }: { onOpenSettings: () => void }) {
   const currentId = useStore((s) => s.currentId);
@@ -100,6 +101,7 @@ export function Workspace({ onOpenSettings }: { onOpenSettings: () => void }) {
         </div>
         <div className="ml-auto flex items-center gap-1">
           <DevBadge />
+          <UpdateBadge />
           <Button
             variant="ghost"
             size="icon"

--- a/src/components/studioArtifacts.tsx
+++ b/src/components/studioArtifacts.tsx
@@ -22,6 +22,7 @@ import {
   TriangleAlert,
   Users,
   Waypoints,
+  Workflow,
 } from "lucide-react";
 
 export type ArtifactFamily = "generate" | "learning" | "documents";
@@ -80,6 +81,7 @@ const LEARNING = inFamily("learning", [
   { kind: "flashcards", label: "Flashcards", icon: <Layers className="h-3.5 w-3.5" /> },
   { kind: "quiz", label: "Quiz", icon: <ListChecks className="h-3.5 w-3.5" /> },
   { kind: "mind_map", label: "Mind map", icon: <Waypoints className="h-3.5 w-3.5" /> },
+  { kind: "uml", label: "UML diagram", icon: <Workflow className="h-3.5 w-3.5" /> },
   {
     kind: "slide_deck",
     label: "Slide deck",

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -169,6 +169,10 @@ export function useHoverCard(side: "left" | "right") {
   const card = state
     ? createPortal(
         <div
+          // The reader's live web view is a NATIVE child webview: it paints
+          // above every HTML layer, whatever the z-index. `data-overlay`
+          // is the marker it watches for to hide itself (see ReaderPane).
+          data-overlay=""
           className={cn(
             "pointer-events-none fixed z-[100] w-64 rounded-lg border border-border-strong bg-surface-2 p-3 shadow-2xl",
             side === "left" && "-translate-x-full",
@@ -960,6 +964,8 @@ export function RowMenu({
   onOpen,
   contextItems,
   alwaysVisible = false,
+  trigger,
+  triggerClassName,
 }: {
   items: RowMenuItem[];
   label?: string;
@@ -976,6 +982,13 @@ export function RowMenu({
    *  or null/undefined to open the normal menu — side effects here (like
    *  collapsing the selection to this row) are welcome (RFC-multi-select). */
   contextItems?: () => RowMenuItem[] | null | undefined;
+  /** Replace the ⋯ glyph with custom trigger content (a text link, say).
+   *  It stays the SAME button, so the dropdown still anchors to it —
+   *  hiding the ⋯ and clicking it from outside gives the menu a zero-sized
+   *  trigger rect, which lands it in the window's top-left corner. */
+  trigger?: React.ReactNode;
+  /** Classes for the trigger button when `trigger` supplies its own look. */
+  triggerClassName?: string;
 }) {
   const [open, setOpen] = React.useState(false);
   const ref = React.useRef<HTMLDivElement>(null);
@@ -1016,7 +1029,11 @@ export function RowMenu({
       return;
     }
     if (!triggerRef.current) return;
-    const t = triggerRef.current.getBoundingClientRect();
+    // A display:none trigger measures 0×0 at the origin; fall back to the
+    // container so the menu still lands on its row.
+    let t = triggerRef.current.getBoundingClientRect();
+    if (t.width === 0 && t.height === 0 && ref.current)
+      t = ref.current.getBoundingClientRect();
     const up = t.bottom + 4 + m.height > window.innerHeight - 8;
     const style: React.CSSProperties = up
       ? { bottom: window.innerHeight - t.top + 4 }
@@ -1156,15 +1173,19 @@ export function RowMenu({
         aria-label={label}
         aria-haspopup="menu"
         aria-expanded={open}
-        className="rounded p-0.5 text-muted-foreground transition-colors hover:text-foreground"
+        className={
+          triggerClassName ??
+          "rounded p-0.5 text-muted-foreground transition-colors hover:text-foreground"
+        }
       >
-        <MoreHorizontal className="h-3.5 w-3.5" />
+        {trigger ?? <MoreHorizontal className="h-3.5 w-3.5" />}
       </button>
       {open &&
         createPortal(
           <div
             ref={menuRef}
             role="menu"
+            data-overlay=""
             aria-label={label}
             style={pos ?? { top: 0, left: 0, visibility: "hidden" }}
             className="menu-glass fixed z-50 w-44 overflow-hidden rounded-md py-1 shadow-[0_0_0_0.5px_var(--border-strong),0_8px_24px_-6px_rgba(0,0,0,0.4)]"

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -342,6 +342,9 @@ export const api = {
     ),
   openInTerminal: (command: string) =>
     run(cmd<void>("open_in_terminal", { command })),
+  /** Start Ollama detached from Alchemy: the Mac app when it's installed,
+   *  else a backgrounded `ollama serve`. Resolves to "app" or "cli". */
+  startOllama: () => run(cmd<string>("start_ollama")),
   /** Apply one settings-tool change from an error-row fix button
    *  (RFC-self-resolve): same allowlist as the chat `settings` tool; the
    *  returned Message is the tool row echoed into the transcript. */

--- a/src/lib/noteExport.ts
+++ b/src/lib/noteExport.ts
@@ -37,7 +37,7 @@ const PDF_TARGET: ExportTarget = {
  *  Word document — plus a PDF of the note's own render for everything the
  *  print pipeline covers (audio stays audio). */
 export function exportTargets(n: Note): ExportTarget[] {
-  if (n.kind === "infographic" || n.kind === "mind_map")
+  if (n.kind === "infographic" || n.kind === "mind_map" || n.kind === "uml")
     return [
       { label: "Export PNG", format: "png", ext: "png", name: "PNG image" },
       PDF_TARGET,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -214,6 +214,7 @@ export type NoteKind =
   | "quiz"
   | "audio_overview"
   | "mind_map"
+  | "uml"
   | "slide_deck"
   | "infographic"
   | "data_table"


### PR DESCRIPTION
Works through the Alchemy Reminders list, plus the `::highlight` build warning.

## UML diagram

New `uml` artifact kind. The generator emits Mermaid; `UmlDiagram.tsx` renders class / sequence / state / ER / component views on the pan-zoom canvas `MindMap` already had, with a type chip and a source toggle.

This breaks RFC-artifact-renderers' "never ask a model for Mermaid" rule on purpose — five UML grammars mean five layout engines, which is a project rather than a renderer. The contract that rule protects (an artifact never arrives broken) is kept another way: a diagram that won't parse shows its source with mermaid's own error, so a near-miss is a hand-fix instead of a Rebuild. Written up as an addendum to that RFC.

## Update notice

The quiet startup check already set `updateAvailable`, then only spoke through a toast that scrolls away. `UpdateBadge` sits right of the DEV chip and stays; the Settings check now clears it too, so the notice can't outlive the update.

## Bugs

- **"linked from n" dropdown opened at the window origin.** The text link clicked a `display:none` RowMenu trigger from a sibling, and a hidden button measures 0×0. The link is the real trigger now, and RowMenu falls back to its container if a trigger ever measures zero again.
- **Start Ollama killed the app.** It drove Terminal over AppleScript, and a build with no `Info.plist` — every `tauri dev` binary — is terminated by TCC the moment it sends an Apple Event. `start_ollama` uses the Mac app via LaunchServices, else a backgrounded `ollama serve` that outlives Alchemy and leaves no zombie.
- **Hover cards painted behind the reader's live web view.** That view is a native child webview and sits above every HTML layer, so z-index cannot win. Floating overlays carry `data-overlay` and the live view hides for them, as it already did for dialogs.
- **The reports tab couldn't be collapsed with no reports.** The collapse button lived only inside `ReportsFeed`, which an empty feed never renders.
- **Apple Stocks showed its markdown table as raw pipes.** `mac.rs` emits proper GFM; the reader's markdown-shaped check just didn't include `mac` sources. Reminders keeps its checkbox view ahead of this.
- **`::highlight()` warned three times per release build.** lightningcss 1.32 doesn't know the pseudo-element; pinned to ^1.33, which parses it.

## Verification

Run in the dev app: stocks table, linked-from anchoring, the UML viewer, `start_ollama` (returns `app`, no crash), and the UML generator in Studio.

Gates green: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (383 passed), `pnpm build` (no CSS warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)