### PR TITLE
Start each Settings tab scrolled to the top

### DIFF
--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -219,8 +219,13 @@ export function SettingsDialog({
             {TABS.find((t) => t.id === tab)?.label}
           </h2>
           {/* The scroll cap MUST stay a definite height on this column (see
-              the note above); 11rem additionally clears the pane header. */}
-          <div className="flex max-h-[calc(92vh-11rem)] min-w-0 flex-col gap-4 overflow-y-auto px-1">
+              the note above); 11rem additionally clears the pane header.
+              key={tab}: the scroll position lives on this div, so switching
+              tabs would otherwise keep the old tab's scroll offset. */}
+          <div
+            key={tab}
+            className="flex max-h-[calc(92vh-11rem)] min-w-0 flex-col gap-4 overflow-y-auto px-1"
+          >
           {tab === "general" && <GeneralTab />}
           {tab === "background" && <BackgroundTab />}
           {tab === "sources" && <SourcesTab />}


### PR DESCRIPTION
The Settings tab panes share one scroll container, so scrolling a long tab to the bottom carried that offset into the next tab. The container is now keyed by tab, remounting it fresh at the top on every switch (the tab content already remounts anyway).

Verified live: scrolled Models to 827px, switched to General → scrollTop 0, and back to Models → 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)