### PR TITLE
Make the slow tests opt-in: cargo test 36s -> 8s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,13 @@ jobs:
         # The crate has no Rust integration-test files or binary tests; all
         # executable coverage lives in the library test harness. Avoid
         # linking an empty second harness and running empty doc-tests.
+        #
+        # ALCHEMY_EVALS: the corpus evals skip themselves unless asked, so a
+        # local `cargo test` stays fast (36s -> 12s) and quiet. CI is exactly
+        # where the retrieval numbers need watching, so it always asks.
+        # ALCHEMY_OLLAMA_TESTS stays unset: no model server here.
+        env:
+          ALCHEMY_EVALS: 1
         run: cargo test --lib
 
       # Wall-clock budgets (docs/RFC-professional-grade.md Pillar 2), run

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,10 +25,28 @@ Tests and evals:
 
 ```bash
 cargo test --lib <name> -- --nocapture           # single test
-cargo test --lib evals -- --nocapture            # retrieval-quality eval (built-in embedder, CI-safe)
 cargo test --lib evals -- --ignored --nocapture  # distill/rerank evals — need live Ollama
-cargo test --lib rag_round_trip -- --nocapture   # e2e data path — no-ops if Ollama isn't running
 ```
+
+**Slow work is opt-in.** A plain `cargo test` runs the 367 correctness tests
+and nothing else: ~12s, no model calls, no corpus embedding. Two env flags buy
+back the rest.
+
+| flag | what it turns on | cost |
+| --- | --- | --- |
+| `ALCHEMY_EVALS=1` | the corpus evals (`evals::`, `retrieval_eval::`) — fixture corpora embedded through the built-in embedder | +23s, CPU-bound |
+| `ALCHEMY_OLLAMA_TESTS=1` | anything that calls a live model (`rag_round_trip`, the LLM half of `eval_deep_rerank`) | model-speed |
+
+```bash
+ALCHEMY_EVALS=1 cargo test --lib -- --nocapture                         # retrieval quality
+ALCHEMY_OLLAMA_TESTS=1 cargo test --lib rag_round_trip -- --nocapture   # e2e data path
+```
+
+Both default off because both used to fire on their own: the evals on every
+run, and the Ollama tests whenever the port happened to answer — which on a
+developer machine is always. Reachability isn't consent, and measurement
+isn't correctness. CI sets `ALCHEMY_EVALS=1` (see `.github/workflows/ci.yml`),
+so the retrieval numbers are still watched where it matters.
 
 To exercise anything the OS has to know about — the `alchemy://` scheme,
 file associations, the Dock menu, Services — build a real bundle, not

--- a/src-tauri/src/evals.rs
+++ b/src-tauri/src/evals.rs
@@ -175,6 +175,58 @@ const GOLDEN: &[Golden] = &[
     },
 ];
 
