### PR TITLE
Finish Alchemy Reminders: CLI, navigation, and Home Chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,23 @@ two-host podcast voiced on-device.*
   ```bash
   npx skills add thrashr888/alchemy@alchemy
   ```
+- **Command line** — a thin, zero-dependency `alchemy` client talks to the
+  embedded MCP server in the running app; it does not open a second database
+  or start a headless Alchemy process. From a source checkout, install the
+  command once with `pnpm add --global ./cli`, then add files, URLs, or piped text
+  and search from any directory:
+
+  ```bash
+  alchemy notebooks
+  alchemy add report.pdf https://example.com --notebook "Project Atlas"
+  pbpaste | alchemy add --notebook "Project Atlas" --title "Meeting notes"
+  alchemy search "renewal risk" --notebook "Project Atlas"
+  alchemy search "where did I save the contractor agreement?" --json
+  ```
+
+  An omitted `--notebook` searches across all notebooks. `--json` keeps every
+  command scriptable. The app must be running with MCP enabled; discovery uses
+  its app-data `mcp.json`, with `--mcp-url` / `ALCHEMY_MCP_URL` as overrides.
 - **Periodic reports** — schedule a notebook to refresh its URL sources and generate a
   timestamped report note on an interval; each run sees the previous report and
   calls out what changed since.

--- a/cli/alchemy.mjs
+++ b/cli/alchemy.mjs
@@ -1,0 +1,418 @@
+#!/usr/bin/env node
+
+/**
+ * Thin command-line client for the MCP server embedded in the running app.
+ *
+ * Intentionally no data access or headless app bootstrap lives here: the
+ * Tauri process remains the one owner of Alchemy's database and models.
+ */
+
+import { realpathSync } from "node:fs";
+import { readFile, stat } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { homedir } from "node:os";
+import { basename, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const { version: VERSION } = createRequire(import.meta.url)("./package.json");
+const DEFAULT_MCP_URL = "http://127.0.0.1:41414/mcp";
+
+const HELP = `Alchemy CLI — add to and search the running Alchemy app
+
+Usage:
+  alchemy notebooks [--json]
+  alchemy add <file-or-url>... --notebook <id-or-title> [--title <title>] [--json]
+  alchemy add - --notebook <id-or-title> [--title <title>] [--json]
+  alchemy search <query...> [--notebook <id-or-title>] [--limit <1-20>] [--json]
+
+Commands:
+  notebooks  List notebooks and their ids.
+  add        Add local files, web URLs, or stdin (use - or pipe with no input).
+  search     Search one notebook, or all notebooks when --notebook is omitted.
+
+Connection:
+  The Alchemy app must be running with MCP enabled. The CLI discovers the
+  app through its mcp.json file. Override with --mcp-url or ALCHEMY_MCP_URL.
+
+Install from this checkout:
+  pnpm add --global ./cli
+
+Examples:
+  alchemy notebooks
+  alchemy add report.pdf https://example.com --notebook "Project Atlas"
+  pbpaste | alchemy add --notebook "Project Atlas" --title "Meeting notes"
+  alchemy search "renewal risk" --notebook "Project Atlas"
+  alchemy search "where did I save the contractor agreement?" --json`;
+
+export class CliError extends Error {}
+
+function takeOption(args, longName) {
+  const at = args.indexOf(longName);
+  if (at === -1) return undefined;
+  if (at === args.length - 1 || args[at + 1].startsWith("--")) {
+    throw new CliError(`${longName} needs a value`);
+  }
+  const value = args[at + 1];
+  args.splice(at, 2);
+  if (args.includes(longName)) throw new CliError(`${longName} may only be used once`);
+  return value;
+}
+
+function takeFlag(args, longName) {
+  const found = args.includes(longName);
+  if (!found) return false;
+  args.splice(args.indexOf(longName), 1);
+  if (args.includes(longName)) throw new CliError(`${longName} may only be used once`);
+  return true;
+}
+
+export function parseArgs(argv) {
+  const args = [...argv];
+  if (args.length === 0 || args[0] === "help" || takeFlag(args, "--help")) {
+    return { command: "help" };
+  }
+  if (takeFlag(args, "--version")) return { command: "version" };
+
+  const command = args.shift();
+  const mcpUrl = takeOption(args, "--mcp-url");
+  const json = takeFlag(args, "--json");
+
+  if (command === "notebooks") {
+    if (args.length) throw new CliError(`unexpected argument: ${args[0]}`);
+    return { command, mcpUrl, json };
+  }
+
+  if (command === "add") {
+    const notebook = takeOption(args, "--notebook");
+    const title = takeOption(args, "--title");
+    if (!notebook) throw new CliError("add requires --notebook <id-or-title>");
+    if (args.some((arg) => arg.startsWith("--"))) {
+      throw new CliError(`unknown option: ${args.find((arg) => arg.startsWith("--"))}`);
+    }
+    if (args.filter((arg) => arg === "-").length > 1) {
+      throw new CliError("stdin (-) may only be added once");
+    }
+    if (title && (args.length > 1 || (args.length === 1 && args[0] !== "-"))) {
+      throw new CliError("--title can only be used when adding one stdin source");
+    }
+    return { command, mcpUrl, json, notebook, title, inputs: args };
+  }
+
+  if (command === "search") {
+    const notebook = takeOption(args, "--notebook");
+    const rawLimit = takeOption(args, "--limit");
+    if (args.some((arg) => arg.startsWith("--"))) {
+      throw new CliError(`unknown option: ${args.find((arg) => arg.startsWith("--"))}`);
+    }
+    const query = args.join(" ").trim();
+    if (!query) throw new CliError("search needs a query");
+    let limit;
+    if (rawLimit !== undefined) {
+      limit = Number(rawLimit);
+      if (!Number.isInteger(limit) || limit < 1 || limit > 20) {
+        throw new CliError("--limit must be an integer from 1 to 20");
+      }
+    }
+    return { command, mcpUrl, json, notebook, query, limit };
+  }
+
+  throw new CliError(`unknown command: ${command}`);
+}
+
+export function discoveryPaths(env = process.env, home = homedir(), platform = process.platform) {
+  if (env.ALCHEMY_MCP_DISCOVERY) return [env.ALCHEMY_MCP_DISCOVERY];
+  if (platform === "darwin") {
+    return [`${home}/Library/Application Support/com.thrashr888.alchemy/mcp.json`];
+  }
+  if (platform === "win32") {
+    return env.APPDATA ? [`${env.APPDATA}/com.thrashr888.alchemy/mcp.json`] : [];
+  }
+  return [
+    `${env.XDG_DATA_HOME || `${home}/.local/share`}/com.thrashr888.alchemy/mcp.json`,
+  ];
+}
+
+export async function discoverMcpUrl(explicit, env = process.env) {
+  if (explicit) return validateMcpUrl(explicit, "--mcp-url");
+  if (env.ALCHEMY_MCP_URL) return validateMcpUrl(env.ALCHEMY_MCP_URL, "ALCHEMY_MCP_URL");
+
+  for (const path of discoveryPaths(env)) {
+    try {
+      const info = JSON.parse(await readFile(path, "utf8"));
+      if (typeof info.url === "string") return validateMcpUrl(info.url, path);
+      if (Number.isInteger(info.port)) {
+        return `http://127.0.0.1:${info.port}/mcp`;
+      }
+      throw new CliError(`Alchemy discovery file has no url or port: ${path}`);
+    } catch (error) {
+      if (error?.code === "ENOENT") continue;
+      if (error instanceof CliError) throw error;
+      throw new CliError(`could not read Alchemy discovery file ${path}: ${error.message}`);
+    }
+  }
+  return DEFAULT_MCP_URL;
+}
+
+function validateMcpUrl(value, source) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new CliError(`${source} is not a valid URL: ${value}`);
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new CliError(`${source} must use http or https`);
+  }
+  return url.toString();
+}
+
+async function parseRpcResponse(response, id) {
+  const contentType = response.headers.get("content-type") || "";
+  if (!contentType.includes("text/event-stream")) return response.json();
+
+  const messages = [];
+  let data = [];
+  for (const line of (await response.text()).split(/\r?\n/)) {
+    if (line === "") {
+      if (data.length) {
+        try {
+          messages.push(JSON.parse(data.join("\n")));
+        } catch {
+          // Ignore keep-alives and non-JSON events.
+        }
+        data = [];
+      }
+    } else if (line.startsWith("data:")) {
+      data.push(line.slice(5).trimStart());
+    }
+  }
+  if (data.length) {
+    try {
+      messages.push(JSON.parse(data.join("\n")));
+    } catch {
+      // The useful error below is clearer than a JSON parser error.
+    }
+  }
+  const message = messages.find((candidate) => candidate.id === id);
+  if (!message) throw new CliError("Alchemy returned no matching MCP response");
+  return message;
+}
+
+export class McpClient {
+  constructor(url, fetchImpl = globalThis.fetch) {
+    this.url = url;
+    this.fetch = fetchImpl;
+    this.sessionId = null;
+    this.nextId = 1;
+  }
+
+  async post(body, sessionId = this.sessionId) {
+    const headers = {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+    };
+    if (sessionId) headers["mcp-session-id"] = sessionId;
+    try {
+      return await this.fetch(this.url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      });
+    } catch (error) {
+      throw new CliError(
+        `could not reach Alchemy at ${this.url}; is the app running with MCP enabled? (${error.message})`,
+      );
+    }
+  }
+
+  async initialize() {
+    if (this.sessionId) return;
+    const id = this.nextId++;
+    const response = await this.post(
+      {
+        jsonrpc: "2.0",
+        id,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "alchemy-cli", version: VERSION },
+        },
+      },
+      null,
+    );
+    if (!response.ok) throw new CliError(`Alchemy MCP initialize failed (HTTP ${response.status})`);
+    const message = await parseRpcResponse(response, id);
+    if (message.error) throw new CliError(message.error.message || "Alchemy MCP initialize failed");
+    this.sessionId = response.headers.get("mcp-session-id");
+    if (!this.sessionId) throw new CliError("Alchemy MCP did not create a session");
+    const notification = await this.post({ jsonrpc: "2.0", method: "notifications/initialized" });
+    if (!notification.ok) {
+      throw new CliError(`Alchemy MCP session setup failed (HTTP ${notification.status})`);
+    }
+  }
+
+  async call(tool, argumentsObject = {}) {
+    await this.initialize();
+    const id = this.nextId++;
+    const response = await this.post({
+      jsonrpc: "2.0",
+      id,
+      method: "tools/call",
+      params: { name: tool, arguments: argumentsObject },
+    });
+    if (!response.ok) throw new CliError(`Alchemy MCP request failed (HTTP ${response.status})`);
+    const message = await parseRpcResponse(response, id);
+    if (message.error) throw new CliError(message.error.message || `${tool} failed`);
+    const result = message.result;
+    const text = (result?.content || [])
+      .filter((part) => part.type === "text")
+      .map((part) => part.text)
+      .join("\n");
+    if (result?.isError) throw new CliError(text || `${tool} failed`);
+    if (!text) return result;
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  }
+}
+
+export async function resolveNotebook(client, requested) {
+  const notebooks = await client.call("list_notebooks");
+  if (!Array.isArray(notebooks)) throw new CliError("Alchemy returned an invalid notebook list");
+  const byId = notebooks.find((notebook) => notebook.id === requested);
+  if (byId) return byId;
+  const byTitle = notebooks.filter(
+    (notebook) => notebook.title?.toLocaleLowerCase() === requested.toLocaleLowerCase(),
+  );
+  if (byTitle.length === 1) return byTitle[0];
+  if (byTitle.length > 1) {
+    throw new CliError(`more than one notebook is titled "${requested}"; use its id instead`);
+  }
+  throw new CliError(`no notebook has id or exact title "${requested}"; run 'alchemy notebooks'`);
+}
+
+function isSupportedUrl(input) {
+  try {
+    return ["http:", "https:", "cider:"].includes(new URL(input).protocol);
+  } catch {
+    return false;
+  }
+}
+
+export async function sourceArguments(input, title, stdinText) {
+  if (input === "-") {
+    if (!stdinText?.trim()) throw new CliError("stdin was empty");
+    return { text: stdinText, ...(title ? { title } : {}) };
+  }
+  if (isSupportedUrl(input)) return { url: input };
+  const path = resolve(input);
+  let metadata;
+  try {
+    metadata = await stat(path);
+  } catch (error) {
+    if (error?.code === "ENOENT") throw new CliError(`file not found: ${input}`);
+    throw error;
+  }
+  if (!metadata.isFile()) throw new CliError(`not a file: ${input}`);
+  return { file_path: path };
+}
+
+function printNotebooks(notebooks) {
+  if (!notebooks.length) {
+    console.log("No notebooks.");
+    return;
+  }
+  for (const notebook of notebooks) {
+    const status = notebook.status ? ` [${notebook.status}]` : "";
+    console.log(`${notebook.id}\t${notebook.title}\t${notebook.sourceCount ?? 0} sources${status}`);
+  }
+}
+
+function printAdded(sources) {
+  for (const source of sources) {
+    console.log(`Added ${source.title || "source"}${source.id ? ` (${source.id})` : ""}`);
+  }
+}
+
+function printSearch(results) {
+  if (!Array.isArray(results) || !results.length) {
+    console.log("No matches.");
+    return;
+  }
+  for (const [index, result] of results.entries()) {
+    const notebook = result.notebookTitle ? ` · ${result.notebookTitle}` : "";
+    const title = result.sourceTitle || result.title || "Untitled";
+    const snippet = result.snippet || result.text || "";
+    console.log(`${index + 1}. ${title}${notebook}`);
+    console.log(`   ${String(snippet).replace(/\s+/g, " ").trim()}`);
+    const id = result.sourceId || result.noteId;
+    if (id) console.log(`   ${id}`);
+  }
+}
+
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+export async function run(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.command === "help") {
+    console.log(HELP);
+    return;
+  }
+  if (options.command === "version") {
+    console.log(VERSION);
+    return;
+  }
+
+  const client = new McpClient(await discoverMcpUrl(options.mcpUrl));
+  if (options.command === "notebooks") {
+    const notebooks = await client.call("list_notebooks");
+    options.json ? console.log(JSON.stringify(notebooks, null, 2)) : printNotebooks(notebooks);
+    return;
+  }
+
+  if (options.command === "add") {
+    const notebook = await resolveNotebook(client, options.notebook);
+    const inputs = [...options.inputs];
+    if (!inputs.length) {
+      if (process.stdin.isTTY) throw new CliError("add needs a file, URL, or piped stdin");
+      inputs.push("-");
+    }
+    const needsStdin = inputs.includes("-");
+    const stdinText = needsStdin ? await readStdin() : undefined;
+    const sources = [];
+    for (const input of inputs) {
+      const args = await sourceArguments(input, options.title, stdinText);
+      sources.push(await client.call("add_source", { notebook_id: notebook.id, ...args }));
+    }
+    options.json ? console.log(JSON.stringify(sources, null, 2)) : printAdded(sources);
+    return;
+  }
+
+  const results = options.notebook
+    ? await (async () => {
+        const notebook = await resolveNotebook(client, options.notebook);
+        return client.call("search", {
+          notebook_id: notebook.id,
+          query: options.query,
+          ...(options.limit ? { max_results: options.limit } : {}),
+        });
+      })()
+    : await client.call("ask_everything", { question: options.query });
+  options.json ? console.log(JSON.stringify(results, null, 2)) : printSearch(results);
+}
+
+const isEntrypoint =
+  process.argv[1] && realpathSync(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isEntrypoint) {
+  run().catch((error) => {
+    console.error(`alchemy: ${error.message || error}`);
+    process.exitCode = 1;
+  });
+}

