### PR TITLE
Tokens generated on the Activity tab, evened into a 4x3 grid

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -11183,6 +11183,12 @@ pub async fn activity_stats(
         chrono::Local::now().date_naive(),
     );
     stats.background_cost_micros = background_cost_micros;
+    // Lifetime output tokens, straight off the persisted throughput
+    // accumulators — the same record the model-speed ranking reads.
+    stats.tokens_generated = {
+        let map = state.model_stats.lock().unwrap();
+        map.values().map(|a| a.total_tokens as i64).sum()
+    };
     Ok(stats)
 }
 

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -643,4 +643,10 @@ pub struct ActivityStats {
     /// are free rather than unrecorded.
     #[serde(default)]
     pub background_cost_micros: i64,
+    /// Measured output tokens across every recorded generation (chat,
+    /// meta-chat, background runs) — the lifetime sum of the per-model
+    /// throughput accumulators, so it counts what the engines reported,
+    /// not an estimate.
+    #[serde(default)]
+    pub tokens_generated: i64,
 }

--- a/src/components/settings/ActivityTab.tsx
+++ b/src/components/settings/ActivityTab.tsx
@@ -5,6 +5,7 @@ import { Spinner } from "../ui";
 import { TileShader } from "./TileShader";
 import type { ActivityStats, ModelStat } from "@/lib/types";
 import {
+  BookOpen,
   CalendarDays,
   Clock,
   Flame,
@@ -53,11 +54,6 @@ function dayKey(d: Date): string {
   const m = String(d.getMonth() + 1).padStart(2, "0");
   const day = String(d.getDate()).padStart(2, "0");
   return `${d.getFullYear()}-${m}-${day}`;
-}
-
-function wordsLine(words: number): string | null {
-  if (words < 1000) return null;
-  return `Your sources hold ~${compact.format(words)} words.`;
 }
 
 /** Time-of-day identity for the peak-hour tile — the icon IS the value,
@@ -425,7 +421,8 @@ export function ActivityTab() {
         year: "numeric",
       })
     : null;
-  const book = wordsLine(Math.round(stats.corpusChars / 6));
+  // chars/6 ≈ words; the ~ in the tile keeps the estimate honest.
+  const sourceWords = Math.round(stats.corpusChars / 6);
 
   return (
     <div className="flex flex-col gap-4 pb-2">
@@ -463,6 +460,13 @@ export function ActivityTab() {
           value={compact.format(ranged.sources)}
           icon={Library}
         />
+        {sourceWords >= 1000 && (
+          <Tile
+            label="Words in sources"
+            value={`~${compact.format(sourceWords)}`}
+            icon={BookOpen}
+          />
+        )}
         <Tile
           label="Notes"
           value={compact.format(ranged.notes)}
@@ -504,10 +508,19 @@ export function ActivityTab() {
           icon={Trophy}
         />
         <Tile
-          label="Background spend"
-          value={money(stats.backgroundCostMicros)}
-          icon={Receipt}
+          label="Tokens generated"
+          value={compact.format(stats.tokensGenerated || 0)}
+          icon={Zap}
         />
+        {/* The spend tile earns its spot only once something actually cost
+            money — an eternal $0.00 is the least interesting number here. */}
+        {stats.backgroundCostMicros > 0 && (
+          <Tile
+            label="Background spend"
+            value={money(stats.backgroundCostMicros)}
+            icon={Receipt}
+          />
+        )}
         {/* The sky IS the value: the sun sits where the hour puts it, or
             stars come out for a night-owl peak. */}
         <Tile
