### PR TITLE
Put a real number in the cost column, or leave it honestly at zero

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1787,7 +1787,7 @@
         <div class="feature-copy">
           <div class="feature-kicker">Studio</div>
           <h3>Create documents, decks, quizzes, and podcasts.</h3>
-          <p>Turn current notebook sources into editable documents, 16:9 decks, quizzes, mind maps, tables, or a narrated Audio Overview—without exporting your context first.</p>
+          <p>Turn current notebook sources into editable documents, 16:9 decks, quizzes, mind maps, UML diagrams, infographics, tables, or a narrated Audio Overview—without exporting your context first.</p>
           <div class="card-meta"><span>Editable output</span><span>Native PDF export</span></div>
         </div>
       </article>
@@ -1825,8 +1825,8 @@
         <div class="feature-copy">
           <div class="feature-kicker">Privacy</div>
           <h3>Your library stays on your Mac.</h3>
-          <p>Sources are extracted, embedded, and stored on your Mac. You choose what chat context reaches a provider; Ollama and Apple’s on-device model keep chat offline.</p>
-          <div class="card-meta"><span>No account</span><span>Offline with local models</span></div>
+          <p>Sources are extracted, embedded, and stored on your Mac. You choose what chat context reaches a provider; Ollama and Apple’s on-device model keep chat offline. Alchemy copies the whole library every night and keeps a week of copies plus four weekly ones, so a bad day is something you restore from rather than recover from.</p>
+          <div class="card-meta"><span>No account</span><span>Offline with local models</span><span>Nightly backups</span></div>
         </div>
       </article>
 
@@ -2028,14 +2028,14 @@
           <div class="staff-copy">
             <div class="staff-head"><span>Night Shift</span><span>On</span></div>
             <h3>Let Night Shift run the routine work.</h3>
-            <p>Keep scheduled refreshes moving from the menu bar.</p>
+            <p>Sources refresh while you sleep, and a page that changed overnight is weighed against the conclusions you already recorded.</p>
           </div>
           <div class="activity-track">
             <div class="activity-event"><span>Sources refreshed</span><time>02:18</time></div>
-            <div class="activity-event is-current"><span>Reports ready</span><time>Now</time></div>
+            <div class="activity-event is-current"><span>Contradiction found</span><time>03:40</time></div>
             <div class="activity-event"><span>Next check</span><time>07:00</time></div>
           </div>
-          <div class="staff-foot"><span>Review it, pause it, or run it now.</span><span>Local</span></div>
+          <div class="staff-foot"><span>One dial: Light, Standard, or Generous.</span><span>Local</span></div>
         </div>
       </article>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1835,7 +1835,7 @@
           <div class="feature-kicker">Benchmarks</div>
           <h3>Search, benchmarked.</h3>
           <p>Alchemy&rsquo;s search is tested against public BEIR benchmarks. The built-in engine scores 0.737 on SciFact, higher than BM25 (0.665) and TAS-B (0.643), with everything running on your Mac.</p>
-          <div class="card-meta"><span>nDCG@10, higher is better</span><span>Run them yourself: cargo test --lib beir_</span></div>
+          <div class="card-meta"><span>nDCG@10, higher is better</span><span>Run them yourself: BEIR_XENC=small cargo test --lib beir_ -- --ignored</span></div>
         </div>
         <div class="bench-rows" aria-label="BEIR benchmark results">
           <div class="bench-cell">

--- a/docs/index.html
+++ b/docs/index.html
@@ -1834,24 +1834,24 @@
         <div class="feature-copy">
           <div class="feature-kicker">Benchmarks</div>
           <h3>Search, benchmarked.</h3>
-          <p>Alchemy&rsquo;s search is tested against public BEIR benchmarks. The built-in engine scores 0.737 on SciFact, higher than BM25 (0.665) and TAS-B (0.643), with everything running on your Mac.</p>
+          <p>Alchemy&rsquo;s search is tested against public BEIR benchmarks. The built-in engine scores 0.737 on SciFact, higher than BM25 (0.665) and TAS-B (0.643), with everything running on your Mac. That figure includes an on-device reranking pass. Ollama embeddings score higher without one — reranking a stronger set of results makes them worse — so each row quotes the setting that wins for it.</p>
           <div class="card-meta"><span>nDCG@10, higher is better</span><span>Run them yourself: BEIR_XENC=small cargo test --lib beir_ -- --ignored</span></div>
         </div>
         <div class="bench-rows" aria-label="BEIR benchmark results">
           <div class="bench-cell">
             <div class="bench-name">BEIR SciFact</div>
             <div class="bench-score">0.737</div>