--- a/cli/alchemy.test.mjs
+++ b/cli/alchemy.test.mjs
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  CliError,
+  McpClient,
+  discoverMcpUrl,
+  parseArgs,
+  resolveNotebook,
+  sourceArguments,
+} from "./alchemy.mjs";
+
+test("parses the narrow command surface", () => {
+  assert.deepEqual(parseArgs(["notebooks", "--json"]), {
+    command: "notebooks",
+    mcpUrl: undefined,
+    json: true,
+  });
+  assert.deepEqual(
+    parseArgs(["search", "renewal", "risk", "--notebook", "Atlas", "--limit", "4"]),
+    {
+      command: "search",
+      mcpUrl: undefined,
+      json: false,
+      notebook: "Atlas",
+      query: "renewal risk",
+      limit: 4,
+    },
+  );
+  assert.throws(() => parseArgs(["search", "query", "--limit", "21"]), CliError);
+  assert.throws(() => parseArgs(["add", "a", "b", "--notebook", "Atlas", "--title", "x"]), CliError);
+  assert.throws(() => parseArgs(["add", "a.pdf", "--notebook", "Atlas", "--title", "x"]), CliError);
+});
+
+test("discovers the running app and honors explicit overrides", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "alchemy-cli-"));
+  const discovery = join(dir, "mcp.json");
+  await writeFile(discovery, JSON.stringify({ port: 43123 }));
+  assert.equal(
+    await discoverMcpUrl(undefined, { ALCHEMY_MCP_DISCOVERY: discovery }),
+    "http://127.0.0.1:43123/mcp",
+  );
+  assert.equal(
+    await discoverMcpUrl("http://localhost:9999/mcp", {}),
+    "http://localhost:9999/mcp",
+  );
+});
+
+test("classifies URLs, files, and stdin for add_source", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "alchemy-cli-source-"));
+  const file = join(dir, "notes.md");
+  await writeFile(file, "hello");
+  assert.deepEqual(await sourceArguments("https://example.com", undefined), {
+    url: "https://example.com",
+  });
+  assert.deepEqual(await sourceArguments(file, undefined), { file_path: file });
+  assert.deepEqual(await sourceArguments("-", "Standup", "hello\n"), {
+    text: "hello\n",
+    title: "Standup",
+  });
+  await assert.rejects(() => sourceArguments("-", undefined, "  "), /stdin was empty/);
+});
+
+test("resolves notebooks only by exact id or exact case-insensitive title", async () => {
+  const client = {
+    call: async () => [
+      { id: "nb-1", title: "Project Atlas" },
+      { id: "nb-2", title: "Other" },
+    ],
+  };
+  assert.equal((await resolveNotebook(client, "nb-1")).title, "Project Atlas");
+  assert.equal((await resolveNotebook(client, "project atlas")).id, "nb-1");
+  await assert.rejects(() => resolveNotebook(client, "Atlas"), /no notebook/);
+});
+
+test("MCP client initializes a session and parses a JSON tool result", async () => {
+  const requests = [];
+  const fetchImpl = async (_url, init) => {
+    const request = JSON.parse(init.body);
+    requests.push({ request, headers: init.headers });
+    if (request.method === "initialize") {
+      return new Response(
+        JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { protocolVersion: "2025-06-18" } }),
+        { headers: { "content-type": "application/json", "mcp-session-id": "session-1" } },
+      );
+    }
+    if (request.method === "notifications/initialized") return new Response(null, { status: 202 });
+    return new Response(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: request.id,
+        result: { content: [{ type: "text", text: '[{"id":"nb-1","title":"Atlas"}]' }] },
+      }),
+      { headers: { "content-type": "application/json" } },
+    );
+  };
+  const client = new McpClient("http://127.0.0.1:41414/mcp", fetchImpl);
+  assert.deepEqual(await client.call("list_notebooks"), [{ id: "nb-1", title: "Atlas" }]);
+  assert.equal(requests[2].headers["mcp-session-id"], "session-1");
+});
+
+test("MCP client ignores SSE progress and returns the matching response", async () => {
+  let initialized = false;
+  const fetchImpl = async (_url, init) => {
+    const request = JSON.parse(init.body);
+    if (request.method === "initialize") {
+      return new Response(
+        `event: message\ndata: {"jsonrpc":"2.0","id":${request.id},"result":{}}\n\n`,
+        { headers: { "content-type": "text/event-stream", "mcp-session-id": "sse-1" } },
+      );
+    }
+    if (request.method === "notifications/initialized") {
+      initialized = true;
+      return new Response(null, { status: 202 });
+    }
+    return new Response(
+      `event: message\ndata: {"jsonrpc":"2.0","method":"notifications/progress","params":{}}\n\n` +
+        `event: message\ndata: {"jsonrpc":"2.0","id":${request.id},"result":{"content":[{"type":"text","text":"[]"}]}}\n\n`,
+      { headers: { "content-type": "text/event-stream" } },
+    );
+  };
+  const client = new McpClient("http://127.0.0.1:41414/mcp", fetchImpl);
+  assert.deepEqual(await client.call("search", {}), []);
+  assert.equal(initialized, true);
+});

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@thrashr888/alchemy-cli",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Thin command-line client for the Alchemy desktop app",
+  "license": "MPL-2.0",
+  "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
+  "bin": {
+    "alchemy": "./alchemy.mjs"
+  }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -173,6 +173,12 @@ refresh live. Requests carrying a browser `Origin` header are rejected (CSRF
 guard); enable/port live in `AiConfig` (Settings → Agents), and a discovery
 file is written to `<app-data>/mcp.json`. See `docs/RFC-mcp-server.md`.
 