+/// Do the corpus evals get to run?
+///
+/// The eval suite seeds fixture corpora and embeds every document through the
+/// built-in embedder — real work, and the bulk of `cargo test`'s wall clock
+/// and CPU (roughly 23s of a 36s run, with the fans to match). It measures
+/// retrieval quality rather than guarding correctness, so it does not need to
+/// run on every local edit. CI sets `ALCHEMY_EVALS=1`, which is where the
+/// numbers actually need watching.
+///
+///   ALCHEMY_EVALS=1 cargo test --lib -- --nocapture
+pub(crate) fn evals_enabled() -> bool {
+    flag_set("ALCHEMY_EVALS")
+}
+
+/// Do the Ollama-backed tests get to run?
+///
+/// A handful of tests reach for a live Ollama *whenever one happens to be
+/// listening* rather than when someone asked for a model run. On any machine
+/// with Ollama up — which is most developer machines — that quietly turns a
+/// fast deterministic `cargo test` into a minutes-long model sweep with the
+/// fans on. Reachability is not consent, so it takes an explicit opt-in:
+///
+///   ALCHEMY_OLLAMA_TESTS=1 cargo test --lib -- --nocapture
+///
+/// Unset (or `0`/`false`/empty), those tests report their deterministic half
+/// and skip the model calls.
+pub(crate) fn ollama_tests_enabled() -> bool {
+    flag_set("ALCHEMY_OLLAMA_TESTS")
+}
+
+/// Truthy-env test shared by the opt-in gates: set and not `0`/`false`.
+fn flag_set(name: &str) -> bool {
+    match std::env::var(name) {
+        Ok(v) => {
+            let v = v.trim();
+            !v.is_empty() && v != "0" && !v.eq_ignore_ascii_case("false")
+        }
+        Err(_) => false,
+    }
+}
+
+/// The embedder for a corpus eval: `builtin_ai`, behind [`evals_enabled`].
+/// The `#[ignore]`d evals call `builtin_ai` directly — `--ignored` is already
+/// an explicit ask, and gating those twice would make them silently no-op.
+pub(crate) async fn eval_ai() -> Option<Ai> {
+    if !evals_enabled() {
+        eprintln!("SKIP: set ALCHEMY_EVALS=1 to run the corpus evals");
+        return None;
+    }
+    builtin_ai().await
+}
+
 pub(crate) async fn builtin_ai() -> Option<Ai> {
     let ai = Ai::new(
         AiConfig {
@@ -259,7 +311,7 @@ fn hit(citations: &[Citation], expect: &str) -> bool {
 /// gives us the vector-only baseline through the exact same code path.
 #[tokio::test]
 async fn eval_retrieval_recall() {
-    let Some(ai) = builtin_ai().await else { return };
+    let Some(ai) = eval_ai().await else { return };
     let dir = std::env::temp_dir().join(format!("nbl-eval-{}", uuid::Uuid::new_v4()));
     let db = Db::open(&dir).await.expect("open db");
     let nb = "eval-nb";

--- a/src-tauri/src/retrieval_eval.rs
+++ b/src-tauri/src/retrieval_eval.rs
@@ -17,7 +17,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 use crate::db::{Db, SearchOptions};
-use crate::evals::{builtin_ai, seed_corpus, seed_docs, CORPUS};
+use crate::evals::{builtin_ai, eval_ai, seed_corpus, seed_docs, CORPUS};
 use crate::models::Citation;
 
 /// Retrieval depth for all metrics; recall is additionally reported at 5.
@@ -263,7 +263,7 @@ fn mean(rows: &[(String, Metrics)], kind: Option<&str>) -> Metrics {
 /// skips BM25), FTS-only, and the production hybrid RRF.
 #[tokio::test]
 async fn eval_retrieval_datasets() {
-    let Some(ai) = builtin_ai().await else { return };
+    let Some(ai) = eval_ai().await else { return };
     let datasets = load_datasets();
     assert!(!datasets.is_empty(), "no datasets in evals/datasets/");
 
@@ -556,7 +556,7 @@ const META_GOLDEN: &[MetaGolden] = &[
 /// distinct sources/notebooks in the top-k.
 #[tokio::test]
 async fn eval_meta_diversity() {
-    let Some(ai) = builtin_ai().await else { return };
+    let Some(ai) = eval_ai().await else { return };
     let dir = std::env::temp_dir().join(format!("nbl-eval-meta-{}", uuid::Uuid::new_v4()));
     let db = Db::open(&dir).await.expect("open db");
     seed_docs(&ai, &db, "meta-a", DOMINATOR, "dom-").await;
@@ -660,11 +660,11 @@ async fn eval_meta_diversity() {
 /// Deep-search eval. Deterministic part: how much recall headroom a wide
 /// pool gives a reranker (recall@4 in fusion order vs recall within the
 /// 16-candidate pool — the ceiling a perfect reranker reaches). Ollama-gated
-/// part: run the real rerank over the pool and score it against fusion
-/// order at the same cutoff.
+/// part (`ALCHEMY_OLLAMA_TESTS=1`): run the real rerank over the pool and
+/// score it against fusion order at the same cutoff.
 #[tokio::test]
 async fn eval_deep_rerank() {
-    let Some(ai) = builtin_ai().await else { return };
+    let Some(ai) = eval_ai().await else { return };
     let dir = std::env::temp_dir().join(format!("nbl-eval-deep-{}", uuid::Uuid::new_v4()));
     let db = Db::open(&dir).await.expect("open db");
     let nb = "eval-nb";
@@ -687,9 +687,15 @@ async fn eval_deep_rerank() {
         },
         crate::ai::AiRuntime::default(),
     );
-    let ollama_up = chat.list_models().await.is_ok();
+    // Opt-in, not opportunistic: the rerank half is a per-query model call
+    // over every dataset, and firing it just because Ollama is listening made
+    // this the slowest test in the suite on any machine with Ollama up.
+    let ollama_up = crate::evals::ollama_tests_enabled() && chat.list_models().await.is_ok();
     if !ollama_up {
-        eprintln!("NOTE: Ollama not reachable — reporting deterministic headroom only");
+        eprintln!(
+            "NOTE: reporting deterministic headroom only — \
+             set ALCHEMY_OLLAMA_TESTS=1 (with Ollama running) for the LLM rerank half"
+        );
     }
 
     let mut n = 0usize;
@@ -762,7 +768,7 @@ async fn eval_deep_rerank() {
 /// (top-2 notebooks) against flat.
 #[tokio::test]
 async fn eval_router() {
-    let Some(ai) = builtin_ai().await else { return };
+    let Some(ai) = eval_ai().await else { return };
     let dir = std::env::temp_dir().join(format!("nbl-eval-router-{}", uuid::Uuid::new_v4()));
     let db = Db::open(&dir).await.expect("open db");
     let notebooks = [
@@ -890,7 +896,7 @@ async fn eval_router() {
 /// on retention: the k=4 profile must keep ≥75% of k=8's hits.
 #[tokio::test]
 async fn eval_context_profiles() {
-    let Some(ai) = builtin_ai().await else { return };
+    let Some(ai) = eval_ai().await else { return };
     let datasets = load_datasets();
     assert!(!datasets.is_empty(), "no datasets in evals/datasets/");
 
@@ -1083,7 +1089,7 @@ async fn seed_gist(ai: &crate::ai::Ai, db: &Db, notebook_id: &str, title: &str, 
 /// title-filling pass this RFC required.
 #[tokio::test]
 async fn eval_gist_rows() {
-    let Some(ai) = builtin_ai().await else { return };
+    let Some(ai) = eval_ai().await else { return };
     let dir = std::env::temp_dir().join(format!("nbl-eval-gist-{}", uuid::Uuid::new_v4()));
     let db = Db::open(&dir).await.expect("open db");
     seed_docs(&ai, &db, "gist-a", CORPUS, "a-").await;
@@ -1191,7 +1197,7 @@ async fn eval_gist_rows() {
 
 #[tokio::test]
 async fn eval_enrichment_reembed() {
-    let Some(ai) = builtin_ai().await else { return };
+    let Some(ai) = eval_ai().await else { return };
     let dir = std::env::temp_dir().join(format!("nbl-eval-enrich-{}", uuid::Uuid::new_v4()));
     let db = Db::open(&dir).await.expect("open db");
     let nb = "enrich-nb";
@@ -1480,7 +1486,7 @@ const GLOBAL_CASES: &[GlobalCase] = &[
 /// gists), so a failure is a selection regression, not flakiness.
 #[tokio::test]
 async fn eval_global_source_selection() {
-    let Some(ai) = builtin_ai().await else { return };
+    let Some(ai) = eval_ai().await else { return };
     let dir = std::env::temp_dir().join(format!("nbl-eval-global-{}", uuid::Uuid::new_v4()));
     let db = Db::open(&dir).await.expect("open db");
     seed_docs(&ai, &db, "glob-net", GLOBAL_NET, "gn-").await;
@@ -2004,7 +2010,7 @@ async fn eval_scale_fence_10m() {
 /// the app with ALCHEMY_TIMING=1. No absolute-time assertions: machines vary.
 #[tokio::test]
 async fn eval_retrieval_latency() {
-    let Some(ai) = builtin_ai().await else { return };
+    let Some(ai) = eval_ai().await else { return };
     let dir = std::env::temp_dir().join(format!("nbl-eval-lat-{}", uuid::Uuid::new_v4()));
     let db = Db::open(&dir).await.expect("open db");
     let nb = "lat-nb";

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -1,8 +1,12 @@
 //! End-to-end data-path test: ingest → embed → LanceDB write → vector search →
-//! grounded chat. Requires a running Ollama with `nomic-embed-text`. If Ollama
-//! isn't reachable the test no-ops so it never fails CI without a model server.
+//! grounded chat. Requires a running Ollama with `nomic-embed-text`.
 //!
-//! Run with:  cargo test --lib rag_round_trip -- --nocapture
+//! Opt-in. It used to run whenever Ollama happened to be listening, which on a
+//! developer machine is always — a full embed-and-chat round trip on every
+//! plain `cargo test`. It no-ops without the flag, so CI stays green with no
+//! model server and a local run stays fast:
+//!
+//!   ALCHEMY_OLLAMA_TESTS=1 cargo test --lib rag_round_trip -- --nocapture
 
 use crate::ai::{Ollama, OllamaConfig};
 use crate::db::Db;
@@ -24,6 +28,10 @@ async fn rag_round_trip() {
         vision_model: String::new(),
         effort: String::new(),
     });
+    if !crate::evals::ollama_tests_enabled() {
+        eprintln!("SKIP: set ALCHEMY_OLLAMA_TESTS=1 to run the Ollama round trip");
+        return;
+    }
     if ai.list_models().await.is_err() {
         eprintln!("SKIP: Ollama not reachable on localhost:11434");
         return;


### PR DESCRIPTION
Follow-up to #15 (which merged before this landed, so it gets its own PR).

Two kinds of work ran on every `cargo test` without anyone asking for it.

**The corpus evals** seed fixture corpora and embed every document through the built-in embedder — ~23s of a 36s run, CPU-bound, fans up. They measure retrieval quality rather than guarding correctness, so they don't belong in the loop you run after every edit. Every default-on eval already funnelled through `builtin_ai()`, so the gate went in at that one point: `eval_ai()` wraps it behind `ALCHEMY_EVALS`. The five `#[ignore]`d evals still call `builtin_ai()` directly — `--ignored` is already an explicit ask, and gating them twice would make `cargo test -- --ignored` silently no-op.

**The Ollama tests** were worse: they reached for a live model whenever the port happened to answer, which on a developer machine is always. `rag_round_trip` ran a full embed-and-chat round trip (13.2s), and `eval_deep_rerank` fired a per-query LLM rerank across every dataset. Both now take `ALCHEMY_OLLAMA_TESTS`. Reachability isn't consent.

| run | harness time |
| --- | --- |
| `cargo test` (367 correctness tests, no model calls) | **7.8s** |
| `ALCHEMY_EVALS=1 cargo test` | 32s |
| before | 36s |

## CI keeps the coverage

`.github/workflows/ci.yml` sets `ALCHEMY_EVALS: 1` on the Rust tests step, so the retrieval numbers are still watched where that matters. `ALCHEMY_OLLAMA_TESTS` stays unset — the runner has no model server.

## Verification

Checked both directions rather than trusting the skip:

- `ALCHEMY_EVALS=1 cargo test --lib eval_retrieval_recall -- --nocapture` still prints its recall table (genuinely runs, not a green skip).
- `ALCHEMY_EVALS=0 cargo test --lib eval_scale_fence -- --ignored` still runs and prints its fence numbers — no double-gate.
- `ALCHEMY_OLLAMA_TESTS=1 cargo test --lib rag_round_trip` 13.2s vs 0.28s skipped.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib` (383 passed) all green.

## Not included

`fidelity::` still runs by default (~5s of the 7.8s) — hostile-corpus ingest and citation round-trips, real PDF rendering. Those are correctness tests, not measurement, so they stayed in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)