-            <div class="bench-note">0.754 with Ollama · BM25 0.665</div>
+            <div class="bench-note">0.754 with Ollama, fusion only · BM25 0.665</div>
           </div>
           <div class="bench-cell">
             <div class="bench-name">BEIR NFCorpus</div>
             <div class="bench-score">0.352</div>
-            <div class="bench-note">0.388 with Ollama · BM25 0.325</div>
+            <div class="bench-note">0.388 with Ollama, fusion only · BM25 0.325</div>
           </div>
           <div class="bench-cell">
             <div class="bench-name">BEIR FiQA</div>
             <div class="bench-score">0.318</div>
-            <div class="bench-note">0.429 with Ollama · BM25 0.236</div>
+            <div class="bench-note">0.429 with Ollama, fusion only · BM25 0.236</div>
           </div>
         </div>
       </article>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1850,7 +1850,7 @@
           </div>
           <div class="bench-cell">
             <div class="bench-name">BEIR FiQA</div>
-            <div class="bench-score">0.322</div>
+            <div class="bench-score">0.318</div>
             <div class="bench-note">0.429 with Ollama · BM25 0.236</div>
           </div>
         </div>

--- a/src-tauri/src/beir_eval.rs
+++ b/src-tauri/src/beir_eval.rs
@@ -203,16 +203,34 @@ async fn nomic_ai() -> Option<Ai> {
 
 /// Built-in embedder + a small live chat model for the rerank leg.
 pub(crate) async fn rerank_ai() -> Option<Ai> {
+    // The repo's fast-local pick (tests.rs uses it for chat steps).
+    const MODEL: &str = "digitsflow/bonsai-8b:latest";
     let ai = Ai::new(
         AiConfig {
             embedder: "builtin".into(),
-            // The repo's fast-local pick (tests.rs uses it for chat steps).
-            chat_model: "digitsflow/bonsai-8b:latest".into(),
+            chat_model: MODEL.into(),
             ..Default::default()
         },
         AiRuntime::default(),
     );
-    ai.test_embed().await.ok()?;
+    // Probe the chat model, which is the thing a reranker actually needs.
+    // This used to call `test_embed`, which exercises the *built-in*
+    // embedder and therefore succeeded with Ollama stopped - so the caller
+    // got a reranker that could not rerank, every query failed quietly, and
+    // the run finished green having measured nothing.
+    if let Err(err) = ai
+        .chat(&[crate::ai::ChatTurn {
+            role: "user".into(),
+            content: "ok".into(),
+        }])
+        .await
+    {
+        eprintln!(
+            "SKIP: rerank leg needs Ollama serving {MODEL} — {err}\n\
+             \x20     start Ollama (`ollama serve`) and `ollama pull {MODEL}`, then rerun"
+        );
+        return None;
+    }
     Some(ai)
 }
 
@@ -792,10 +810,20 @@ async fn run_beir(
         vec_ndcg: vec_sum / n as f64,
         fts_ndcg: fts_sum / n as f64,
         sweep,
+        // A rerank that was asked for and produced nothing is a failed
+        // measurement, not an absent one - and it used to be reported the
+        // same way as "no rerank requested": by omitting the line.
         rerank: (rr_n > 0).then_some((rr_n, rr_sum / rr_n as f64)),
         docs: seeded_docs,
         queries: n,
     };
+    if rerank_with.is_some() && rr_n == 0 {
+        eprintln!(
+            "WARNING {name}: a rerank was requested but every call failed — \
+             the numbers below are the un-reranked pipeline. Check Ollama is \
+             serving the rerank model."
+        );
+    }
     let sweep_line = run
         .sweep
         .iter()
@@ -941,15 +969,30 @@ async fn beir_nomic_prefixed() {
 async fn beir_rerank_all() {
     let Some(ai) = builtin_ai().await else { return };
     let Some(rr) = rerank_ai().await else { return };
+    // BEIR_RERANK_DATASETS narrows the run ("scifact"), the same targeted
+    // probe BEIR_NANO_DATASETS gives the Nano sweep. Re-measuring one
+    // headline number should not cost the other two.
+    let only = std::env::var("BEIR_RERANK_DATASETS").unwrap_or_default();
     for name in ["scifact", "nfcorpus", "fiqa"] {
-        run_beir(
+        if !only.is_empty() && !only.split(',').any(|d| d.trim() == name) {
+            continue;
+        }
+        // A dataset that yields nothing used to print nothing at all, so a
+        // run that silently dropped one looked exactly like a run that
+        // covered everything - which is how scifact went missing from a
+        // 44-minute sweep without a word.
+        if run_beir(
             name,
             &ai,
             Some((&rr, RerankStrategy::Listwise)),
             EmbedStyle::default(),
             "builtin",
         )
-        .await;
+        .await
+        .is_none()
+        {
+            eprintln!("SKIPPED {name}: produced no run — see the reason above");
+        }
     }
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -10027,7 +10027,19 @@ pub async fn activity_stats(
     let titles: std::collections::HashMap<String, String> =
         all_notebooks.into_iter().map(|n| (n.id, n.title)).collect();
     let retrievals = crate::activity::trace_times(&state.trace_dir);
-    Ok(crate::activity::aggregate(
+    // What the background actually cost, read back off the receipts rather
+    // than tallied separately, so the figure cannot drift from the record.
+    // The receipts table is a rolling 30-day window, so this is a recent
+    // total and the caption says so.
+    let background_cost_micros: i64 = state
+        .db
+        .list_receipts(0, usize::MAX)
+        .await
+        .unwrap_or_default()
+        .iter()
+        .map(|r| r.cost_micros)
+        .sum();
+    let mut stats = crate::activity::aggregate(
         &messages,
         &notes,
         &sources,
@@ -10035,7 +10047,9 @@ pub async fn activity_stats(
         &ranked_out,
         &retrievals,
         chrono::Local::now().date_naive(),
-    ))
+    );
+    stats.background_cost_micros = background_cost_micros;
+    Ok(stats)
 }
 
 // ---- OKF export ------------------------------------------------------------

--- a/src-tauri/src/freshness.rs
+++ b/src-tauri/src/freshness.rs
@@ -68,6 +68,56 @@ pub fn record_spend(tokens: i64) {
     SPENT_TONIGHT.fetch_add(tokens.max(0), Ordering::Relaxed);
 }
 
+tokio::task_local! {
+    /// Money spent by the run executing in this task, in micro-dollars.
+    ///
+    /// Task-scoped rather than global on purpose. Reports, the nightly Weave
+    /// and the gist sweep each run under their own single-flight guard and
+    /// can overlap, so a process-wide counter would bill one job for
+    /// another's spend - and a receipt asserting a cost that was not this
+    /// run's is the same class of lie as the "overdue by 34h" badge. A task
+    /// cannot run concurrently with itself, so this attributes exactly.
+    ///
+    /// Unset everywhere it has not been armed, which is what keeps a
+    /// foreground Studio generation - a user waiting at the keyboard - from
+    /// being charged to any run at all.
+    static RUN_COST_MICROS: AtomicI64;
+}
+
+/// Run `fut` as a metered unit, returning its output and what it spent.
+///
+/// Only engines that report a price move the number: local models are
+/// genuinely free and say 0. A generation that spawns its own task escapes
+/// the scope and is undercounted, which is the safe direction to be wrong -
+/// a receipt that understates is recoverable from the provider's own
+/// billing, one that overstates is not.
+pub async fn metered_run<F, T>(fut: F) -> (T, i64)
+where
+    F: std::future::Future<Output = T>,
+{
+    RUN_COST_MICROS
+        .scope(AtomicI64::new(0), async move {
+            let out = fut.await;
+            let spent = RUN_COST_MICROS.with(|c| c.load(Ordering::Relaxed));
+            (out, spent)
+        })
+        .await
+}
+
+/// Attribute one generation's price to the metered run, if any is armed.
+///
+/// Dollars arrive as f64 from the provider and are stored as integer
+/// micro-dollars: money in floats accumulates error, and a receipt is a
+/// record rather than an estimate. Nothing to do when no run is armed.
+pub fn record_cost(cost_usd: Option<f64>) {
+    let Some(usd) = cost_usd else { return };
+    if !usd.is_finite() || usd <= 0.0 {
+        return;
+    }
+    let micros = (usd * 1_000_000.0).round() as i64;
+    let _ = RUN_COST_MICROS.try_with(|c| c.fetch_add(micros, Ordering::Relaxed));
+}
+
 /// Fold one background generation's token count into tonight's spend.
 /// Only background work is metered here: a user waiting at the keyboard is
 /// not spending the night's budget.
@@ -75,6 +125,7 @@ pub fn record_outcome(out: &crate::inference::ChatOutcome) {
     if let Some(stats) = out.stats.as_ref() {
         record_spend(stats.eval_count as i64);
     }
+    record_cost(out.cost_usd);
 }
 
 pub fn spent_tonight() -> i64 {
@@ -286,5 +337,50 @@ mod tests {
         // A negative report cannot claw budget back.
         record_spend(-500_000);
         assert_eq!(spent_tonight(), 1_050_000);
+    }
+
+    /// A run is billed for its own generations and no one else's. The whole
+    /// reason this is task-scoped: reports, the Weave and the gist sweep
+    /// overlap, and a receipt naming another job's spend would be a lie
+    /// stated as a measurement.
+    #[tokio::test]
+    async fn concurrent_runs_do_not_bill_each_other() {
+        let a = metered_run(async {
+            record_cost(Some(1.50));
+            tokio::task::yield_now().await;
+            record_cost(Some(0.25));
+        });
+        let b = metered_run(async {
+            record_cost(Some(0.10));
+            tokio::task::yield_now().await;
+        });
+        let ((), a_cost) = a.await;
+        let ((), b_cost) = b.await;
+        assert_eq!(a_cost, 1_750_000, "1.50 + 0.25 in micro-dollars");
+        assert_eq!(b_cost, 100_000, "0.10 in micro-dollars");
+    }
+
+    /// Foreground work is charged to nobody. `record_cost` outside a metered
+    /// run must be a no-op rather than a panic or a stray global.
+    #[tokio::test]
+    async fn spend_outside_a_run_is_attributed_nowhere() {
+        record_cost(Some(9.99));
+        let ((), cost) = metered_run(async {}).await;
+        assert_eq!(cost, 0, "an unarmed generation bills no run");
+    }
+
+    /// Local models are free and must say 0, not an invented figure. Junk
+    /// from a provider is refused for the same reason.
+    #[tokio::test]
+    async fn unpriced_and_nonsense_costs_are_ignored() {
+        let ((), cost) = metered_run(async {
+            record_cost(None);
+            record_cost(Some(0.0));
+            record_cost(Some(-5.0));
+            record_cost(Some(f64::NAN));
+            record_cost(Some(f64::INFINITY));
+        })
+        .await;
+        assert_eq!(cost, 0, "only a real, positive price counts");
     }
 }

--- a/src-tauri/src/inference/mod.rs
+++ b/src-tauri/src/inference/mod.rs
@@ -250,6 +250,25 @@ pub enum ChatEngine {
     Agent(AgentCli),
 }
 
+/// Attribute a finished generation's price to the metered run it belongs to,
+/// then hand the outcome straight back.
+///
+/// Placed on `ChatEngine` rather than on `Ai`, because `Ai`'s methods are not
+/// the only way in: the provider-override branches of artifact generation
+/// hold a `ChatEngine` and call it directly, and those are precisely the runs
+/// that cost money - an agent CLI is the only engine that reports a price at
+/// all. Metering the engine means a new caller cannot route around it, and
+/// means it is counted exactly once.
+///
+/// `record_cost` is a no-op unless a run is armed (`freshness::metered_run`),
+/// so a user waiting at the keyboard is charged to nothing.
+fn metered(out: Result<ChatOutcome>) -> Result<ChatOutcome> {
+    if let Ok(o) = out.as_ref() {
+        crate::freshness::record_cost(o.cost_usd);
+    }
+    out
+}
+
 impl ChatEngine {
     /// Stable identifier for stats keying and provider attribution (used by
     /// the availability probes when the preference ladder lands).
@@ -268,12 +287,12 @@ impl ChatEngine {
     where
         F: FnMut(&str),
     {
-        match self {
+        metered(match self {
             ChatEngine::Ollama(o) => o.chat_stream(messages, on_token).await,
             ChatEngine::Gateway(g) => g.chat_stream(messages, on_token).await,
             ChatEngine::FoundationModels(f) => f.chat_stream(messages, on_token).await,
             ChatEngine::Agent(a) => a.chat_stream(messages, on_token).await,
-        }
+        })
     }
 
     /// Streaming with progress: only agent CLIs have anything to narrate
@@ -289,18 +308,21 @@ impl ChatEngine {
         S: FnMut(Step<'_>),
     {
         match self {
-            ChatEngine::Agent(a) => a.chat_stream_steps(messages, on_token, on_step).await,
+            // The delegating arm is metered by `chat_stream` itself; only the
+            // agent path needs its own call, and agent CLIs are the engines
+            // that actually report a price.
+            ChatEngine::Agent(a) => metered(a.chat_stream_steps(messages, on_token, on_step).await),
             _ => self.chat_stream(messages, on_token).await,
         }
     }
 
     pub async fn chat(&self, messages: &[ChatTurn]) -> Result<ChatOutcome> {
-        match self {
+        metered(match self {
             ChatEngine::Ollama(o) => o.chat(messages).await,
             ChatEngine::Gateway(g) => g.chat(messages).await,
             ChatEngine::FoundationModels(f) => f.chat(messages).await,
             ChatEngine::Agent(a) => a.chat(messages).await,
-        }
+        })
     }
 }
 

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -571,4 +571,10 @@ pub struct ActivityStats {
     pub source_types: Vec<ActivityCount>,
     /// Millis of the earliest recorded activity; 0 for a fresh install.
     pub first_activity_at: i64,
+    /// What background runs cost over the receipts window (30 days), in
+    /// micro-dollars. Background work only - a user at the keyboard is not a
+    /// scheduled job - and 0 when every run was local, because local models
+    /// are free rather than unrecorded.
+    #[serde(default)]
+    pub background_cost_micros: i64,
 }

--- a/src-tauri/src/scheduler.rs
+++ b/src-tauri/src/scheduler.rs
@@ -77,6 +77,7 @@ pub(crate) async fn schedule_receipt(
     started_at: i64,
     note: Option<&crate::models::Note>,
     error: Option<&str>,
+    cost_micros: i64,
 ) -> RunReceipt {
     let (provider, model) = engine_attribution(state).await;
     let mut detail = match (note, error) {
@@ -106,10 +107,10 @@ pub(crate) async fn schedule_receipt(
         note_id: note.map(|n| n.id.clone()).unwrap_or_default(),
         provider,
         model,
-        // Only agent CLIs report a price today; local runs are genuinely
-        // free. Left at zero rather than estimated - an invented number on a
-        // receipt is worse than no number.
-        cost_micros: 0,
+        // Measured for this run alone (crate::freshness::metered_run), never
+        // estimated: only engines that report a price move it, so a local
+        // run is genuinely 0 and says so.
+        cost_micros,
         due_at,
         started_at,
         ended_at: now_ms(),
@@ -566,7 +567,14 @@ async fn run_pass(app: &AppHandle) {
                 let mut finished = 0u32;
                 for (schedule, due_at) in due {
                     let started_at = now_ms();
-                    match commands::run_report_inner(&app, &state, &schedule.id).await {
+                    // Meter the run as a unit so its receipt can state what
+                    // it cost rather than leaving a column that only ever
+                    // reads zero.
+                    let (outcome, cost_micros) = crate::freshness::metered_run(
+                        commands::run_report_inner(&app, &state, &schedule.id),
+                    )
+                    .await;
+                    match outcome {
                         Ok(note) => {
                             finished += 1;
                             let receipt = schedule_receipt(
@@ -576,6 +584,7 @@ async fn run_pass(app: &AppHandle) {
                                 started_at,
                                 Some(&note),
                                 None,
+                                cost_micros,
                             )
                             .await;
                             write_receipt(&state, receipt).await;
@@ -643,6 +652,7 @@ async fn run_pass(app: &AppHandle) {
                                 started_at,
                                 None,
                                 Some(&err),
+                                cost_micros,
                             )
                             .await;
                             write_receipt(&state, receipt).await;

--- a/src/components/settings/ActivityTab.tsx
+++ b/src/components/settings/ActivityTab.tsx
@@ -17,6 +17,7 @@ import {
   Sun,
   Sunrise,
   Sunset,
+  Receipt,
   Trophy,
   type LucideIcon,
 } from "lucide-react";
@@ -67,6 +68,13 @@ function peakHourFace(h: number): LucideIcon {
   if (h < 11) return Sunrise;
   if (h < 17) return Sun;
   return Sunset;
+}
+
+/** Micro-dollars as money. Sub-cent spend rounds to "$0.00" rather than
+ *  being dressed up in extra decimals: the point of the tile is the order of
+ *  magnitude, and a fake precision on a cost is the thing to avoid. */
+function money(micros: number): string {
+  return `$${(Math.max(0, micros) / 1_000_000).toFixed(2)}`;
 }
 
 function Tile({
@@ -495,6 +503,11 @@ export function ActivityTab() {
           value={`${String(stats.longestStreak)}d`}
           icon={Trophy}
         />
+        <Tile
+          label="Background spend"
+          value={money(stats.backgroundCostMicros)}
+          icon={Receipt}
+        />
         {/* The sky IS the value: the sun sits where the hour puts it, or
             stars come out for a night-owl peak. */}
         <Tile
@@ -515,6 +528,12 @@ export function ActivityTab() {
             ) : undefined
           }
         />
+      </div>
+
+      <div className="text-caption text-subtle-foreground">
+        Background spend covers scheduled work over the last 30 days. Local
+        models are free, so it stays at $0.00 unless you point a role at a paid
+        provider.
       </div>
 
       <div className="flex flex-col gap-1.5">

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -311,6 +311,10 @@ export interface ActivityStats {
   notebooks: ActivityCount[];
   sourceTypes: ActivityCount[];
   firstActivityAt: number;
+  /** What background runs cost over the receipts window (30 days), in
+   *  millionths of a dollar. Background work only, and 0 when every run was
+   *  local — local models are free, not unrecorded. */
+  backgroundCostMicros: number;
 }
 
 /** One exact-match window from the `/grep` chat command (Rust grep_sources). */


### PR DESCRIPTION
`RunReceipt.cost_micros` was hardcoded to `0` at both construction sites. The RFC assumed the raw material was to hand; it isn't. Agent CLIs do report `total_cost_usd`, but `run_report_inner` returns a `Note`, so the price is dropped long before the receipt is built. A column that can only ever say 0 isn't "unmetered" — it's noise wearing a measurement's clothes.

Threading cost back through `generate_content`'s return type would touch every caller, so the accounting goes where the generations already pass. `freshness::metered_run` wraps a run in a task-local micro-dollar cell and returns what it spent; the scheduler wraps `run_report_inner` in it and hands the total to `schedule_receipt`.

**Task-local, not global — that's the point.** Reports, the nightly Weave and the gist sweep each have their own single-flight guard and can overlap, so a process-wide counter would bill one job for another's spend. A receipt asserting a cost that wasn't this run's is the same class of lie as the "overdue by 34h" badge. A task never runs concurrently with itself, so attribution is exact. A generation that spawns its own task escapes the scope and is undercounted — the safe direction, since an understatement is recoverable from the provider's billing and an overstatement isn't.

**The meter sits on `ChatEngine`, not `Ai`.** `Ai`'s methods aren't the only way in: the provider-override branches of artifact generation hold a `ChatEngine` and call it directly — and those are exactly the runs that cost money, since an agent CLI is the only engine reporting a price. One level down means a new caller can't route around it, and it's counted once. I had it on `Ai` first, where the doc comment claimed callers couldn't forget it while two already did.

Local models stay at 0 because they're free, not because nothing was recorded. Unpriced, zero, negative and non-finite figures are all refused — a provider returning junk must not become a number on a record. Failed runs carry their cost too.

392 tests, fmt/clippy/`pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)