+`cli/alchemy.mjs` is a zero-dependency command-line client for that same
+server. It discovers the live URL from `mcp.json` and exposes a deliberately
+small shell surface (list notebooks, add file/URL/stdin sources, and search).
+It never opens the database or starts a second backend process; a running app
+remains the sole owner of ingestion, indexing, and retrieval.
+
 ### `connectors.rs` — agent client registry
 One-click registration of the MCP server (plus the bundled `skills/alchemy`
 SKILL.md) with installed agent clients — Claude Code, Codex, OpenCode, Gemini

--- a/docs/RFC-meta-chat.md
+++ b/docs/RFC-meta-chat.md
@@ -73,11 +73,23 @@ Expose the same capability over MCP as **`ask_everything`** (or extend
 Agents mostly want the raw passages, not our synthesized answer — so the
 MCP tool returns passages + notebook names, mirroring `search`.
 
-## Non-goals (v1)
+## As built: persistent Home Chat
 
-- Persisting meta-chat threads (ephemeral; a rerun is cheap and the corpus
-  moved anyway). Revisit if users ask to save answers as notes — likely as
-  a "Save as note" button that writes to a chosen notebook.
+The original v1 intentionally kept corpus-wide conversation inside the
+ephemeral command palette. Home Chat is the approved extension to that design:
+Home now has a first-class **Chat** section backed by the same
+`ask_everything` retrieval, progress events, and navigable citations. Its
+bounded conversation and draft persist locally, follow-up history is supplied
+to `ask_everything`, and an in-flight answer remains store-owned while the user
+navigates elsewhere. The command palette's glanceable ask mode remains
+available and unchanged; the two surfaces serialize access to the per-window
+meta stream.
+
+## Original v1 non-goals
+
+- Persisting meta-chat threads was a v1 non-goal. The Home Chat extension above
+  supersedes it with bounded local conversation history; saving an individual
+  answer as a notebook note remains future work.
 - A separate window or menu-bar popover. ⌥Space + palette is the surface.
 - Source-selection scoping (all notebooks always; per-notebook chat already
   covers the scoped case).

--- a/package.json
+++ b/package.json
@@ -10,12 +10,17 @@
     "url": "https://github.com/thrashr888/alchemy.git"
   },
   "type": "module",
