### PR TITLE
Shader growth charts on the Activity tiles

### DIFF
--- a/src/components/settings/ActivityTab.tsx
+++ b/src/components/settings/ActivityTab.tsx
@@ -68,6 +68,37 @@ function peakHourFace(h: number): LucideIcon {
   return Sunset;
 }
 
+/** Cumulative growth series for the spark tiles: per-day counts summed
+ *  over calendar time (inactive days hold flat — a gap is a plateau, not
+ *  a cliff), bucketed to the shader's 48-point uniform and normalized so
+ *  the curve always ends at 1. Empty when there's nothing to draw. */
+function growthSeries(
+  days: ActivityStats["days"],
+  pick: (d: ActivityStats["days"][number]) => number,
+): number[] {
+  if (days.length < 2) return [];
+  const by = new Map(days.map((d) => [d.date, pick(d)]));
+  const cursor = new Date(days[0].date + "T00:00");
+  const last = days[days.length - 1].date;
+  const daily: number[] = [];
+  let cum = 0;
+  for (let guard = 0; guard < 3660; guard++) {
+    const key = dayKey(cursor);
+    cum += by.get(key) ?? 0;
+    daily.push(cum);
+    if (key === last) break;
+    cursor.setDate(cursor.getDate() + 1);
+  }
+  const total = daily[daily.length - 1];
+  if (total <= 0) return [];
+  const stride = Math.ceil(daily.length / 48);
+  const out: number[] = [];
+  for (let i = stride - 1; i < daily.length; i += stride)
+    out.push(daily[i] / total);
+  if (out[out.length - 1] !== 1) out.push(1);
+  return out.length >= 2 ? out : [];
+}
+
 /** Micro-dollars as money. Sub-cent spend rounds to "$0.00" rather than
  *  being dressed up in extra decimals: the point of the tile is the order of
  *  magnitude, and a fake precision on a cost is the thing to avoid. */