@@ -530,18 +543,14 @@ export function ActivityTab() {
         />
       </div>
 
-      <div className="text-caption text-subtle-foreground">
-        Background spend covers scheduled work over the last 30 days. Local
-        models are free, so it stays at $0.00 unless you point a role at a paid
-        provider.
-      </div>
+      {stats.backgroundCostMicros > 0 && (
+        <div className="text-caption text-subtle-foreground">
+          Background spend covers scheduled work over the last 30 days. Local
+          models are free, so only paid-provider runs show up here.
+        </div>
+      )}
 
-      <div className="flex flex-col gap-1.5">
-        <Heatmap stats={stats} />
-        {book && (
-          <div className="text-caption text-subtle-foreground">{book}</div>
-        )}
-      </div>
+      <Heatmap stats={stats} />
 
       <div className="grid grid-cols-2 gap-5">
         <CountList title="Most used models" rows={stats.models} />

--- a/src/components/settings/ActivityTab.tsx
+++ b/src/components/settings/ActivityTab.tsx
@@ -7,6 +7,8 @@ import type { ActivityStats, ModelStat } from "@/lib/types";
 import {
   BookOpen,
   CalendarDays,
+  NotebookText,
+  PenLine,
   Clock,
   Flame,
   Library,
@@ -451,31 +453,44 @@ export function ActivityTab() {
 
       <div className="grid grid-cols-4 gap-2">
         <Tile
-          label="Messages"
-          value={compact.format(ranged.messages)}
-          icon={MessageSquare}
+          label="Notebooks"
+          value={compact.format(stats.totalNotebooks)}
+          icon={NotebookText}
         />
         <Tile
           label="Sources"
           value={compact.format(ranged.sources)}
           icon={Library}
         />
-        {sourceWords >= 1000 && (
-          <Tile
-            label="Words in sources"
-            value={`~${compact.format(sourceWords)}`}
-            icon={BookOpen}
-          />
-        )}
+        <Tile
+          label="Words in sources"
+          value={`~${compact.format(sourceWords)}`}
+          icon={BookOpen}
+        />
         <Tile
           label="Notes"
           value={compact.format(ranged.notes)}
           icon={StickyNote}
         />
         <Tile
+          label="Messages"
+          value={compact.format(ranged.messages)}
+          icon={MessageSquare}
+        />
+        <Tile
           label="Retrievals"
           value={compact.format(ranged.retrievals)}
           icon={Search}
+        />
+        <Tile
+          label="Tokens generated"
+          value={compact.format(stats.tokensGenerated || 0)}
+          icon={Zap}
+        />
+        <Tile
+          label="Words written"
+          value={compact.format(stats.assistantWords)}
+          icon={PenLine}
         />
         <Tile
           label="Active days"
@@ -506,11 +521,6 @@ export function ActivityTab() {
           label="Longest streak"
           value={`${String(stats.longestStreak)}d`}
           icon={Trophy}
-        />
-        <Tile
-          label="Tokens generated"
-          value={compact.format(stats.tokensGenerated || 0)}
-          icon={Zap}
         />
         {/* The spend tile earns its spot only once something actually cost
             money — an eternal $0.00 is the least interesting number here. */}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -375,6 +375,8 @@ export interface ActivityStats {
    *  millionths of a dollar. Background work only, and 0 when every run was
    *  local — local models are free, not unrecorded. */
   backgroundCostMicros: number;
+  /** Measured output tokens across every recorded generation, lifetime. */
+  tokensGenerated: number;
 }
 
 /** One exact-match window from the `/grep` chat command (Rust grep_sources). */


### PR DESCRIPTION
The Activity tab's numbers get more interesting and the grid gets even.

- New **Tokens generated** tile: the lifetime sum of output tokens read off the persisted per-model throughput accumulators — measured by the engines, not estimated (223.4K on the dev store).
- The $0.00 **Background spend** tile and its explainer paragraph now render only when something actually cost money.
- **Words in sources** moves up from a caption under the heatmap into the metric tiles.
- Two more tiles the stats already measured but never showed — **Notebooks** and **Words written** — fill the grid to a themed 4x3: corpus row, conversation row, rhythm row.

Verified live: activity_stats returns tokensGenerated 223370; the tab renders all twelve tiles with spend hidden at $0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