+  "bin": {
+    "alchemy": "./cli/alchemy.mjs"
+  },
   "scripts": {
     "dev": "vite",
     "typecheck": "tsc --noEmit",
     "bundle": "vite build",
     "build": "pnpm run typecheck && pnpm run bundle",
     "test": "vitest run",
+    "test:cli": "node --test cli/alchemy.test.mjs",
+    "cli": "node ./cli/alchemy.mjs",
     "test:rust": "cargo test --manifest-path src-tauri/Cargo.toml --lib",
     "preview": "vite preview",
     "tauri": "tauri",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -10754,9 +10754,13 @@ pub(crate) async fn registry_card_citations(
 /// chat step trail uses, on its own channel so a palette ask never writes
 /// into a notebook's step trail (or vice versa). `None` (the MCP path) emits
 /// nothing.
-fn meta_step(app: Option<&AppHandle>, label: impl Into<String>, transient: bool) {
-    if let Some(app) = app {
-        let _ = app.emit(
+fn meta_step(target: Option<(&AppHandle, &str)>, label: impl Into<String>, transient: bool) {
+    if let Some((app, window_label)) = target {
+        // Meta streams are per-window generation scopes. Target their events
+        // to the asking webview too, so simultaneous asks in two windows can
+        // never paint into each other's Home Chat or command palette.
+        let _ = app.emit_to(
+            window_label,
             "meta://step",
             StepEvent {
                 label: label.into(),
@@ -10785,7 +10789,7 @@ pub struct MetaAnswer {
 /// order, so deep can only reorder-or-equal, never lose the flat result.
 pub(crate) async fn retrieve_everything(
     state: &AppState,
-    app: Option<&AppHandle>,
+    target: Option<(&AppHandle, &str)>,
     question: &str,
     k: usize,
     deep: bool,
@@ -10809,7 +10813,7 @@ pub(crate) async fn retrieve_everything(
     // searched in full either way.
     let routed: Option<Vec<String>> = if nb_titles.len() > crate::router::MIN_NOTEBOOKS_TO_ROUTE {
         meta_step(
-            app,
+            target,
             format!("Searching {} notebooks", nb_titles.len()),
             false,
         );
@@ -10854,7 +10858,7 @@ pub(crate) async fn retrieve_everything(
         max_gists: profile.max_gists,
     };
     meta_step(
-        app,
+        target,
         match &routed {
             Some(ids) => format!("Searching the {} most likely notebooks", ids.len()),
             None => match nb_titles.len() {
@@ -10912,7 +10916,7 @@ pub(crate) async fn retrieve_everything(
     // to the fusion-ordered top k — exactly the non-deep result.
     if deep && out.len() > k {
         meta_step(
-            app,
+            target,
             format!(
                 "Picking the {k} passages that answer best (of {})",
                 out.len()
@@ -10993,7 +10997,7 @@ pub(crate) async fn retrieve_everything(
             .collect::<HashSet<_>>()
             .len();
         meta_step(
-            app,
+            target,
             format!(
                 "Found {} passage{} across {} notebook{}",
                 out.len(),
@@ -11081,7 +11085,7 @@ async fn global_extract(ai: &Ai, question: &str, content: &str) -> Option<String
 /// caller then takes the pointed path unchanged.
 async fn global_meta_route(
     state: &AppState,
-    app: Option<&AppHandle>,
+    target: Option<(&AppHandle, &str)>,
     question: &str,
 ) -> anyhow::Result<Option<(Vec<MetaCitation>, Vec<rag::MetaPassage>)>> {
     if state.db.list_gists().await?.is_empty() {
@@ -11125,7 +11129,7 @@ async fn global_meta_route(
     let mut passages: Vec<rag::MetaPassage> = Vec::with_capacity(selected.len());
     let mut fallbacks: Vec<bool> = Vec::with_capacity(selected.len());
     meta_step(
-        app,
+        target,
         format!(
             "Reading {} source{} in depth",
             selected.len(),
@@ -11137,7 +11141,7 @@ async fn global_meta_route(
         // Live per-source status, transient: each read replaces the last in
         // the trail — a fan-out of six must not become six log lines.
         meta_step(
-            app,
+            target,
             format!(
                 "Reading {} ({} of {})",
                 gist.source_title,
@@ -11214,7 +11218,7 @@ pub async fn ask_everything(
     // classifier is pure; ANY failure inside the route degrades to None, so
     // the pointed path below runs unchanged whenever the route doesn't fire.
     let global = if rag::is_global_query(&question) {
-        match global_meta_route(&state, Some(&app), &question).await {
+        match global_meta_route(&state, Some((&app, window.label())), &question).await {
             Ok(g) => g,
             Err(err) => {
                 crate::note!("meta-global route failed, falling back to pointed: {err:#}");
@@ -11231,7 +11235,8 @@ pub async fn ask_everything(
     let (mut citations, mut passages) = if let Some(g) = global {
         g
     } else {
-        let passages_raw = retrieve_everything(&state, Some(&app), &question, 16, deep).await?;
+        let passages_raw =
+            retrieve_everything(&state, Some((&app, window.label())), &question, 16, deep).await?;
         let mut citations: Vec<MetaCitation> = Vec::new();
         let mut passages: Vec<rag::MetaPassage> = Vec::new();
         for c in &passages_raw {
@@ -11263,7 +11268,7 @@ pub async fn ask_everything(
     let card_citations = registry_card_citations(&state, &question, 3).await;
     if !card_citations.is_empty() {
         meta_step(
-            Some(&app),
+            Some((&app, window.label())),
             format!(
                 "Reading {} registry card{}",
                 card_citations.len(),
@@ -11310,7 +11315,7 @@ pub async fn ask_everything(
     // Same stream/cancel dance as notebook chat, under its own scope so a
     // palette Esc never kills a notebook stream (or vice versa).
     meta_step(
-        Some(&app),
+        Some((&app, window.label())),
         format!(
             "Synthesizing from {} excerpt{}",
             passages.len(),
@@ -11319,6 +11324,7 @@ pub async fn ask_everything(
         false,
     );
     let app_for_cb = app.clone();
+    let window_label = window.label().to_string();
     let cancel = state.begin_generation(&format!("meta:{}", window.label()));
     let partial = Arc::new(Mutex::new(String::new()));
     let partial_cb = partial.clone();
@@ -11331,7 +11337,8 @@ pub async fn ask_everything(
             out = ai.chat_stream(&messages, |tok| {
                 ttft_cb.mark();
                 partial_cb.lock().unwrap().push_str(tok);
-                let _ = app_for_cb.emit(
+                let _ = app_for_cb.emit_to(
+                    &window_label,
                     "meta://token",
                     TokenEvent { content: tok.to_string() },
                 );

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -106,6 +106,14 @@ const CMD: &[Command] = &[
         context: "",
     },
     Command {
+        id: "menu-home-chat",
+        menu_label: "Home Chat",
+        accelerator: None,
+        keys: "",
+        label: "",
+        context: "",
+    },
+    Command {
         id: "menu-back",
         menu_label: "Back",
         accelerator: None,
@@ -454,6 +462,7 @@ pub fn build(app: &AppHandle, recents: &[(String, String)]) -> tauri::Result<App
         .item(&cmd_item(app, "menu-forward")?)
         .separator()
         .item(&cmd_item(app, "menu-search")?)
+        .item(&cmd_item(app, "menu-home-chat")?)
         .separator()
         .item(&cmd_item(app, "menu-toggle-sources")?)
         .item(&cmd_item(app, "menu-toggle-studio")?)

--- a/src/components/AppNavigationControls.tsx
+++ b/src/components/AppNavigationControls.tsx
@@ -1,0 +1,45 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useStore } from "@/lib/store";
+import { Button } from "./ui";
+
+/** App-level browser history. Reader-local history remains in ReaderPane. */
+export function AppNavigationControls() {
+  const canGoBack = useStore((s) => s.nav.index > 0);
+  const canGoForward = useStore((s) => s.nav.index < s.nav.stack.length - 1);
+  const goBack = useStore((s) => s.navBack);
+  const goForward = useStore((s) => s.navForward);
+
+  return (
+    <nav
+      aria-label="History navigation"
+      className="flex shrink-0 items-center gap-0.5"
+    >
+      {/* The wrapper keeps the native tooltip available while the button is
+          disabled (Button deliberately turns pointer events off then). */}
+      <span className="inline-flex" title="Back (⌘←)">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={goBack}
+          disabled={!canGoBack}
+          aria-label="Back"
+          aria-keyshortcuts="Meta+ArrowLeft"
+        >
+          <ChevronLeft aria-hidden className="h-4 w-4" />
+        </Button>
+      </span>
+      <span className="inline-flex" title="Forward (⌘→)">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={goForward}
+          disabled={!canGoForward}
+          aria-label="Forward"
+          aria-keyshortcuts="Meta+ArrowRight"
+        >
+          <ChevronRight aria-hidden className="h-4 w-4" />
+        </Button>
+      </span>
+    </nav>
+  );
+}

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -153,6 +153,19 @@ export function CommandPalette() {
   function startAsk(question: string) {
     const q = question.trim();
     if (!q || askLoading) return;
+    const store = useStore.getState();
+    // ask_everything's events and cancellation scope are shared by the two
+    // corpus-wide surfaces in this window. Only one may own that stream.
+    if (store.metaAskOwner) {
+      store.pushToast(
+        "info",
+        store.metaAskOwner === "home"
+          ? "Home Chat is already answering. Stop it before asking here."
+          : "A library answer is already running.",
+      );
+      return;
+    }
+    useStore.setState({ metaAskOwner: "palette" });
     setMode("ask");
     setAskQuestion(q);
     setAskText("");
@@ -178,7 +191,11 @@ export function CommandPalette() {
       .catch((e) => {
         setAskText(e instanceof Error ? e.message : String(e));
       })
-      .finally(() => setAskLoading(false));
+      .finally(() => {
+        if (useStore.getState().metaAskOwner === "palette")
+          useStore.setState({ metaAskOwner: null });
+        setAskLoading(false);
+      });
   }
 
   function exitAsk() {
@@ -509,11 +526,7 @@ export function CommandPalette() {
           if (h.kind === "card") {
             // Cards are corpus-scoped: leave the notebook and open the card
             // on Home rather than switching notebooks.
-            s.closeNotebook();
-            useStore.setState({
-              homeSection: "registry",
-              openCardId: h.id,
-            });
+            s.openHomeSection("registry", h.id);
           } else if (h.kind === "ledger") {
             // Open the notebook's Ledger tab — where the row can be acted on.
             await s.selectNotebook(h.notebookId);
@@ -626,8 +639,7 @@ export function CommandPalette() {
     void (async () => {
       const s = useStore.getState();
       if (c.kind === "card") {
-        s.closeNotebook();
-        useStore.setState({ homeSection: "registry", openCardId: c.id });
+        s.openHomeSection("registry", c.id);
       } else if (c.kind === "note") {
         useStore.setState({ justCreatedNoteId: c.id });
         if (!s.studioOpen) s.toggleStudio();

--- a/src/components/HomeChat.tsx
+++ b/src/components/HomeChat.tsx
@@ -1,0 +1,412 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { api } from "@/lib/api";
+import { useStore } from "@/lib/store";
+import type { MetaCitation } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import { AlchemySymbol } from "./AlchemyHero";
+import { DitherBackground } from "./DitherBackground";
+import { Markdown } from "./Markdown";
+import { Button, LiveRegion, Spinner, Textarea, useConfirm } from "./ui";
+import {
+  AlertTriangle,
+  ArrowUp,
+  Eraser,
+  FileText,
+  Package,
+  RefreshCw,
+  Sparkles,
+  Square,
+  SquarePen,
+} from "lucide-react";
+
+const COMPOSER_MAX_H = 180;
+
+/** Persistent, corpus-wide chat for Home. Retrieval and citation semantics
+ * are the existing ask_everything contract; this component is the durable
+ * reading/composing surface around it. */
+export function HomeChat() {
+  const turns = useStore((s) => s.homeChatTurns);
+  const sending = useStore((s) => s.homeChatSending);
+  const question = useStore((s) => s.homeChatQuestion);
+  const streamingText = useStore((s) => s.homeChatStreamingText);
+  const steps = useStore((s) => s.homeChatSteps);
+  const waiting = useStore((s) => s.homeChatWaiting);
+  const send = useStore((s) => s.sendHomeMessage);
+  const clear = useStore((s) => s.clearHomeChat);
+  const theme = useStore((s) => s.theme);
+  const glassOn = useStore((s) => s.reading.glass);
+  const [draft, setDraft] = useState(
+    () => localStorage.getItem("homeChatDraft") ?? "",
+  );
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const initialScrollDone = useRef(false);
+  const { confirm, dialog } = useConfirm();
+
+  useEffect(() => {
+    if (draft) localStorage.setItem("homeChatDraft", draft);
+    else localStorage.removeItem("homeChatDraft");
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, COMPOSER_MAX_H)}px`;
+  }, [draft]);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || initialScrollDone.current) return;
+    el.scrollTop = el.scrollHeight;
+    initialScrollDone.current = true;
+  }, [turns.length]);
+
+  // Follow a live answer only while the reader is already near the bottom;
+  // scrolling up to inspect an earlier citation must remain stable.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 120;
+    if (nearBottom) el.scrollTop = el.scrollHeight;
+  }, [turns, streamingText, steps, waiting]);
+
+  const [announcements, setAnnouncements] = useState<
+    { id: number; text: string }[]
+  >([]);
+  const announcementSeq = useRef(0);
+  const wasSending = useRef(false);
+  useEffect(() => {
+    if (sending === wasSending.current) return;
+    wasSending.current = sending;
+    if (sending) {
+      setAnnouncements([
+        { id: ++announcementSeq.current, text: "Searching your library." },
+      ]);
+      return;
+    }
+    const last = turns[turns.length - 1];
+    if (!last) return;
+    if (last.status === "error") {
+      setAnnouncements([
+        { id: ++announcementSeq.current, text: `The answer failed. ${last.answer}` },
+      ]);
+      return;
+    }
+    const count = last.citations.length;
+    setAnnouncements([
+      {
+        id: ++announcementSeq.current,
+        text: `Answer ready. ${count === 0 ? "No citations" : count === 1 ? "1 citation" : `${count} citations`}.`,
+      },
+    ]);
+  }, [sending, turns]);
+
+  const citedNotebooks = useMemo(() => {
+    const seen = new Map<string, string>();
+    for (const turn of turns) {
+      for (const citation of turn.citations) {
+        if (citation.notebookId && !seen.has(citation.notebookId))
+          seen.set(citation.notebookId, citation.notebookTitle);
+      }
+    }
+    return seen;
+  }, [turns]);
+
+  function submit() {
+    const text = draft.trim();
+    if (!text || sending) return;
+    const state = useStore.getState();
+    if (state.metaAskOwner && state.metaAskOwner !== "home") {
+      state.pushToast(
+        "info",
+        "Another library answer is already running. Stop it before starting Home Chat.",
+      );
+      return;
+    }
+    setDraft("");
+    void send(text);
+    requestAnimationFrame(() => {
+      const el = scrollRef.current;
+      if (el) el.scrollTop = el.scrollHeight;
+    });
+  }
+
+  function openCitation(citation: MetaCitation) {
+    void (async () => {
+      const state = useStore.getState();
+      if (citation.kind === "card") {
+        state.openHomeSection("registry", citation.id);
+      } else if (citation.kind === "note") {
+        useStore.setState({ justCreatedNoteId: citation.id });
+        if (!state.studioOpen) state.toggleStudio();
+        await state.selectNotebook(citation.notebookId);
+      } else {
+        await state.selectNotebook(citation.notebookId);
+        useStore
+          .getState()
+          .openSourceViewer(citation.id, citation.title, citation.snippet);
+      }
+    })();
+  }
+
+  const blank = turns.length === 0 && !sending;
+  const progress =
+    waiting || steps[steps.length - 1] || "Searching your entire library…";
+
+  return (
+    <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
+      <LiveRegion announcements={announcements} />
+      {blank && !glassOn && (
+        <>
+          <div className="glass-mist pointer-events-none absolute inset-0 z-0">
+            <DitherBackground themeKey={theme} />
+          </div>
+          <div className="chat-mist-fade glass-mist pointer-events-none absolute inset-0 z-0" />
+        </>
+      )}
+
+      <div className="relative z-10 flex h-12 shrink-0 items-center border-b border-border px-5">
+        <Sparkles className="size-4 text-citation" aria-hidden />
+        <span className="ml-2 text-caption font-semibold uppercase text-muted-foreground">
+          Home chat
+        </span>
+        <span className="ml-2 truncate text-caption text-subtle-foreground">
+          All notebooks + Registry
+        </span>
+        {turns.length > 0 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="ml-auto"
+            disabled={sending}
+            onClick={() =>
+              void confirm({
+                title: "Clear Home Chat?",
+                message: "This removes the locally saved conversation.",
+                confirmLabel: "Clear",
+                danger: true,
+              }).then((ok) => {
+                if (ok) clear();
+              })
+            }
+          >
+            <Eraser className="size-3.5" aria-hidden />
+            Clear
+          </Button>
+        )}
+      </div>
+
+      <div
+        ref={scrollRef}
+        className="relative z-10 min-h-0 flex-1 overflow-y-auto"
+        aria-busy={sending}
+      >
+        <div className="mx-auto flex min-h-full w-full max-w-[720px] flex-col gap-6 px-5 py-8">
+          {blank && (
+            <div className="my-auto flex flex-col items-center px-4 py-12 text-center">
+              <AlchemySymbol className="mb-6 size-20 text-citation/70" />
+              <h1 className="text-balance text-page font-semibold text-foreground">
+                Ask across your whole library
+              </h1>
+              <p className="mt-2 max-w-md text-pretty text-body leading-relaxed text-muted-foreground">
+                Home Chat searches indexed sources, notes, reports, and
+                Registry cards across every notebook. Citations take you back
+                to the exact place an answer came from.
+              </p>
+            </div>
+          )}
+
+          {turns.map((turn) => (
+            <article key={turn.id} className="flex flex-col gap-3">
+              <div className="ml-auto max-w-[85%] rounded-lg bg-surface-2 px-3.5 py-2.5 text-body leading-relaxed text-foreground">
+                <p className="whitespace-pre-wrap text-pretty">{turn.question}</p>
+              </div>
+              <div className="flex min-w-0 flex-col gap-2">
+                <div className="flex items-center gap-2 text-micro font-medium uppercase text-subtle-foreground">
+                  <Sparkles className="size-3.5" aria-hidden />
+                  Across Alchemy
+                </div>
+                {turn.status === "error" ? (
+                  <div
+                    role="alert"
+                    className="flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-body text-destructive"
+                  >
+                    <AlertTriangle className="mt-0.5 size-4 shrink-0" aria-hidden />
+                    <span className="min-w-0 flex-1 text-pretty">{turn.answer}</span>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      disabled={sending}
+                      onClick={() => void send(turn.question)}
+                    >
+                      <RefreshCw className="size-3.5" aria-hidden />
+                      Retry
+                    </Button>
+                  </div>
+                ) : (
+                  <>
+                    <div className="text-body leading-relaxed">
+                      <Markdown
+                        citations={turn.citations}
+                        onCitation={openCitation}
+                        citationLabel={(citation) =>
+                          `${citation.title || "Untitled"} · ${citation.notebookTitle}`
+                        }
+                      >
+                        {turn.answer}
+                      </Markdown>
+                    </div>
+                    <HomeChatCitations
+                      citations={turn.citations}
+                      onOpen={openCitation}
+                    />
+                  </>
+                )}
+              </div>
+            </article>
+          ))}
+
+          {sending && (
+            <article className="flex flex-col gap-3">
+              <div className="ml-auto max-w-[85%] rounded-lg bg-surface-2 px-3.5 py-2.5 text-body leading-relaxed text-foreground">
+                <p className="whitespace-pre-wrap text-pretty">{question}</p>
+              </div>
+              <div className="flex min-w-0 flex-col gap-2">
+                <div className="flex items-center gap-2 text-micro font-medium uppercase text-subtle-foreground">
+                  <Sparkles className="size-3.5" aria-hidden />
+                  Across Alchemy
+                </div>
+                {streamingText ? (
+                  <div className="text-body leading-relaxed">
+                    <Markdown>{streamingText}</Markdown>
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-2 py-2 text-caption text-muted-foreground">
+                    <Spinner className="size-3.5 shrink-0" />
+                    <span className="min-w-0 truncate">{progress}</span>
+                    {steps.length > 1 && (
+                      <span className="ml-auto shrink-0 tabular-nums text-micro text-subtle-foreground">
+                        {steps.length} steps
+                      </span>
+                    )}
+                  </div>
+                )}
+              </div>
+            </article>
+          )}
+
+          {!blank && citedNotebooks.size > 0 && (
+            <div className="mt-auto flex flex-wrap items-center gap-1.5 border-t border-border pt-4">
+              <span className="mr-1 text-micro uppercase text-subtle-foreground">
+                In this thread
+              </span>
+              {[...citedNotebooks].map(([id, title]) => (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => void useStore.getState().selectNotebook(id)}
+                  className="rounded-full border border-border bg-surface px-2 py-0.5 text-micro text-muted-foreground transition-colors hover:border-border-strong hover:text-foreground"
+                >
+                  {title || "Untitled"}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="relative z-10 shrink-0 px-5 pb-5 pt-2">
+        <div className="mx-auto max-w-[720px]">
+          <div
+            className={cn(
+              "relative rounded-lg border border-border-strong bg-surface p-2.5 shadow-md transition-colors",
+              "focus-within:border-ring/60",
+            )}
+          >
+            <Textarea
+              ref={textareaRef}
+              rows={1}
+              value={draft}
+              onChange={(event) => setDraft(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.nativeEvent.isComposing) return;
+                if (event.key === "Enter" && !event.shiftKey) {
+                  event.preventDefault();
+                  submit();
+                }
+              }}
+              className="max-h-[180px] min-h-6 border-0 bg-transparent px-1.5 py-1 focus:ring-0"
+              placeholder="Ask across all notebooks…"
+              aria-label="Ask Home Chat across all notebooks"
+            />
+            <div className="mt-2 flex items-center gap-2 pl-1.5">
+              <span className="min-w-0 flex-1 truncate text-micro text-subtle-foreground">
+                Sources, notes, reports, and Registry cards
+              </span>
+              {sending ? (
+                <Button
+                  variant="secondary"
+                  size="icon"
+                  onClick={() => void api.cancelGeneration("meta")}
+                  aria-label="Stop Home Chat answer"
+                  title="Stop"
+                >
+                  <Square className="size-3 fill-current" aria-hidden />
+                </Button>
+              ) : (
+                <Button
+                  variant="primary"
+                  size="icon"
+                  disabled={!draft.trim()}
+                  onClick={submit}
+                  aria-label="Send to Home Chat"
+                  title="Send"
+                >
+                  <ArrowUp className="size-4" aria-hidden />
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+      {dialog}
+    </div>
+  );
+}
+
+function HomeChatCitations({
+  citations,
+  onOpen,
+}: {
+  citations: MetaCitation[];
+  onOpen: (citation: MetaCitation) => void;
+}) {
+  if (citations.length === 0) return null;
+  return (
+    <div className="mt-1 flex flex-col gap-0.5 border-t border-border pt-2.5">
+      {citations.map((citation, index) => (
+        <button
+          key={`${citation.kind}-${citation.id}-${index}`}
+          type="button"
+          onClick={() => onOpen(citation)}
+          className="group flex items-center gap-2 rounded-md px-1.5 py-1 text-left text-caption text-muted-foreground transition-colors hover:bg-surface-2 hover:text-foreground"
+        >
+          <span className="shrink-0 tabular-nums text-badge text-subtle-foreground">
+            [{index + 1}]
+          </span>
+          {citation.kind === "card" ? (
+            <Package className="size-3 shrink-0" aria-hidden />
+          ) : citation.kind === "note" ? (
+            <SquarePen className="size-3 shrink-0" aria-hidden />
+          ) : (
+            <FileText className="size-3 shrink-0" aria-hidden />
+          )}
+          <span className="min-w-0 flex-1 truncate">
+            {citation.title || "Untitled"}
+          </span>
+          <span className="shrink-0 text-micro text-subtle-foreground">
+            {citation.notebookTitle}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -52,6 +52,8 @@ import {
 import { BriefSidebar, SidebarRail, StaffSidebar } from "./HomeSections";
 import { NOTEBOOK_ICONS, notebookIcon } from "@/lib/notebookIcons";
 import { RegistrySection } from "./RegistrySection";
+import { AppNavigationControls } from "./AppNavigationControls";
+import { HomeChat } from "./HomeChat";
 import {
   HomeTable,
   HomeViewControls,
@@ -184,13 +186,15 @@ function NotebookTable({
  *  Chat|Reader|Gallery|Ledger tabs (CenterModeTabs, ReaderPane.tsx): one
  *  control, in the title bar, choosing what the center column shows about a
  *  constant subject. There the subject is one notebook; here it's the whole
- *  corpus — its notebooks, or the cast of things they're about. Same kind of
- *  switch, so it lives in the same place and wears the same chrome. */
+ *  corpus — its notebooks, a corpus-wide conversation, or the cast of things
+ *  they're about. Same kind of switch, so it lives in the same place and
+ *  wears the same chrome. */
 function HomeSectionTabs() {
   const section = useStore((s) => s.homeSection);
 
   const tabs = [
     { id: "notebooks", label: "Notebooks", icon: BookOpen },
+    { id: "chat", label: "Chat", icon: Sparkles },
     { id: "registry", label: "Registry", icon: Package },
   ] as const;
   return (
@@ -206,7 +210,9 @@ function HomeSectionTabs() {
           title={
             id === "registry"
               ? "The things your documents are about"
-              : "Your notebooks"
+              : id === "chat"
+                ? "Ask across your whole library"
+                : "Your notebooks"
           }
           className={cn(
             "flex items-center gap-1.5 rounded-md px-2 py-1 text-caption transition-colors",
@@ -460,16 +466,22 @@ export function HomeView({ onOpenSettings }: { onOpenSettings: () => void }) {
     },
   ];
 
-  // The unified ask box: one input over the WHOLE corpus. Enter hands the
-  // question to the palette's ask mode (meta-chat, docs/RFC-meta-chat.md) —
-  // no notebook choice needed; citations name where answers live.
+  // The unified ask box is Home Chat's front door. The command palette keeps
+  // its ephemeral ask mode; questions started on Home belong to the visible,
+  // persistent Home conversation instead.
   const [ask, setAsk] = useState("");
   function submitAsk(e: React.FormEvent) {
     e.preventDefault();
     const q = ask.trim();
     if (!q) return;
+    const state = useStore.getState();
+    if (state.metaAskOwner) {
+      state.pushToast("info", "Another library answer is already running.");
+      return;
+    }
     setAsk("");
-    useStore.setState({ pendingAsk: q, paletteOpen: true });
+    useStore.setState({ homeSection: "chat", openCardId: null });
+    void state.sendHomeMessage(q);
   }
 
   // "Since you were away": what landed since the last time home was open.
@@ -616,6 +628,7 @@ export function HomeView({ onOpenSettings }: { onOpenSettings: () => void }) {
         data-tauri-drag-region
         className="flex h-12 items-center gap-2.5 pl-[84px] pr-5"
       >
+        <AppNavigationControls />
         <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-primary/15 text-primary">
           <BookOpen className="h-4 w-4" />
         </div>
@@ -675,6 +688,8 @@ export function HomeView({ onOpenSettings }: { onOpenSettings: () => void }) {
             </Button>
           </EmptyState>
         </div>
+      ) : homeSection === "chat" ? (
+        <HomeChat />
       ) : notebooks.length === 0 ? (
         <div className="flex-1">
           <AlchemyHero
@@ -845,9 +860,9 @@ export function HomeView({ onOpenSettings }: { onOpenSettings: () => void }) {
                 </div>
               </div>
 
-              {/* The unified ask box: one input, the whole corpus. Enter asks
-              across every notebook (palette ask mode); the ⌘K chip is the
-              same surface in search mode. */}
+              {/* The unified ask box: one input, the whole corpus. Enter opens
+              the persistent Home Chat; the ⌘K chip keeps the command/search
+              surface one click away. */}
               <div className="mb-8">
                 <form
                   onSubmit={submitAsk}

--- a/src/components/Workspace.tsx
+++ b/src/components/Workspace.tsx
@@ -15,6 +15,7 @@ import { ChevronLeft, Search, Settings } from "lucide-react";
 import { notebookIcon } from "@/lib/notebookIcons";
 import { DevBadge } from "./DevBadge";
 import { UpdateBadge } from "./UpdateBadge";
+import { AppNavigationControls } from "./AppNavigationControls";
 
 export function Workspace({ onOpenSettings }: { onOpenSettings: () => void }) {
   const currentId = useStore((s) => s.currentId);
@@ -68,6 +69,8 @@ export function Workspace({ onOpenSettings }: { onOpenSettings: () => void }) {
         data-tauri-drag-region
         className="flex h-12 items-center gap-2 pl-[84px] pr-3"
       >
+        <AppNavigationControls />
+        <div className="mx-1 h-4 w-px bg-border" />
         <Button
           variant="ghost"
           size="sm"

--- a/src/lib/appNavigation.test.ts
+++ b/src/lib/appNavigation.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { navEntryFromSnapshot, sameNavEntry } from "./appNavigation";
+
+const base = {
+  currentId: null,
+  ledgerOpen: false,
+  galleryOpen: false,
+  readerOpen: false,
+  homeSection: "notebooks" as const,
+  openCardId: null,
+};
+
+describe("app navigation locations", () => {
+  it("treats each Home section as a distinct Back/Forward destination", () => {
+    const notebooks = navEntryFromSnapshot(base);
+    const chat = navEntryFromSnapshot({ ...base, homeSection: "chat" });
+    const registry = navEntryFromSnapshot({ ...base, homeSection: "registry" });
+
+    expect(notebooks).toEqual({
+      nb: null,
+      mode: "chat",
+      homeSection: "notebooks",
+    });
+    expect(sameNavEntry(notebooks, chat)).toBe(false);
+    expect(sameNavEntry(chat, registry)).toBe(false);
+  });
+
+  it("records an open Registry card but drops Home fields inside notebooks", () => {
+    const card = navEntryFromSnapshot({
+      ...base,
+      homeSection: "registry",
+      openCardId: "card-1",
+    });
+    expect(card.openCardId).toBe("card-1");
+
+    expect(
+      navEntryFromSnapshot({
+        ...base,
+        currentId: "nb-1",
+        homeSection: "chat",
+        openCardId: "card-1",
+      }),
+    ).toEqual({ nb: "nb-1", mode: "chat" });
+  });
+
+  it("drops one-time reader highlights from the history identity", () => {
+    const reader = navEntryFromSnapshot({
+      ...base,
+      currentId: "nb-1",
+      readerOpen: true,
+      readerDoc: { type: "source", id: "source-1", highlight: "needle" },
+    });
+    expect(reader).toEqual({
+      nb: "nb-1",
+      mode: "reader",
+      doc: { type: "source", id: "source-1" },
+    });
+  });
+});

--- a/src/lib/appNavigation.ts
+++ b/src/lib/appNavigation.ts
@@ -1,0 +1,54 @@
+import type { NavEntry, ReaderDoc } from "./storeTypes";
+
+export interface NavSnapshot {
+  currentId: string | null;
+  ledgerOpen: boolean;
+  galleryOpen: boolean;
+  readerOpen: boolean;
+  readerDoc?: ReaderDoc;
+  homeSection: "notebooks" | "chat" | "registry";
+  openCardId: string | null;
+}
+
+/** Canonicalize live store state into one browser-history location. Reader
+ * highlights are events, not locations; Home sections and open Registry cards
+ * are locations because Back/Forward must visibly restore them. */
+export function navEntryFromSnapshot(snapshot: NavSnapshot): NavEntry {
+  const mode = snapshot.galleryOpen
+    ? ("gallery" as const)
+    : snapshot.ledgerOpen
+      ? ("ledger" as const)
+      : snapshot.readerOpen
+        ? ("reader" as const)
+        : ("chat" as const);
+  const entry: NavEntry = {
+    nb: snapshot.currentId,
+    mode,
+    ...(snapshot.readerOpen && snapshot.readerDoc
+      ? {
+          doc: {
+            type: snapshot.readerDoc.type,
+            id: snapshot.readerDoc.id,
+          },
+        }
+      : {}),
+  };
+  if (snapshot.currentId === null) {
+    entry.homeSection = snapshot.homeSection;
+    if (snapshot.homeSection === "registry" && snapshot.openCardId)
+      entry.openCardId = snapshot.openCardId;
+  }
+  return entry;
+}
+
+export function sameNavEntry(a: NavEntry | undefined, b: NavEntry): boolean {
+  return (
+    !!a &&
+    a.nb === b.nb &&
+    a.mode === b.mode &&
+    a.doc?.type === b.doc?.type &&
+    a.doc?.id === b.doc?.id &&
+    a.homeSection === b.homeSection &&
+    a.openCardId === b.openCardId
+  );
+}

--- a/src/lib/homeChat.test.ts
+++ b/src/lib/homeChat.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  appendHomeChatTurn,
+  HOME_CHAT_MAX_TURNS,
+  homeChatHistory,
+  parseHomeChatTurns,
+  type HomeChatTurn,
+} from "./homeChat";
+
+function turn(i: number, status: HomeChatTurn["status"] = "complete"): HomeChatTurn {
+  return {
+    id: `turn-${i}`,
+    question: `Question ${i}`,
+    answer: status === "complete" ? `Answer ${i}` : "Provider unavailable",
+    citations: [],
+    status,
+    createdAt: i,
+  };
+}
+
+describe("Home Chat history", () => {
+  it("restores valid turns while dropping malformed data and citations", () => {
+    const raw = JSON.stringify([
+      {
+        ...turn(1),
+        citations: [
+          {
+            kind: "source",
+            notebookId: "nb-1",
+            notebookTitle: "Research",
+            id: "source-1",
+            title: "Brief",
+            snippet: "Evidence",
+          },
+          { kind: "source", id: 42 },
+        ],
+      },
+      { question: "missing the rest" },
+    ]);
+
+    expect(parseHomeChatTurns(raw)).toEqual([
+      {
+        ...turn(1),
+        citations: [
+          {
+            kind: "source",
+            notebookId: "nb-1",
+            notebookTitle: "Research",
+            id: "source-1",
+            title: "Brief",
+            snippet: "Evidence",
+          },
+        ],
+      },
+    ]);
+    expect(parseHomeChatTurns("not json")).toEqual([]);
+  });
+
+  it("keeps the newest bounded window", () => {
+    const turns = Array.from({ length: HOME_CHAT_MAX_TURNS + 3 }, (_, i) => turn(i));
+    const kept = appendHomeChatTurn(turns.slice(0, -1), turns[turns.length - 1]);
+    expect(kept).toHaveLength(HOME_CHAT_MAX_TURNS);
+    expect(kept[0].id).toBe("turn-3");
+    expect(kept[kept.length - 1]?.id).toBe(`turn-${HOME_CHAT_MAX_TURNS + 2}`);
+  });
+
+  it("builds follow-up context from completed answers only", () => {
+    expect(homeChatHistory([turn(1), turn(2, "error"), { ...turn(3), answer: "" }])).toEqual([
+      { role: "user", content: "Question 1" },
+      { role: "assistant", content: "Answer 1" },
+    ]);
+  });
+});

--- a/src/lib/homeChat.ts
+++ b/src/lib/homeChat.ts
@@ -1,0 +1,80 @@
+import type { MetaCitation } from "./types";
+
+/** Home Chat is intentionally compact local history, not another unbounded
+ * artifact store. The backend still fits the resulting prompt to the active
+ * model; this cap keeps the app snapshot and relaunch restore predictable. */
+export const HOME_CHAT_MAX_TURNS = 24;
+
+export interface HomeChatTurn {
+  id: string;
+  question: string;
+  answer: string;
+  citations: MetaCitation[];
+  status: "complete" | "error";
+  createdAt: number;
+}
+
+function isCitation(value: unknown): value is MetaCitation {
+  if (!value || typeof value !== "object") return false;
+  const c = value as Record<string, unknown>;
+  return (
+    (c.kind === "source" || c.kind === "note" || c.kind === "card") &&
+    typeof c.notebookId === "string" &&
+    typeof c.notebookTitle === "string" &&
+    typeof c.id === "string" &&
+    typeof c.title === "string" &&
+    typeof c.snippet === "string"
+  );
+}
+
+function isTurn(value: unknown): value is HomeChatTurn {
+  if (!value || typeof value !== "object") return false;
+  const turn = value as Record<string, unknown>;
+  return (
+    typeof turn.id === "string" &&
+    typeof turn.question === "string" &&
+    turn.question.trim().length > 0 &&
+    typeof turn.answer === "string" &&
+    (turn.status === "complete" || turn.status === "error") &&
+    typeof turn.createdAt === "number" &&
+    Number.isFinite(turn.createdAt) &&
+    Array.isArray(turn.citations)
+  );
+}
+
+/** Parse the relaunch snapshot defensively. A corrupt or older shape must not
+ * keep Home from rendering; malformed citations are simply unavailable. */
+export function parseHomeChatTurns(raw: string | null): HomeChatTurn[] {
+  if (!raw) return [];
+  try {
+    const value: unknown = JSON.parse(raw);
+    if (!Array.isArray(value)) return [];
+    return value
+      .filter(isTurn)
+      .map((turn) => ({
+        ...turn,
+        citations: turn.citations.filter(isCitation),
+      }))
+      .slice(-HOME_CHAT_MAX_TURNS);
+  } catch {
+    return [];
+  }
+}
+
+export function appendHomeChatTurn(
+  turns: HomeChatTurn[],
+  turn: HomeChatTurn,
+): HomeChatTurn[] {
+  return [...turns, turn].slice(-HOME_CHAT_MAX_TURNS);
+}
+
+/** Only successful answers become model context. Error copy is UI state, not
+ * something the next answer should treat as a claim about the user's corpus. */
+export function homeChatHistory(turns: HomeChatTurn[]) {
+  return turns
+    .filter((turn) => turn.status === "complete" && turn.answer.trim())
+    .flatMap((turn) => [
+      { role: "user", content: turn.question },
+      { role: "assistant", content: turn.answer },
+    ]);
+}

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -14,6 +14,12 @@ import { describe } from "./errors";
 import { notify } from "./notify";
 import { dropEntry, makeEntry, pushEntry } from "./history";
 import { claimTextUndo } from "./textUndo";
+import {
+  appendHomeChatTurn,
+  homeChatHistory,
+  parseHomeChatTurns,
+} from "./homeChat";
+import { navEntryFromSnapshot, sameNavEntry } from "./appNavigation";
 import { playArrival, playDone, playError } from "./sound";
 import { autoUpdateEnabled, checkForUpdatesQuietly } from "./updates";
 import { DEFAULT_CHAT_CONFIG, DEFAULT_READING_PREFS } from "./types";
@@ -255,6 +261,19 @@ let listenersBound = false;
 // appendToken's per-frame buffer — plumbing, not state (see appendToken).
 let tokenBuffer = "";
 let tokenFlushHandle = 0;
+// Home Chat uses the corpus-wide meta stream. It has the notebook stream's
+// same frame batching, but separate state so the two surfaces never repaint
+// each other.
+let homeChatTokenBuffer = "";
+let homeChatTokenFlushHandle = 0;
+function persistHomeChatTurns(turns: ReturnType<typeof parseHomeChatTurns>) {
+  try {
+    localStorage.setItem("homeChat:v1", JSON.stringify(turns));
+  } catch {
+    // The conversation remains live in the store. A full/quarantined browser
+    // store must not turn a successful model answer into a failed answer.
+  }
+}
 // The artifact stream's twin of the chat token buffer.
 let artifactBuffer = "";
 let artifactFlushHandle = 0;
@@ -351,6 +370,37 @@ export const useStore = create<AppState>((set, get) => {
       .map((s) => s.id);
   };
 
+  /** One atomic notebook → Home transition. `closeNotebook` uses the current
+   *  Home section; explicit destinations (answer-ready, Registry citation)
+   *  set the section in the same store commit so history sees one place. */
+  const showHome = (
+    homeSection?: "notebooks" | "chat" | "registry",
+    openCardId?: string,
+  ) => {
+    void getCurrentWebviewWindow().setTitle("Alchemy");
+    set({
+      currentId: null,
+      sources: [],
+      selectedSourceIds: null,
+      messages: [],
+      messagesHasMore: false,
+      messagesLoadingOlder: false,
+      notes: [],
+      reportSchedules: [],
+      ingestQueue: [],
+      steps: [],
+      waiting: "",
+      reader: { open: false, history: [], index: -1 },
+      ...(homeSection
+        ? {
+            homeSection,
+            openCardId:
+              homeSection === "registry" ? (openCardId ?? null) : null,
+          }
+        : {}),
+    });
+  };
+
   return {
     notebooks: [],
     currentId: null,
@@ -432,6 +482,13 @@ export const useStore = create<AppState>((set, get) => {
     ledgerBump: 0,
     registryBump: 0,
     homeSection: "notebooks",
+    homeChatTurns: parseHomeChatTurns(localStorage.getItem("homeChat:v1")),
+    homeChatSending: false,
+    homeChatQuestion: "",
+    homeChatStreamingText: "",
+    homeChatSteps: [],
+    homeChatWaiting: "",
+    metaAskOwner: null,
     homeView:
       (localStorage.getItem("homeView") as "grid" | "table") || "grid",
     homeQuery: "",
@@ -445,7 +502,10 @@ export const useStore = create<AppState>((set, get) => {
     reader: { open: false, history: [], index: -1 },
     // Home is always the floor of the app-level history; restores and
     // navigations stack on top of it via the location subscriber below.
-    nav: { stack: [{ nb: null, mode: "chat" }], index: 0 },
+    nav: {
+      stack: [{ nb: null, mode: "chat", homeSection: "notebooks" }],
+      index: 0,
+    },
     folderScan: null,
     importingFolders: [],
     noteReads: loadNoteReads(),
@@ -574,7 +634,7 @@ export const useStore = create<AppState>((set, get) => {
           doc?: ReaderDoc;
           readerHistory?: ReaderDoc[];
           readerIndex?: number;
-          section?: "notebooks" | "registry";
+          section?: "notebooks" | "chat" | "registry";
           card?: string | null;
         } | null = null;
         try {
@@ -643,6 +703,39 @@ export const useStore = create<AppState>((set, get) => {
       });
       void listen<{ label: string; transient: boolean }>("chat://step", (e) => {
         if (get().sending) get().appendStep(e.payload.label, e.payload.transient);
+      });
+      // Corpus-wide Home Chat is store-owned for the same reason as notebook
+      // chat: navigating away must not unbind its stream or lose tokens.
+      void listen<{ content: string }>("meta://token", (e) => {
+        if (!get().homeChatSending || get().metaAskOwner !== "home") return;
+        if (get().homeChatWaiting) set({ homeChatWaiting: "" });
+        homeChatTokenBuffer += e.payload.content;
+        if (homeChatTokenFlushHandle !== 0) return;
+        homeChatTokenFlushHandle = requestAnimationFrame(() => {
+          homeChatTokenFlushHandle = 0;
+          const chunk = homeChatTokenBuffer;
+          homeChatTokenBuffer = "";
+          if (
+            !get().homeChatSending ||
+            get().metaAskOwner !== "home" ||
+            !chunk
+          )
+            return;
+          set({
+            homeChatStreamingText: get().homeChatStreamingText + chunk,
+          });
+        });
+      });
+      void listen<{ label: string; transient: boolean }>("meta://step", (e) => {
+        if (!get().homeChatSending || get().metaAskOwner !== "home") return;
+        set(
+          e.payload.transient
+            ? { homeChatWaiting: e.payload.label }
+            : {
+                homeChatSteps: [...get().homeChatSteps, e.payload.label],
+                homeChatWaiting: "",
+              },
+        );
       });
       // Verify-and-repair swaps a revised answer under the same message id
       // (backend spawn_answer_verify) — apply only when the message is in
@@ -854,6 +947,7 @@ export const useStore = create<AppState>((set, get) => {
         if (e.payload.id === "menu-settings") s.openSettings();
         else if (e.payload.id === "menu-about") s.openSettings("about");
         else if (e.payload.id === "menu-search") s.togglePalette();
+        else if (e.payload.id === "menu-home-chat") s.openHomeSection("chat");
         else if (e.payload.id === "menu-check-updates") {
           set({ pendingUpdateCheck: true });
           s.openSettings("general");
@@ -1183,22 +1277,92 @@ export const useStore = create<AppState>((set, get) => {
       void api.resyncSources(id).catch(() => {});
     },
 
-    closeNotebook: () => {
-      void getCurrentWebviewWindow().setTitle("Alchemy");
+    closeNotebook: () => showHome(),
+    openHomeSection: (section, openCardId) => showHome(section, openCardId),
+
+    sendHomeMessage: async (question) => {
+      const q = question.trim();
+      if (!q || get().homeChatSending) return;
+      if (get().metaAskOwner) {
+        get().pushToast(
+          "info",
+          "Another library answer is already running. Stop it before starting Home Chat.",
+        );
+        return;
+      }
+      const history = homeChatHistory(get().homeChatTurns);
+      homeChatTokenBuffer = "";
+      if (homeChatTokenFlushHandle !== 0) {
+        cancelAnimationFrame(homeChatTokenFlushHandle);
+        homeChatTokenFlushHandle = 0;
+      }
       set({
-        currentId: null,
-        sources: [],
-        selectedSourceIds: null,
-        messages: [],
-        messagesHasMore: false,
-        messagesLoadingOlder: false,
-        notes: [],
-        reportSchedules: [],
-        ingestQueue: [],
-        steps: [],
-        waiting: "",
-        reader: { open: false, history: [], index: -1 },
+        homeChatSending: true,
+        homeChatQuestion: q,
+        homeChatStreamingText: "",
+        homeChatSteps: [],
+        homeChatWaiting: "",
+        metaAskOwner: "home",
       });
+      try {
+        const result = await api.askEverything(q, history);
+        const turns = appendHomeChatTurn(get().homeChatTurns, {
+          id: `home-chat-${Date.now()}`,
+          question: q,
+          answer: result.answer,
+          citations: result.citations,
+          status: "complete",
+          createdAt: Date.now(),
+        });
+        persistHomeChatTurns(turns);
+        set({ homeChatTurns: turns });
+        playDone();
+        if (get().currentId || get().homeSection !== "chat") {
+          get().pushToast("success", "Answer ready in Home Chat — click to open", () => {
+            get().openHomeSection("chat");
+          });
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        const turns = appendHomeChatTurn(get().homeChatTurns, {
+          id: `home-chat-${Date.now()}`,
+          question: q,
+          answer: message,
+          citations: [],
+          status: "error",
+          createdAt: Date.now(),
+        });
+        persistHomeChatTurns(turns);
+        set({ homeChatTurns: turns });
+        if (get().currentId || get().homeSection !== "chat")
+          get().pushToast("error", `Home Chat failed: ${message}`);
+        else playError();
+      } finally {
+        homeChatTokenBuffer = "";
+        if (homeChatTokenFlushHandle !== 0) {
+          cancelAnimationFrame(homeChatTokenFlushHandle);
+          homeChatTokenFlushHandle = 0;
+        }
+        set({
+          homeChatSending: false,
+          homeChatQuestion: "",
+          homeChatStreamingText: "",
+          homeChatSteps: [],
+          homeChatWaiting: "",
+          ...(get().metaAskOwner === "home" ? { metaAskOwner: null } : {}),
+        });
+        void get().refreshModelStats();
+      }
+    },
+
+    clearHomeChat: () => {
+      if (get().homeChatSending) return;
+      try {
+        localStorage.removeItem("homeChat:v1");
+      } catch {
+        /* the in-memory clear still succeeds */
+      }
+      set({ homeChatTurns: [] });
     },
 
     navBack: () => void applyNav(-1),
@@ -2738,7 +2902,13 @@ async function applyNav(delta: 1 | -1): Promise<void> {
     useStore.setState({ nav: { stack, index: at } });
     if (target.nb !== s.currentId) {
       if (target.nb) await s.selectNotebook(target.nb);
-      else s.closeNotebook();
+      else s.openHomeSection(target.homeSection ?? "notebooks");
+    }
+    if (!target.nb) {
+      useStore.setState({
+        homeSection: target.homeSection ?? "notebooks",
+        openCardId: target.openCardId ?? null,
+      });
     }
     const st = useStore.getState();
     if (target.mode === "reader" && target.doc) {
@@ -2762,35 +2932,27 @@ useStore.subscribe((s, prev) => {
     s.currentId === prev.currentId &&
     s.ledgerOpen === prev.ledgerOpen &&
     s.galleryOpen === prev.galleryOpen &&
-    s.reader === prev.reader
+    s.reader === prev.reader &&
+    s.homeSection === prev.homeSection &&
+    s.openCardId === prev.openCardId
   )
     return;
   if (navApplying) return;
-  const mode = s.galleryOpen
-    ? ("gallery" as const)
-    : s.ledgerOpen
-      ? ("ledger" as const)
-      : s.reader.open
-        ? ("reader" as const)
-        : ("chat" as const);
   const rdoc = s.reader.open ? s.reader.history[s.reader.index] : undefined;
-  // Highlight is a one-time citation jump, not a place — drop it.
-  const doc = rdoc && { type: rdoc.type, id: rdoc.id };
+  const entry = navEntryFromSnapshot({
+    currentId: s.currentId,
+    ledgerOpen: s.ledgerOpen,
+    galleryOpen: s.galleryOpen,
+    readerOpen: s.reader.open,
+    readerDoc: rdoc,
+    homeSection: s.homeSection,
+    openCardId: s.openCardId,
+  });
   const { stack, index } = s.nav;
   const cur = stack[index];
-  if (
-    cur &&
-    cur.nb === s.currentId &&
-    cur.mode === mode &&
-    cur.doc?.type === doc?.type &&
-    cur.doc?.id === doc?.id
-  )
-    return;
+  if (sameNavEntry(cur, entry)) return;
   // A fresh navigation discards forward entries, browser-style.
-  const next: NavEntry[] = [
-    ...stack.slice(0, index + 1),
-    { nb: s.currentId, mode, doc },
-  ];
+  const next: NavEntry[] = [...stack.slice(0, index + 1), entry];
   if (next.length > 100) next.splice(0, next.length - 100);
   useStore.setState({ nav: { stack: next, index: next.length - 1 } });
 });

--- a/src/lib/storeTypes.ts
+++ b/src/lib/storeTypes.ts
@@ -17,6 +17,7 @@ import type {
   ToastKind,
 } from "./types";
 import type { HistoryEntry } from "./history";
+import type { HomeChatTurn } from "./homeChat";
 
 export interface QueueItem {
   id: string;
@@ -43,6 +44,9 @@ export interface NavEntry {
   nb: string | null;
   mode: "chat" | "reader" | "ledger" | "gallery";
   doc?: { type: ReaderDoc["type"]; id: string };
+  /** Home is a first-class location too. Omitted on notebook entries. */
+  homeSection?: "notebooks" | "chat" | "registry";
+  openCardId?: string;
 }
 
 export interface ExternalAdd {
@@ -200,7 +204,18 @@ export interface AppState {
    *  a document). Corpus-scoped, so it fires with no notebook open. */
   registryBump: number;
   /** Home's center column: the notebook grid, or the Registry's cast. */
-  homeSection: "notebooks" | "registry";
+  homeSection: "notebooks" | "chat" | "registry";
+  /** Corpus-wide conversation owned by the store so a generation continues
+   *  while Home is unmounted and returning shows the accumulated stream. */
+  homeChatTurns: HomeChatTurn[];
+  homeChatSending: boolean;
+  homeChatQuestion: string;
+  homeChatStreamingText: string;
+  homeChatSteps: string[];
+  homeChatWaiting: string;
+  /** ask_everything broadcasts one meta stream per window. Serializing its
+   *  two consumers prevents Home Chat and the command palette mixing tokens. */
+  metaAskOwner: "home" | "palette" | null;
   /** How that column lays out. Cards are recognisable, rows are scannable
    *  and sortable — which one is "easier to find things in" depends on the
    *  collection, so it's a per-user choice, remembered. */
@@ -242,6 +257,12 @@ export interface AppState {
   refreshNotebooks: () => Promise<void>;
   selectNotebook: (id: string) => Promise<void>;
   closeNotebook: () => void;
+  /** Leave any notebook and land on one Home section in a single location
+   *  transition, so app back/forward records only the intended destination. */
+  openHomeSection: (
+    section: "notebooks" | "chat" | "registry",
+    openCardId?: string,
+  ) => void;
   navBack: () => void;
   navForward: () => void;
   /** Resolves to the new notebook's id. */
@@ -265,6 +286,8 @@ export interface AppState {
   togglePalette: () => void;
   openAddSource: (step?: "url" | "text") => void;
   closeAddSource: () => void;
+  sendHomeMessage: (question: string) => Promise<void>;
+  clearHomeChat: () => void;
 
   /** Omit the id to export the currently open notebook (palette/menu). */
   exportNotebookOkf: (notebookId?: string) => Promise<void>;


### PR DESCRIPTION
## Summary

- add a thin `alchemy` CLI for listing notebooks, ingesting files/URLs/stdin, and searching through the running app's MCP server
- add visible Back and Forward controls to Home and notebook headers using the existing navigation history
- add a persistent Home Chat for streamed questions across every notebook and Registry card, with bounded local history and navigable citations

## Implementation notes

- the CLI discovers the running app through `mcp.json`, while supporting explicit URL overrides for scripting
- Home Chat and the command palette serialize corpus-wide requests so their streams cannot mix
- Rust meta events target the requesting window, preserving correct behavior across multiple windows
- Home sections and Registry cards participate in Back/Forward history; View → Home Chat is also available from the native menu

## Validation

- `pnpm test` — 157 passed
- `pnpm test:cli` — 6 passed
- `pnpm build`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml` — 389 passed, 42 ignored
- packaged Tauri desktop QA: Home Chat layout, Home and workspace navigation controls, Back/Forward restoration, and View → Home Chat

The three corresponding Alchemy reminders were marked complete after validation.