@@ -425,6 +456,12 @@ export function ActivityTab() {
     : null;
   // chars/6 ≈ words; the ~ in the tile keeps the estimate honest.
   const sourceWords = Math.round(stats.corpusChars / 6);
+  // Growth curves for the spark tiles. Sources/day genuinely shapes the
+  // corpus curve; messages/day stands in for token history (tokens are
+  // only kept as a running total), so that curve is the right shape drawn
+  // from a correlated record, not a measurement.
+  const corpusCurve = growthSeries(stats.days, (d) => d.sources);
+  const tokensCurve = growthSeries(stats.days, (d) => d.messages);
 
   return (
     <div className="flex flex-col gap-4 pb-2">
@@ -461,11 +498,31 @@ export function ActivityTab() {
           label="Sources"
           value={compact.format(ranged.sources)}
           icon={Library}
+          shader={
+            corpusCurve.length > 0 ? (
+              <TileShader
+                mode="spark"
+                series={corpusCurve}
+                tintVar="--primary"
+                intensity={0.8}
+              />
+            ) : undefined
+          }
         />
         <Tile
           label="Words in sources"
           value={`~${compact.format(sourceWords)}`}
           icon={BookOpen}
+          shader={
+            corpusCurve.length > 0 ? (
+              <TileShader
+                mode="spark"
+                series={corpusCurve}
+                tintVar="--primary"
+                intensity={0.8}
+              />
+            ) : undefined
+          }
         />
         <Tile
           label="Notes"
@@ -486,11 +543,31 @@ export function ActivityTab() {
           label="Tokens generated"
           value={compact.format(stats.tokensGenerated || 0)}
           icon={Zap}
+          shader={
+            tokensCurve.length > 0 ? (
+              <TileShader
+                mode="spark"
+                series={tokensCurve}
+                tintVar="--primary"
+                intensity={0.8}
+              />
+            ) : undefined
+          }
         />
         <Tile
           label="Words written"
           value={compact.format(stats.assistantWords)}
           icon={PenLine}
+          shader={
+            tokensCurve.length > 0 ? (
+              <TileShader
+                mode="spark"
+                series={tokensCurve}
+                tintVar="--primary"
+                intensity={0.8}
+              />
+            ) : undefined
+          }
         />
         <Tile
           label="Active days"

--- a/src/components/settings/TileShader.tsx
+++ b/src/components/settings/TileShader.tsx
@@ -12,20 +12,28 @@ import { useReducedMotion } from "../DitherBackground";
  *   sky   — the peak-hour tile's weather: a soft sun whose position across
  *           the tile IS the hour (dawn left, noon high, dusk right), or a
  *           sparse twinkling starfield at night.
+ *   spark — a cumulative growth chart as weather: `series` (0–1, left to
+ *           right in time) becomes a dithered area fill rising toward the
+ *           right. The data IS the field.
  */
+const MAX_SERIES = 48;
+
 export function TileShader({
   mode,
   hour = 12,
   intensity = 1,
   tintVar,
+  series,
 }: {
-  mode: "ember" | "sky";
+  mode: "ember" | "sky" | "spark";
   /** Local hour 0–23; only the sky reads it. */
   hour?: number;
   /** 0–1 luminance multiplier. */
   intensity?: number;
   /** CSS custom property to tint with, e.g. "--artifact-template". */
   tintVar: string;
+  /** Normalized cumulative values, oldest first; only spark reads it. */
+  series?: number[];
 }) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const reducedMotion = useReducedMotion();
@@ -66,9 +74,22 @@ export function TileShader({
     const uGain = gl.getUniformLocation(program, "u_gain");
     const uMode = gl.getUniformLocation(program, "u_mode");
     const uHour = gl.getUniformLocation(program, "u_hour");
+    // "u_series[0]" is the array's canonical name — some GL stacks return
+    // null for the bare name, and uniform1fv on null is a silent no-op.
+    const uSeries =
+      gl.getUniformLocation(program, "u_series[0]") ??
+      gl.getUniformLocation(program, "u_series");
+    const uN = gl.getUniformLocation(program, "u_n");
     gl.uniform1f(uGain, intensity);
-    gl.uniform1f(uMode, mode === "ember" ? 0 : 1);
+    gl.uniform1f(uMode, mode === "ember" ? 0 : mode === "sky" ? 1 : 2);
     gl.uniform1f(uHour, hour);
+    // The series rides a fixed-size uniform array (GLSL ES 1.0 has no
+    // dynamic arrays); downsampling past MAX_SERIES is the caller's job.
+    const pts = (series ?? []).slice(-MAX_SERIES);
+    const packed = new Float32Array(MAX_SERIES);
+    packed.set(pts.map((v) => Math.max(0, Math.min(1, v))));
+    gl.uniform1fv(uSeries, packed);
+    gl.uniform1f(uN, Math.max(2, pts.length));
     const tint = hexToRgb(
       getComputedStyle(document.documentElement)
         .getPropertyValue(tintVar)
@@ -118,7 +139,8 @@ export function TileShader({
       gl.deleteBuffer(buf);
       gl.deleteProgram(program);
     };
-  }, [mode, hour, intensity, tintVar, reducedMotion]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- series compared by content
+  }, [mode, hour, intensity, tintVar, reducedMotion, (series ?? []).join(",")]);
 
   return (
     <canvas
@@ -149,6 +171,8 @@ uniform vec3 u_tint;
 uniform float u_gain;
 uniform float u_mode;
 uniform float u_hour;
+uniform float u_series[48];
+uniform float u_n;
 
 float hash(vec2 p){ return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453123); }
 float vnoise(vec2 p){
@@ -213,9 +237,44 @@ float skyField(vec2 uv){
   return clamp(disc * 0.95 + glow + haze, 0.0, 1.0);
 }
 
+// spark — the growth chart. Linear interpolation across the series (the
+// constant-index loop is GLSL ES 1.0's price for array access), then an
+// area fill that brightens toward its own top edge, a soft crest line,
+// and a slow shimmer inside the fill so the chart reads as weather, not
+// chrome. gl_FragCoord's bottom-left origin means the area rises from
+// the tile floor for free.
+float seriesAt(float x){
+  float fi = clamp(x, 0.0, 1.0) * (u_n - 1.0);
+  float i0 = floor(fi);
+  float v0 = 0.0; float v1 = 0.0;
+  for (int i = 0; i < 48; i++) {
+    float f = float(i);
+    if (f == i0) v0 = u_series[i];
+    if (f == i0 + 1.0) v1 = u_series[i];
+  }
+  if (i0 >= u_n - 1.0) v1 = v0;
+  return mix(v0, v1, fi - i0);
+}
+
+float sparkField(vec2 uv){
+  float t = mod(u_time, 2048.0);
+  // Ceiling at 0.55: the curve lives under the tile's label block, never
+  // behind it — the chart is weather for the number, not a rival.
+  float h = 0.05 + 0.50 * seriesAt(uv.x);
+  float inside = step(uv.y, h);
+  // Thin fill, bright crest: it should read as a chart line with a wash
+  // under it, not a flood.
+  float fill = inside * (0.12 + 0.22 * smoothstep(0.0, h, uv.y));
+  float crest = smoothstep(0.035, 0.0, abs(uv.y - h));
+  float shimmer = 0.08 * vnoise(vec2(uv.x * 5.0 + t * 0.12, uv.y * 4.0 - t * 0.05));
+  return clamp(fill + crest + shimmer * inside, 0.0, 1.0);
+}
+
 void main(){
   vec2 uv = gl_FragCoord.xy / u_res;
-  float L = u_mode < 0.5 ? emberField(uv) : skyField(uv);
+  float L = u_mode < 0.5 ? emberField(uv)
+          : u_mode < 1.5 ? skyField(uv)
+          : sparkField(uv);
   float d = bayer4(gl_FragCoord.xy) - 0.5;
   // 6 levels (vs the backdrops' 5): tile features are small, so a step more
   // tonal resolution keeps the sun's edge from dissolving.


### PR DESCRIPTION
Growth-over-time shader charts behind the Activity tab's growth tiles.

- New `spark` mode for TileShader: a cumulative series (up to 48 points) rides a uniform float array and renders as a dithered area chart in the theme primary — same WebGL1/Bayer family as ember and sky, capped below the tile's label block so the chart stays weather for the number.
- Sources and Words in sources draw the real per-day source cumsum from `stats.days`; Tokens generated and Words written draw the messages cumsum (tokens keep only a running total, so this is the right shape from a correlated record, not a measurement). Inactive days plateau rather than gap.
- Gotcha fixed along the way: the array uniform must be looked up by its canonical name `u_series[0]` — the bare name returns null on some GL stacks and `uniform1fv` on null no-ops silently, which flattens the chart to nothing.

Verified live against the dev store: all four tiles render, the Jul 30 bulk-import cliff is legible, labels stay clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
