### PR TITLE
The generation queue, plus the post-release quick wins

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -267,6 +267,36 @@ What each clause means here:
 
 When a rule here conflicts with a web idiom, the Mac wins.
 
+### Multi-select — the Finder pattern
+
+Any surface listing selectable objects (source rows, gallery cards, note
+rows, registry index) speaks one selection dialect, implemented once:
+
+- **One shared selection.** Rows/cards carry `data-pick-id`; selection
+  lives in the store's `picked` (kind + ids). The same objects shown on
+  two surfaces (sidebar rows, gallery cards) share one selection — pick
+  in either, both show it.
+- **The gestures.** Plain click acts on the object (open). ⌘-click
+  toggles. Shift-click ranges over the surface's visible order. A drag on
+  the background rubber-bands (`useMarquee`); ⇧/⌘-drag unions against the
+  selection as it stood when the drag began. Escape/background-click
+  clears.
+- **Selection is chrome.** The list container is `select-none` — object
+  text never becomes a native text selection under a band. (The marquee's
+  own `userSelect` guard only lands after the 4px drag threshold, so the
+  container class is load-bearing, not belt-and-braces.) Prose surfaces
+  (reader, chat) never host marquees; they keep real text selection.
+- **The click after a band is the band's tail** — suppress it
+  (`justEnded()`), or the drag "opens" whatever it ended on.
+- **Selected look**: `ring-1 ring-primary` (offset on cards), never a
+  tonal fill — hairlines over washes, §1.
+- **Batch verbs ride the object menu.** Right-clicking a selected object
+  shows the batch variants with counts ("Remove 4 sources…") in place of
+  the singular menu; no separate toolbar appears.
+- **Drag-out beats band** on surfaces whose rows export as files
+  (`data-drag-out`): pressing an item means "take this file"; bands begin
+  on background only — Finder draws the same line.
+
 ## 10. Agent Prompt Guide
 
 Quick reference for agents building UI here:

--- a/docs/RFC-generation-queue.md
+++ b/docs/RFC-generation-queue.md
@@ -1,6 +1,6 @@
 # RFC: The Generation Queue
 
-**Status:** Draft, awaiting review
+**Status:** Shipped (v1 — mid-stream checkpoints and a cross-notebook queue view remain out of scope)
 **Owner:** Paul
 **Prior art:** NotebookLM's studio queue; docs/RFC-diagnostics.md (Staff events); docs/RFC-living-notebook.md (background sweeps)
 

--- a/docs/RFC-generation-queue.md
+++ b/docs/RFC-generation-queue.md
@@ -1,0 +1,105 @@
+# RFC: The Generation Queue
+
+**Status:** Draft, awaiting review
+**Owner:** Paul
+**Prior art:** NotebookLM's studio queue; docs/RFC-diagnostics.md (Staff events); docs/RFC-living-notebook.md (background sweeps)
+
+## Problem
+
+Document generation blocks the studio. `generateArtifact` refuses to start
+while `generatingKind` is set, so one generation locks every tile in every
+notebook; the result only exists when the full pipeline returns, so an app
+restart mid-run loses the work invisibly; and when the chat role points at
+Ollama while Ollama is down, the run dies with an error the user discovers
+only after waiting.
+
+NotebookLM's answer is the right shape: the artifact appears **immediately**
+as a pending item, progress lives on the item, several can cook at once, and
+the studio stays interactive throughout.
+
+## Design
+
+### 1. Jobs, persisted
+
+A generation becomes a **job** in a queue the backend owns:
+
+```
+GenJob { id, notebook_id, kind, template_id?, prompt?, source_ids,
+         note_id, status, error, progress_chars, created_at, updated_at }
+status: queued | running | waiting-engine | done | error | cancelled
+```
+
+Jobs persist to `<app-data>/generation-queue.json` — a sidecar, not a Lance
+column, for the same reason as the growth flags: the store is shared
+dev/prod and schema changes brick older binaries. The file is small (jobs
+prune once `done`/`cancelled` and older than a day).
+
+### 2. The pending note is the artifact
+
+Enqueueing **creates the note immediately** with `status: "pending"` and a
+placeholder body. It renders in Studio at the top of the notes list with a
+progress indicator and a Stop verb — the same place the result will land,
+so there is no separate "queue UI" to learn. Progress streams over
+`generation://progress` events keyed by job id (chars so far, stage label).
+On completion the note flips to `ready` in place; on error it shows the
+message with Retry/Remove verbs. Deleting a pending note cancels its job.
+
+### 3. A backend worker owns execution
+
+Today the webview awaits the whole pipeline, which is why reload kills it.
+Instead the enqueue command returns as soon as the job and pending note
+exist; a worker task inside the backend drains the queue. The webview is a
+spectator — reload, navigate, or close the window and the run continues.
+
+Concurrency: **one job per engine at a time** — local engines (Ollama, the
+built-in, MLX) serialize because parallel decodes thrash the same GPU/RAM,
+while distinct engines (a cloud gateway beside Ollama) run in parallel.
+This gives "more than one at a time" exactly when it actually helps.
+
+### 4. Engine-down means paused, not dead
+
+Before running a job the worker probes the role's engine (the existing
+health-check path). Unreachable → the job parks as `waiting-engine`, the
+pending note says "Waiting for Ollama — it isn't running", and a Staff
+event announces it once. The worker re-probes every 30s and auto-resumes
+when the engine answers; models loading cold are just a slow first token,
+already handled. Cancel remains available while parked.
+
+### 5. Restart resume
+
+At boot the worker reloads the queue file. Jobs found `running` (the app
+died mid-run) re-enter as `queued` and restart from scratch — generation is
+cheap relative to the complexity of mid-stream checkpoints, and the pending
+note is still there to show it. `waiting-engine` jobs resume waiting.
+(Checkpointed partial content is a possible v2; not in scope here.)
+
+### 6. Agent-reachable
+
+MCP gains `list_generations`, plus enqueue via the existing generate tools
+(they now return a job id immediately) and `cancel_generation`. The Staff
+feed shows queue activity the same way wiki/growth events land today.
+
+## What changes for the user
+
+- Click three generator tiles in a row: three pending notes appear, each
+  with live progress; the studio never locks.
+- Restart the app mid-generation: the pending notes are still there,
+  running again on their own.
+- Ollama off: the note says so plainly and the run starts by itself once
+  Ollama is back — no silent failure, no lost click.
+
+## Out of scope
+
+- Mid-stream content checkpoints (v2).
+- Cross-notebook queue UI — the pending notes in each notebook are the UI.
+- Priorities/reordering: FIFO per engine is enough at this scale.
+
+## Implementation notes
+
+- `begin_generation(scope)`'s per-scope cancellation tokens generalize to
+  per-job tokens; the global `generatingKind` gate in the store shrinks to
+  "is *this notebook's* studio streaming a preview".
+- The audio path (podcast) joins the same queue with `kind: "audio"`; its
+  progress events already exist.
+- `justCreatedNoteId` auto-open behavior moves to job completion, keeping
+  the "result appears where you acted" rule when the notebook is open.

--- a/docs/index.html
+++ b/docs/index.html
@@ -297,6 +297,20 @@
     white-space: nowrap;
   }
   .brew .prompt { color: var(--subtle); user-select: none; }
+  .brew .copy {
+    display: inline-flex;
+    align-items: center;
+    margin-left: 4px;
+    padding: 2px;
+    border: 0;
+    border-radius: 5px;
+    background: none;
+    color: var(--subtle);
+    cursor: pointer;
+    transition: color 0.15s ease;
+  }
+  .brew .copy:hover { color: var(--ink); }
+  .brew .copy svg { display: block; width: 13px; height: 13px; }
 
   /* ---------- product visual ---------- */
 
@@ -2141,6 +2155,60 @@
   </div>
 </footer>
 
+<script>
+// Copy buttons on the command snippets: the button rides inside each
+// .brew block, copies the command without its $ prompt, and confirms
+// with a brief check.
+(() => {
+  const clipboard =
+    '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" aria-hidden="true"><rect x="5.5" y="5.5" width="8" height="8" rx="1.5"/><path d="M10.5 5.5v-2a1.5 1.5 0 0 0-1.5-1.5H4A1.5 1.5 0 0 0 2.5 3.5v5A1.5 1.5 0 0 0 4 10h1.5"/></svg>';
+  const check =
+    '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><path d="M3 8.5 6.5 12 13 4.5"/></svg>';
+  document.querySelectorAll("code.brew").forEach((block) => {
+    const command = Array.from(block.childNodes)
+      .filter((n) => !(n.nodeType === 1 && n.classList.contains("prompt")))
+      .map((n) => n.textContent)
+      .join("")
+      .trim();
+    const btn = document.createElement("button");
+    btn.className = "copy";
+    btn.type = "button";
+    btn.title = "Copy command";
+    btn.setAttribute("aria-label", "Copy command");
+    btn.innerHTML = clipboard;
+    btn.addEventListener("click", () => {
+      const confirm = () => {
+        btn.innerHTML = check;
+        setTimeout(() => {
+          btn.innerHTML = clipboard;
+        }, 1200);
+      };
+      // execCommand fallback covers file:// and other non-secure contexts
+      // where the async clipboard API refuses.
+      const fallback = () => {
+        const ta = document.createElement("textarea");
+        ta.value = command;
+        ta.style.position = "fixed";
+        ta.style.opacity = "0";
+        document.body.appendChild(ta);
+        ta.select();
+        try {
+          document.execCommand("copy");
+          confirm();
+        } finally {
+          ta.remove();
+        }
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(command).then(confirm, fallback);
+      } else {
+        fallback();
+      }
+    });
+    block.appendChild(btn);
+  });
+})();
+</script>
 <script>
 (() => {
   const sceneIds = {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -155,6 +155,9 @@ pub struct AppState {
     /// Last successfully applied glass state per window label
     /// (enabled, dark, pinned) — evicted on window destroy in lib.rs.
     pub glass_applied: Mutex<HashMap<String, (bool, bool, bool)>>,
+    /// The generation queue (genqueue.rs): pending-note jobs the backend
+    /// worker drains independently of any window.
+    pub gen_queue: crate::genqueue::GenQueue,
 }
 
 /// Background sweeps outlive any one command and hold no Tauri handle (the
@@ -7305,7 +7308,18 @@ async fn try_tool_route(
                     transient: false,
                 },
             );
-            match generate_content(state, None, notebook_id, &kind, &prompt, None, None, None).await
+            match generate_content(
+                state,
+                None,
+                notebook_id,
+                &kind,
+                &prompt,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
             {
                 Ok((title, body)) => {
                     let ts = now();
@@ -9350,6 +9364,10 @@ async fn generate_content(
     source_ids: Option<&[String]>,
     prior_report: Option<&str>,
     provider: Option<&str>,
+    // When set, tokens emit as note-tagged `generation://token` events
+    // (the queue's per-job stream) instead of the window-global
+    // `artifact://token`.
+    stream_note: Option<&str>,
 ) -> anyhow::Result<(String, String)> {
     // Instruction base by kind precedence: "template:<id>" resolves the
     // template at RUN time (a schedule tracks the template's current body,
@@ -9495,7 +9513,7 @@ async fn generate_content(
         rag::persona_block(&ai.config().profile)
     };
     let messages = rag::build_artifact_messages(&instruction, &corpus, &persona);
-    let mut content = run_generation_chat(state, app, &messages, provider).await?;
+    let mut content = run_generation_chat(state, app, &messages, provider, stream_note).await?;
 
     // A twenty-minute episode is ~3,000 words, and chat models routinely fade
     // early. Continue the episode (dropping any premature outro) until it's
@@ -9509,7 +9527,7 @@ async fn generate_content(
             }
             let trimmed = strip_outro(&content);
             let messages = rag::build_audio_continuation(&instruction, &corpus, &persona, &trimmed);
-            let more = run_generation_chat(state, app, &messages, provider).await?;
+            let more = run_generation_chat(state, app, &messages, provider, stream_note).await?;
             // A tiny continuation means the model considers the episode done.
             if more.split_whitespace().count() < 100 {
                 break;
@@ -9527,7 +9545,27 @@ async fn run_generation_chat(
     app: Option<&AppHandle>,
     messages: &[crate::ai::ChatTurn],
     provider: Option<&str>,
+    stream_note: Option<&str>,
 ) -> anyhow::Result<String> {
+    let emit_tok = {
+        let note_id = stream_note.map(|s| s.to_string());
+        move |app: &AppHandle, tok: &str| match &note_id {
+            Some(nid) => {
+                let _ = app.emit(
+                    "generation://token",
+                    serde_json::json!({ "noteId": nid, "content": tok }),
+                );
+            }
+            None => {
+                let _ = app.emit(
+                    "artifact://token",
+                    TokenEvent {
+                        content: tok.to_string(),
+                    },
+                );
+            }
+        }
+    };
     let (text, stats, model) = {
         let ai = state.ai.read().await.clone();
         // A per-call provider override (the MCP generate tool's optional
@@ -9563,27 +9601,17 @@ async fn run_generation_chat(
         let out = match (&overridden, app) {
             (Some((engine, _)), Some(app)) => {
                 let app = app.clone();
+                let emit_tok = emit_tok.clone();
                 engine
-                    .chat_stream(messages, move |tok| {
-                        let _ = app.emit(
-                            "artifact://token",
-                            TokenEvent {
-                                content: tok.to_string(),
-                            },
-                        );
-                    })
+                    .chat_stream(messages, move |tok| emit_tok(&app, tok))
                     .await?
             }
             (Some((engine, _)), None) => engine.chat(messages).await?,
             (None, Some(app)) => {
                 let app = app.clone();
+                let emit_tok = emit_tok.clone();
                 ai.chat_role_stream(crate::inference::Role::Generate, messages, move |tok| {
-                    let _ = app.emit(
-                        "artifact://token",
-                        TokenEvent {
-                            content: tok.to_string(),
-                        },
-                    );
+                    emit_tok(&app, tok)
                 })
                 .await?
             }
@@ -9623,6 +9651,154 @@ pub(crate) fn strip_outro(script: &str) -> String {
     lines[..end].join("\n")
 }
 
+/// The pending note's display title for a queued generation — also the
+/// kind validation: an unknown kind errors at the call, not twenty
+/// seconds into a background job.
+pub(crate) fn placeholder_title(kind: &str, prompt: &str) -> anyhow::Result<String> {
+    if let Some(id) = kind.strip_prefix("template:") {
+        return crate::templates::list_templates()
+            .map_err(|e| anyhow::anyhow!(e))?
+            .into_iter()
+            .find(|t| t.id == id)
+            .map(|t| t.name)
+            .ok_or_else(|| anyhow::anyhow!("no template with id {id}"));
+    }
+    match rag::artifact_spec(kind) {
+        Some((t, _)) => Ok(format!("{t} (generating…)")),
+        None if !prompt.trim().is_empty() => Ok("Report (generating…)".to_string()),
+        None => anyhow::bail!(
+            "unknown kind \"{kind}\" — use one of {}, template:<id>, or \"custom\" with a prompt",
+            rag::ARTIFACT_KINDS.join(", ")
+        ),
+    }
+}
+
+/// Queue a generation (docs/RFC-generation-queue.md): the pending note
+/// exists the moment this returns, and the queue worker does the rest —
+/// the caller never blocks on the model.
+pub(crate) async fn enqueue_generation_impl(
+    state: &AppState,
+    notebook_id: &str,
+    kind: &str,
+    prompt: &str,
+    source_ids: Option<Vec<String>>,
+    provider: Option<String>,
+    origin: &str,
+) -> anyhow::Result<Note> {
+    // Fail fast on an unknown provider id — a typo should error at the
+    // call, not as a dead pending note discovered later.
+    if let Some(id) = provider.as_deref() {
+        let ai = state.ai.read().await.clone();
+        ai.engine_for_provider(id)?;
+    }
+    let title = placeholder_title(kind, prompt)?;
+    let ts = now();
+    let note = Note {
+        id: new_id(),
+        notebook_id: notebook_id.to_string(),
+        title,
+        content: String::new(),
+        kind: kind.to_string(),
+        prompt: prompt.to_string(),
+        origin: origin.to_string(),
+        status: "generating".to_string(),
+        created_at: ts,
+        updated_at: ts,
+    };
+    // Stored but NOT indexed: an empty in-flight note has nothing for
+    // retrieval yet; indexing happens on completion.
+    state.db.add_note(&note).await?;
+    state.gen_queue.enqueue(crate::genqueue::GenJob {
+        id: new_id(),
+        notebook_id: notebook_id.to_string(),
+        kind: kind.to_string(),
+        prompt: prompt.to_string(),
+        source_ids,
+        note_id: note.id.clone(),
+        status: "queued".to_string(),
+        error: String::new(),
+        provider,
+        engine_key: String::new(),
+        created_at: ts,
+        updated_at: ts,
+    });
+    Ok(note)
+}
+
+/// One queued job's full production: content, then synthesis for audio
+/// kinds — a failed synthesis is a failed job, never a half artifact.
+pub(crate) async fn generate_content_for_job(
+    state: &AppState,
+    app: &AppHandle,
+    job: &crate::genqueue::GenJob,
+    cancel: &tokio_util::sync::CancellationToken,
+) -> anyhow::Result<(String, String)> {
+    let (title, content) = generate_content(
+        state,
+        Some(app),
+        &job.notebook_id,
+        &job.kind,
+        &job.prompt,
+        job.source_ids.as_deref(),
+        None,
+        job.provider.as_deref(),
+        Some(&job.note_id),
+    )
+    .await?;
+    if job.kind == "audio_overview" {
+        synthesize_audio(app, &job.note_id, &content, cancel).await?;
+    }
+    Ok((title, content))
+}
+
+#[tauri::command]
+pub async fn enqueue_generation(
+    state: State<'_, AppState>,
+    notebook_id: String,
+    kind: String,
+    prompt: Option<String>,
+    source_ids: Option<Vec<String>>,
+) -> Result<Note, String> {
+    e(enqueue_generation_impl(
+        &state,
+        &notebook_id,
+        &kind,
+        &prompt.unwrap_or_default(),
+        source_ids,
+        None,
+        "",
+    )
+    .await)
+}
+
+#[tauri::command]
+pub async fn cancel_generation_job(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    note_id: String,
+) -> Result<(), String> {
+    if let Some((job, was_running)) = state.gen_queue.cancel_by_note(&note_id) {
+        // A running job's token fires and its task cleans up; a job that
+        // never started has no task, so its pending note goes here.
+        if !was_running {
+            let _ = state.db.delete_note(&job.note_id).await;
+            crate::genqueue::emit_status(&app, &job, "", "");
+            let _ = app.emit(
+                "mcp://changed",
+                serde_json::json!({ "scope": "notes", "notebookId": job.notebook_id }),
+            );
+        }
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn list_generations(
+    state: State<'_, AppState>,
+) -> Result<Vec<crate::genqueue::GenJob>, String> {
+    Ok(state.gen_queue.list())
+}
+
 #[tauri::command]
 pub async fn generate_artifact(
     app: AppHandle,
@@ -9636,7 +9812,7 @@ pub async fn generate_artifact(
     let prompt = prompt.unwrap_or_default();
     let cancel = state.begin_generation(&format!("artifact:{}", window.label()));
     let produced = tokio::select! {
-        r = generate_content(&state, Some(&app), &notebook_id, &kind, &prompt, source_ids.as_deref(), None, None) => Some(e(r)?),
+        r = generate_content(&state, Some(&app), &notebook_id, &kind, &prompt, source_ids.as_deref(), None, None, None) => Some(e(r)?),
         _ = cancel.cancelled() => None,
     };
     let (title, content) = match produced {
@@ -9679,126 +9855,13 @@ pub async fn start_generation_detached(
     prompt: &str,
     provider: Option<String>,
 ) -> anyhow::Result<Note> {
-    // Fail fast on an unknown provider id: the whole point of the override is
-    // an agent steering one call, and a typo should error at the tool call,
-    // not as a dead "generating" note discovered by polling.
-    if let Some(id) = provider.as_deref() {
-        let state = app.state::<AppState>();
-        let ai = state.ai.read().await.clone();
-        ai.engine_for_provider(id)?;
-    }
-    // Fail fast on kinds the async path can't honor: audio synthesis needs
-    // the window-side player anyway, and a wrong kind should error at the
-    // tool call, not twenty seconds into a background task.
+    // Fail fast on kinds the queue can't honor over MCP: audio synthesis
+    // wants the window-side player and voice-model download UI.
     if kind == "audio_overview" {
         anyhow::bail!("audio_overview can't be generated over MCP — use the app's Studio panel");
     }
     let state = app.state::<AppState>();
-    let title = if let Some(id) = kind.strip_prefix("template:") {
-        crate::templates::list_templates()
-            .map_err(|e| anyhow::anyhow!(e))?
-            .into_iter()
-            .find(|t| t.id == id)
-            .map(|t| t.name)
-            .ok_or_else(|| anyhow::anyhow!("no template with id {id}"))?
-    } else {
-        match rag::artifact_spec(kind) {
-            Some((t, _)) => format!("{t} (generating…)"),
-            None if !prompt.trim().is_empty() => "Report (generating…)".to_string(),
-            None => anyhow::bail!(
-                "unknown kind \"{kind}\" — use one of {}, template:<id>, or \"custom\" with a prompt",
-                rag::ARTIFACT_KINDS.join(", ")
-            ),
-        }
-    };
-    let ts = now();
-    let note = Note {
-        id: new_id(),
-        notebook_id: notebook_id.to_string(),
-        title,
-        content: String::new(),
-        kind: kind.to_string(),
-        prompt: prompt.to_string(),
-        origin: "mcp".to_string(),
-        status: "generating".to_string(),
-        created_at: ts,
-        updated_at: ts,
-    };
-    // Stored but NOT indexed: an empty in-flight note has nothing for
-    // retrieval yet; indexing happens on completion.
-    state.db.add_note(&note).await?;
-
-    // Hard deadline over the whole background generation. "generating" must
-    // be a bounded state: a polling agent has no other signal, and live
-    // verification found a slow headless-CLI provider holding a note in
-    // "generating" past twenty minutes. Providers carry their own request
-    // timeouts; this is the belt over corpus assembly + provider + retries.
-    const DETACHED_DEADLINE: std::time::Duration = std::time::Duration::from_secs(20 * 60);
-
-    let app = app.clone();
-    let spawned = note.clone();
-    tauri::async_runtime::spawn(async move {
-        let state = app.state::<AppState>();
-        let result = match tokio::time::timeout(
-            DETACHED_DEADLINE,
-            generate_content(
-                &state,
-                None, // no window streaming — the poller reads the stored note
-                &spawned.notebook_id,
-                &spawned.kind,
-                &spawned.prompt,
-                None,
-                None,
-                provider.as_deref(),
-            ),
-        )
-        .await
-        {
-            Ok(r) => r,
-            Err(_) => Err(anyhow::anyhow!(
-                "generation exceeded {} minutes — the model provider may be \
-                 overloaded; try again or switch providers",
-                DETACHED_DEADLINE.as_secs() / 60
-            )),
-        };
-        let ts = now();
-        let outcome = match result {
-            Ok((title, content)) => {
-                let title = if spawned.kind.starts_with("template:") {
-                    spawned.title.clone()
-                } else {
-                    title
-                };
-                if let Err(err) = state
-                    .db
-                    .update_note(&spawned.id, &title, &content, ts)
-                    .await
-                {
-                    crate::note!("mcp generate: persisting result failed: {err:#}");
-                    return;
-                }
-                let _ = state.db.set_note_status(&spawned.id, "").await;
-                if let Ok(Some(done)) = state.db.get_note(&spawned.id).await {
-                    index_note(&state, &done).await;
-                }
-                "done"
-            }
-            Err(err) => {
-                let msg = format!("Generation failed: {err:#}");
-                let _ = state
-                    .db
-                    .update_note(&spawned.id, &spawned.title, &msg, ts)
-                    .await;
-                let _ = state.db.set_note_status(&spawned.id, "error").await;
-                "error"
-            }
-        };
-        let _ = app.emit(
-            "mcp://changed",
-            serde_json::json!({ "scope": "notes", "notebookId": spawned.notebook_id, "outcome": outcome }),
-        );
-    });
-    Ok(note)
+    enqueue_generation_impl(&state, notebook_id, kind, prompt, None, provider, "mcp").await
 }
 
 #[tauri::command]
@@ -9813,7 +9876,7 @@ pub async fn rebuild_note(
 ) -> Result<Note, String> {
     let cancel = state.begin_generation(&format!("artifact:{}", window.label()));
     let produced = tokio::select! {
-        r = generate_content(&state, Some(&app), &notebook_id, &kind, &prompt, None, None, None) => Some(e(r)?),
+        r = generate_content(&state, Some(&app), &notebook_id, &kind, &prompt, None, None, None, None) => Some(e(r)?),
         _ = cancel.cancelled() => None,
     };
     let (title, content) = match produced {
@@ -10312,6 +10375,7 @@ pub async fn generate_notebook_summary(
         "custom",
         "Write a 2-4 sentence plain-prose overview of what these sources collectively cover. \
          No lists, headings, or preamble — just the overview.",
+        None,
         None,
         None,
         None,

--- a/src-tauri/src/commands/brief.rs
+++ b/src-tauri/src/commands/brief.rs
@@ -328,7 +328,7 @@ pub(crate) async fn run_brief(
     };
     let _ = app.emit("report://step", "Writing the brief".to_string());
     let messages = rag::build_artifact_messages(&instruction, &corpus, &persona);
-    let content = run_generation_chat(state, None, &messages, None)
+    let content = run_generation_chat(state, None, &messages, None, None)
         .await
         .map_err(|e| format!("{e:#}"))?;
 

--- a/src-tauri/src/commands/reports.rs
+++ b/src-tauri/src/commands/reports.rs
@@ -174,6 +174,7 @@ pub(crate) async fn run_report_inner(
         None,
         prior_content.as_deref(),
         None,
+        None,
     )
     .await)?;
 

--- a/src-tauri/src/genqueue.rs
+++ b/src-tauri/src/genqueue.rs
@@ -1,0 +1,420 @@
+//! The generation queue (docs/RFC-generation-queue.md).
+//!
+//! Enqueueing a generation creates its note immediately (status
+//! "generating") and parks a job here; a worker task the backend owns
+//! drains the queue, so the webview is a spectator — reload or close the
+//! window and the run continues. Jobs persist to a JSON sidecar (not a
+//! Lance column: the store is shared dev/prod and schema changes brick
+//! older binaries), so an app restart re-queues whatever was mid-flight.
+//!
+//! Concurrency is one job per engine: local engines serialize because
+//! parallel decodes thrash the same GPU/RAM, while a per-job provider
+//! override (MCP) runs beside the default engine. An engine that refuses
+//! connections parks the job as "waiting" and the worker's 30s tick
+//! re-tries until it answers — Ollama being off means paused, not dead.
+
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use tauri::{Emitter, Manager};
+use tokio_util::sync::CancellationToken;
+
+pub const QUEUE_FILE: &str = "generation-queue.json";
+
+/// Terminal jobs older than this prune from the file on save.
+const PRUNE_MS: i64 = 86_400_000;
+
+/// Hard deadline over one run — "generating" must be a bounded state.
+const RUN_DEADLINE: std::time::Duration = std::time::Duration::from_secs(20 * 60);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GenJob {
+    pub id: String,
+    pub notebook_id: String,
+    pub kind: String,
+    #[serde(default)]
+    pub prompt: String,
+    #[serde(default)]
+    pub source_ids: Option<Vec<String>>,
+    pub note_id: String,
+    /// queued | running | waiting | done | error | cancelled
+    pub status: String,
+    #[serde(default)]
+    pub error: String,
+    /// MCP's per-call provider override; None routes the Generate role.
+    #[serde(default)]
+    pub provider: Option<String>,
+    /// Concurrency key, stamped at dispatch (engine id or provider id).
+    #[serde(default)]
+    pub engine_key: String,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct StatusEvent {
+    job_id: String,
+    note_id: String,
+    notebook_id: String,
+    status: String,
+    detail: String,
+    title: String,
+}
+
+pub struct GenQueue {
+    jobs: std::sync::Mutex<Vec<GenJob>>,
+    cancels: std::sync::Mutex<HashMap<String, CancellationToken>>,
+    pub notify: tokio::sync::Notify,
+    path: PathBuf,
+}
+
+impl GenQueue {
+    /// Load the persisted queue. Jobs found running or waiting were
+    /// interrupted by the last shutdown — they re-enter as queued and
+    /// restart from scratch (mid-stream checkpoints are v2).
+    pub fn load(data_dir: &std::path::Path) -> Self {
+        let path = data_dir.join(QUEUE_FILE);
+        let mut jobs: Vec<GenJob> = std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|t| serde_json::from_str(&t).ok())
+            .unwrap_or_default();
+        for j in &mut jobs {
+            if j.status == "running" || j.status == "waiting" {
+                j.status = "queued".into();
+            }
+        }
+        Self {
+            jobs: std::sync::Mutex::new(jobs),
+            cancels: std::sync::Mutex::new(HashMap::new()),
+            notify: tokio::sync::Notify::new(),
+            path,
+        }
+    }
+
+    fn save(&self, jobs: &mut Vec<GenJob>) {
+        let now = crate::commands::now();
+        jobs.retain(|j| {
+            !matches!(j.status.as_str(), "done" | "error" | "cancelled")
+                || now - j.updated_at < PRUNE_MS
+        });
+        if let Ok(json) = serde_json::to_string_pretty(jobs) {
+            let _ = std::fs::write(&self.path, json);
+        }
+    }
+
+    pub fn enqueue(&self, job: GenJob) {
+        let mut jobs = self.jobs.lock().unwrap();
+        jobs.push(job);
+        self.save(&mut jobs);
+        drop(jobs);
+        self.notify.notify_one();
+    }
+
+    pub fn list(&self) -> Vec<GenJob> {
+        self.jobs.lock().unwrap().clone()
+    }
+
+    /// Cancel by note id (the id the UI holds). A running job's token
+    /// fires; a queued/waiting job just flips. Returns the job if one
+    /// was actually cancelled.
+    pub fn cancel_by_note(&self, note_id: &str) -> Option<(GenJob, bool)> {
+        let mut jobs = self.jobs.lock().unwrap();
+        let job = jobs.iter_mut().find(|j| {
+            j.note_id == note_id && matches!(j.status.as_str(), "queued" | "waiting" | "running")
+        })?;
+        let was_running = job.status == "running";
+        job.status = "cancelled".into();
+        job.updated_at = crate::commands::now();
+        let out = job.clone();
+        self.save(&mut jobs);
+        drop(jobs);
+        if was_running {
+            if let Some(t) = self.cancels.lock().unwrap().get(&out.id) {
+                t.cancel();
+            }
+        }
+        self.notify.notify_one();
+        Some((out, was_running))
+    }
+
+    fn set_status(&self, id: &str, status: &str, error: &str) {
+        let mut jobs = self.jobs.lock().unwrap();
+        if let Some(j) = jobs.iter_mut().find(|j| j.id == id) {
+            // A cancel that raced the finish stays a cancel.
+            if j.status == "cancelled" && status != "cancelled" {
+                return;
+            }
+            j.status = status.into();
+            j.error = error.into();
+            j.updated_at = crate::commands::now();
+        }
+        self.save(&mut jobs);
+    }
+
+    fn was_cancelled(&self, id: &str) -> bool {
+        self.jobs
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|j| j.id == id && j.status == "cancelled")
+    }
+}
+
+/// An error that means "the engine isn't there", as opposed to one the
+/// prompt or model earned: these park the job instead of failing it.
+pub fn is_engine_down(err: &str) -> bool {
+    let l = err.to_lowercase();
+    l.contains("connection refused") || l.contains("tcp connect error") || l.contains("dns error")
+}
+
+pub(crate) fn emit_status(app: &tauri::AppHandle, job: &GenJob, title: &str, detail: &str) {
+    let _ = app.emit(
+        "generation://status",
+        StatusEvent {
+            job_id: job.id.clone(),
+            note_id: job.note_id.clone(),
+            notebook_id: job.notebook_id.clone(),
+            status: job.status.clone(),
+            detail: detail.to_string(),
+            title: title.to_string(),
+        },
+    );
+}
+
+/// The drain loop: dispatch whatever can run, then sleep until something
+/// changes (a new job, a cancel) or the 30s tick re-probes waiting jobs.
+pub fn spawn_worker(app: tauri::AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        loop {
+            dispatch(&app).await;
+            let state = app.state::<crate::commands::AppState>();
+            let queue = &state.gen_queue;
+            tokio::select! {
+                _ = queue.notify.notified() => {}
+                _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {}
+            }
+        }
+    });
+}
+
+async fn dispatch(app: &tauri::AppHandle) {
+    let state = app.state::<crate::commands::AppState>();
+    // The default engine key is read outside the jobs lock (it awaits).
+    let default_key = {
+        let ai = state.ai.read().await;
+        ai.chat_engine_id(crate::inference::Role::Generate)
+            .to_string()
+    };
+    let to_run: Vec<GenJob> = {
+        let mut jobs = state.gen_queue.jobs.lock().unwrap();
+        let mut busy: HashSet<String> = jobs
+            .iter()
+            .filter(|j| j.status == "running")
+            .map(|j| j.engine_key.clone())
+            .collect();
+        let mut out = Vec::new();
+        let now = crate::commands::now();
+        for j in jobs.iter_mut() {
+            if !matches!(j.status.as_str(), "queued" | "waiting") {
+                continue;
+            }
+            let key = j.provider.clone().unwrap_or_else(|| default_key.clone());
+            if busy.contains(&key) {
+                continue;
+            }
+            busy.insert(key.clone());
+            j.status = "running".into();
+            // A fresh attempt owes nothing to the last one's failure text.
+            j.error = String::new();
+            j.engine_key = key;
+            j.updated_at = now;
+            out.push(j.clone());
+        }
+        if !out.is_empty() {
+            state.gen_queue.save(&mut jobs);
+        }
+        out
+    };
+    for job in to_run {
+        let app = app.clone();
+        tauri::async_runtime::spawn(async move { run_job(app, job).await });
+    }
+}
+
+async fn run_job(app: tauri::AppHandle, job: GenJob) {
+    let state = app.state::<crate::commands::AppState>();
+    let queue = &state.gen_queue;
+    let token = CancellationToken::new();
+    queue
+        .cancels
+        .lock()
+        .unwrap()
+        .insert(job.id.clone(), token.clone());
+    emit_status(&app, &job, "", "");
+
+    let produced = tokio::select! {
+        r = tokio::time::timeout(
+            RUN_DEADLINE,
+            crate::commands::generate_content_for_job(&state, &app, &job, &token),
+        ) => Some(match r {
+            Ok(inner) => inner,
+            Err(_) => Err(anyhow::anyhow!(
+                "generation exceeded {} minutes — the model provider may be \
+                 overloaded; try again or switch providers",
+                RUN_DEADLINE.as_secs() / 60
+            )),
+        }),
+        _ = token.cancelled() => None,
+    };
+    queue.cancels.lock().unwrap().remove(&job.id);
+
+    let ts = crate::commands::now();
+    match produced {
+        // Cancelled mid-run: the pending note held nothing — remove it.
+        None => {
+            let _ = state.db.delete_note(&job.note_id).await;
+            let mut j = job.clone();
+            j.status = "cancelled".into();
+            emit_status(&app, &j, "", "");
+        }
+        Some(Ok((title, content))) => {
+            if let Err(err) = state
+                .db
+                .update_note(&job.note_id, &title, &content, ts)
+                .await
+            {
+                crate::note!("genqueue: persisting result failed: {err:#}");
+                queue.set_status(&job.id, "error", "persist failed");
+                return;
+            }
+            let _ = state.db.set_note_status(&job.note_id, "").await;
+            queue.set_status(&job.id, "done", "");
+            if let Ok(Some(done)) = state.db.get_note(&job.note_id).await {
+                crate::commands::index_note(&state, &done).await;
+                let _ = app.emit("generate://done", &done);
+            }
+            let mut j = job.clone();
+            j.status = "done".into();
+            emit_status(&app, &j, &title, "");
+        }
+        Some(Err(err)) => {
+            let raw = format!("{err:#}");
+            // A user cancel surfaces as an engine error on some providers
+            // (the stream drops) — honor the recorded cancel over the error.
+            if queue.was_cancelled(&job.id) {
+                let _ = state.db.delete_note(&job.note_id).await;
+                let mut j = job.clone();
+                j.status = "cancelled".into();
+                emit_status(&app, &j, "", "");
+            } else if is_engine_down(&raw) {
+                // Parked, not failed: the pending note says so and the
+                // worker's tick re-tries until the engine answers.
+                queue.set_status(&job.id, "waiting", &raw);
+                let detail = crate::commands::classify_model_error(&raw)
+                    .unwrap_or_else(|| "The model engine isn't answering.".into());
+                let mut j = job.clone();
+                j.status = "waiting".into();
+                emit_status(&app, &j, "", &detail);
+            } else {
+                let msg = crate::commands::classify_model_error(&raw)
+                    .unwrap_or_else(|| format!("Generation failed: {raw}"));
+                let _ = state
+                    .db
+                    .update_note(&job.note_id, &placeholder_stripped(&job), &msg, ts)
+                    .await;
+                let _ = state.db.set_note_status(&job.note_id, "error").await;
+                queue.set_status(&job.id, "error", &msg);
+                let mut j = job.clone();
+                j.status = "error".into();
+                emit_status(&app, &j, "", &msg);
+            }
+        }
+    }
+    let _ = app.emit(
+        "mcp://changed",
+        serde_json::json!({ "scope": "notes", "notebookId": job.notebook_id }),
+    );
+    // A finished engine frees its slot — someone may be queued behind it.
+    queue.notify.notify_one();
+}
+
+/// The pending title without its "(generating…)" tail, so an error note
+/// reads as the artifact it wanted to be.
+fn placeholder_stripped(job: &GenJob) -> String {
+    match crate::rag::artifact_spec(&job.kind) {
+        Some((t, _)) => t.to_string(),
+        None => "Report".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn job(id: &str, status: &str) -> GenJob {
+        GenJob {
+            id: id.into(),
+            notebook_id: "nb".into(),
+            kind: "briefing".into(),
+            prompt: String::new(),
+            source_ids: None,
+            note_id: format!("note-{id}"),
+            status: status.into(),
+            error: String::new(),
+            provider: None,
+            engine_key: String::new(),
+            created_at: crate::commands::now(),
+            updated_at: crate::commands::now(),
+        }
+    }
+
+    #[test]
+    fn interrupted_jobs_requeue_on_load() {
+        let dir = std::env::temp_dir().join(format!("alchemy-genq-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let q = GenQueue::load(&dir);
+        let mut running = job("a", "running");
+        running.engine_key = "ollama".into();
+        q.enqueue(running);
+        q.enqueue(job("b", "waiting"));
+        q.enqueue(job("c", "done"));
+        drop(q);
+        let q = GenQueue::load(&dir);
+        let jobs = q.list();
+        assert_eq!(jobs.iter().filter(|j| j.status == "queued").count(), 2);
+        assert_eq!(jobs.iter().filter(|j| j.status == "done").count(), 1);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn cancel_flips_queued_jobs_and_survives_status_races() {
+        let dir = std::env::temp_dir().join(format!("alchemy-genq2-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let q = GenQueue::load(&dir);
+        q.enqueue(job("a", "queued"));
+        let (cancelled, was_running) = q.cancel_by_note("note-a").expect("job found");
+        assert_eq!(cancelled.status, "cancelled");
+        assert!(!was_running);
+        // A late "done" from a racing finish must not resurrect it.
+        q.set_status("a", "done", "");
+        assert!(q.was_cancelled("a"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn engine_down_classifier_matches_field_errors() {
+        assert!(is_engine_down(
+            "ollama chat request failed: error sending request for url \
+             (http://localhost:11434/api/chat): client error (Connect): \
+             tcp connect error: Connection refused (os error 61)"
+        ));
+        assert!(!is_engine_down(
+            "model \"x\" not found, try pulling it first"
+        ));
+        assert!(!is_engine_down("invalid api key"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ mod examples;
 mod export;
 mod filesearch;
 mod freshness;
+mod genqueue;
 mod gist;
 mod git;
 mod graph;
@@ -285,7 +286,11 @@ pub fn run() {
                 cancel: std::sync::Mutex::new(std::collections::HashMap::new()),
                 folder_scan_lock: tokio::sync::Mutex::new(()),
                 glass_applied: std::sync::Mutex::new(std::collections::HashMap::new()),
+                gen_queue: genqueue::GenQueue::load(&data_dir),
             });
+            // The queue worker drains generations the webview only watches;
+            // jobs interrupted by the last shutdown are already re-queued.
+            genqueue::spawn_worker(app.handle().clone());
 
             // Studio templates: write the default pack on first run so
             // ~/Documents/Alchemy/templates exists before anything lists it.
@@ -516,6 +521,9 @@ pub fn run() {
             commands::note_opened,
             commands::convert_note_to_source,
             commands::generate_artifact,
+            commands::enqueue_generation,
+            commands::cancel_generation_job,
+            commands::list_generations,
             commands::rebuild_note,
             commands::get_ai_config,
             commands::set_ai_config,

--- a/src/components/GalleryPane.tsx
+++ b/src/components/GalleryPane.tsx
@@ -11,6 +11,7 @@ import {
   RowMenu,
   useConfirm,
   useHoverCard,
+  useMarquee,
 } from "./ui";
 import { cn, isWebUrl, relativeTime, scrollMemory, shortcutBlocked, urlHost } from "@/lib/utils";
 import { FilterBar } from "./FilterBar";
@@ -350,6 +351,35 @@ export function GalleryPane() {
     ro.observe(scrollerEl);
     return () => ro.disconnect();
   }, [scrollerEl]);
+  // Multi-select, same model as the sources sidebar: the shared "sources"
+  // pick, so a selection made here is the same selection there. Cmd-click
+  // toggles, shift-click ranges, and a rubber-band drag sweeps cards.
+  const picked = useStore((st) => st.picked);
+  const pickedIds = useMemo(
+    () => new Set(picked?.kind === "sources" ? picked.ids : []),
+    [picked],
+  );
+  const pickToggle = useStore((st) => st.pickToggle);
+  const pickRange = useStore((st) => st.pickRange);
+  const pickSet = useStore((st) => st.pickSet);
+  const clearPicked = useStore((st) => st.clearPicked);
+  const refreshSourcesBatch = useStore((st) => st.refreshSourcesBatch);
+  const marqueeBase = useRef<string[]>([]);
+  const { onPointerDown: marqueeDown, marquee, justEnded } = useMarquee({
+    containerRef: scrollerRef,
+    onStart: (additive) => {
+      const pk = useStore.getState().picked;
+      marqueeBase.current = additive && pk?.kind === "sources" ? pk.ids : [];
+    },
+    onSelect: (ids) =>
+      pickSet(
+        "sources",
+        [...new Set([...marqueeBase.current, ...ids])],
+        false,
+      ),
+    onClearBackground: clearPicked,
+  });
+
   const colCount = Math.min(4, Math.max(1, Math.floor((width + 12) / 232)));
   // Shortest-column-first, not round-robin: cards range from a two-line title
   // to a 256px image plus a four-line snippet, so dealing them out in order
@@ -398,6 +428,38 @@ export function GalleryPane() {
 
   // The same actions the Sources panel rows carry, on the card's ⋯ menu —
   // and on plain right-click (RowMenu opens from the nearest .group).
+  /** Batch variants of the card verbs when this card sits in a
+   *  multi-selection — counts in the labels, same as the sidebar. */
+  const batchMenuItems = (ids: string[]): ReturnType<typeof cardMenuItems> => {
+    const count = ids.length;
+    const refreshable = ids.filter(
+      (id) => !!sources.find((x) => x.id === id)?.url,
+    );
+    return [
+      ...(refreshable.length
+        ? [
+            {
+              label: `Refresh ${refreshable.length} sources`,
+              icon: <RefreshCw className="h-3.5 w-3.5" />,
+              onClick: () => void refreshSourcesBatch(refreshable),
+            },
+          ]
+        : []),
+      {
+        label: `Tag ${count} sources…`,
+        icon: <Pencil className="h-3.5 w-3.5" />,
+        onClick: () =>
+          meta.setTagEdit({ ids, title: `${count} sources`, value: "" }),
+      },
+      {
+        label: `Remove ${count} sources…`,
+        icon: <Trash2 className="h-3.5 w-3.5" />,
+        danger: true,
+        onClick: () => void removeSourcesGuarded(ids, confirm),
+      },
+    ];
+  };
+
   const cardMenuItems = (s: Source) => {
     const st = useStore.getState();
     const editable =
@@ -595,6 +657,7 @@ export function GalleryPane() {
       ) : (
         <div
           ref={attachScroller}
+          onPointerDown={marqueeDown}
           onScroll={(e) =>
             scrollMemory.set(scrollKey, e.currentTarget.scrollTop)
           }
@@ -605,28 +668,66 @@ export function GalleryPane() {
             <div className="flex items-start gap-3">
               {columns.map((col, i) => (
                 <div key={i} className="flex min-w-0 flex-1 flex-col gap-3">
-                  {col.map((s) =>
-                    GROUP_OF[s.sourceType] === "folders" ? (
-                      <FolderCard
-                        key={s.id}
-                        source={s}
-                        childrenSources={childrenIndex.get(s.id) ?? []}
-                        onOpen={() => setFolderId(s.id)}
-                        menuItems={cardMenuItems(s)}
-                        onHover={(e) => showCard(e, sourceHoverData(s))}
-                        onLeave={hideCard}
-                      />
-                    ) : (
-                      <GalleryCard
-                        key={s.id}
-                        source={s}
-                        snippet={snippets[s.id]}
-                        menuItems={cardMenuItems(s)}
-                        onHover={(e) => showCard(e, sourceHoverData(s))}
-                        onLeave={hideCard}
-                      />
-                    ),
-                  )}
+                  {col.map((s) => (
+                    <div
+                      key={s.id}
+                      data-pick-id={s.id}
+                      className={cn(
+                        "rounded-lg",
+                        pickedIds.has(s.id) &&
+                          "ring-1 ring-primary ring-offset-1 ring-offset-background",
+                      )}
+                      onClickCapture={(e) => {
+                        // A rubber-band drag ends in a click — that click
+                        // is the drag's tail, not an open.
+                        if (justEnded()) {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          return;
+                        }
+                        if (e.metaKey || e.ctrlKey) {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          pickToggle("sources", s.id);
+                        } else if (e.shiftKey) {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          pickRange(
+                            "sources",
+                            cards.map((c) => c.id),
+                            s.id,
+                          );
+                        }
+                      }}
+                    >
+                      {GROUP_OF[s.sourceType] === "folders" ? (
+                        <FolderCard
+                          source={s}
+                          childrenSources={childrenIndex.get(s.id) ?? []}
+                          onOpen={() => setFolderId(s.id)}
+                          menuItems={
+                            pickedIds.has(s.id) && pickedIds.size > 1
+                              ? batchMenuItems([...pickedIds])
+                              : cardMenuItems(s)
+                          }
+                          onHover={(e) => showCard(e, sourceHoverData(s))}
+                          onLeave={hideCard}
+                        />
+                      ) : (
+                        <GalleryCard
+                          source={s}
+                          snippet={snippets[s.id]}
+                          menuItems={
+                            pickedIds.has(s.id) && pickedIds.size > 1
+                              ? batchMenuItems([...pickedIds])
+                              : cardMenuItems(s)
+                          }
+                          onHover={(e) => showCard(e, sourceHoverData(s))}
+                          onLeave={hideCard}
+                        />
+                      )}
+                    </div>
+                  ))}
                 </div>
               ))}
             </div>
@@ -638,6 +739,7 @@ export function GalleryPane() {
         sourceTitle={attaching?.title ?? ""}
         onClose={() => setAttaching(null)}
       />
+      {marquee}
       {confirmDialog}
       {meta.modals}
       {hoverCard}

--- a/src/components/GalleryPane.tsx
+++ b/src/components/GalleryPane.tsx
@@ -661,7 +661,10 @@ export function GalleryPane() {
           onScroll={(e) =>
             scrollMemory.set(scrollKey, e.currentTarget.scrollTop)
           }
-          className="min-h-0 flex-1 overflow-y-auto px-6 py-4"
+          // select-none: cards are a browse surface, not prose — and the
+          // marquee's own userSelect guard only lands after the 4px drag
+          // threshold, so selectable card text paints a highlight first.
+          className="min-h-0 flex-1 select-none overflow-y-auto px-6 py-4"
         >
           {/* Skip the one-column flash while the first measure lands. */}
           {width > 0 && (

--- a/src/components/StudioPanel.tsx
+++ b/src/components/StudioPanel.tsx
@@ -81,6 +81,57 @@ const TINT_DISCLOSURE: Tint = {
   icon: "text-muted-foreground",
 };
 
+/** Wiki entity pages are numerous by design — one per registry entity —
+ *  and would drown the handful of notes a person actually wrote. The
+ *  "Notebook index" note stays in the main list as the wiki's front door;
+ *  its entity pages live behind this fold. */
+const isEntityPage = (n: Note) => n.title.startsWith("Entity: ");
+
+function WikiNotes({
+  notes,
+  onOpen,
+}: {
+  notes: Note[];
+  onOpen: (n: Note) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  if (notes.length === 0) return null;
+  return (
+    <div className="mt-2 border-t border-border pt-2">
+      <button
+        className="flex w-full items-center gap-1.5 rounded px-1 py-1 text-micro font-medium text-subtle-foreground hover:text-foreground transition-colors"
+        onClick={() => setOpen((o) => !o)}
+      >
+        {open ? (
+          <ChevronUp className="h-3 w-3" />
+        ) : (
+          <ChevronDown className="h-3 w-3" />
+        )}
+        Wiki pages ({notes.length})
+      </button>
+      {open && (
+        <div className="mt-1 flex flex-col gap-1.5">
+          {notes.map((n) => (
+            <button
+              type="button"
+              key={n.id}
+              onClick={() => onOpen(n)}
+              className="group w-full rounded-md border border-border bg-surface-2/40 px-3 py-2 text-left transition-colors hover:border-border-strong"
+            >
+              <span className="block truncate text-caption font-medium text-foreground">
+                {n.title.replace(/^Entity: /, "")}
+              </span>
+              <span className="text-micro text-subtle-foreground">
+                {relativeTime(n.updatedAt)} · linked from the notebook index
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 /** Notes the curator archived: out of retrieval, collapsed but never gone.
  *  Opening one still works; editing it revives it (see RFC-note-curator). */
 function ArchivedNotes({
@@ -172,7 +223,7 @@ export function StudioPanel() {
     [picked],
   );
   const visibleNoteIds = notes
-    .filter((n) => n.status !== "archived")
+    .filter((n) => n.status !== "archived" && !isEntityPage(n))
     .map((n) => n.id);
   const visibleNoteIdsRef = useRef(visibleNoteIds);
   visibleNoteIdsRef.current = visibleNoteIds;
@@ -581,7 +632,9 @@ export function StudioPanel() {
             />
           ) : (
             <div className="flex flex-col gap-1.5">
-              {notes.filter((n) => n.status !== "archived").map((n) => (
+              {notes
+                .filter((n) => n.status !== "archived" && !isEntityPage(n))
+                .map((n) => (
                 <div
                   key={n.id}
                   data-pick-id={n.id}
@@ -733,6 +786,12 @@ export function StudioPanel() {
               ))}
             </div>
           )}
+          <WikiNotes
+            notes={notes.filter(
+              (n) => n.status !== "archived" && isEntityPage(n),
+            )}
+            onOpen={openNoteCard}
+          />
           <ArchivedNotes
             notes={notes.filter((n) => n.status === "archived")}
             onOpen={openNoteCard}

--- a/src/components/StudioPanel.tsx
+++ b/src/components/StudioPanel.tsx
@@ -188,6 +188,8 @@ export function StudioPanel() {
   // preview belongs to ONE notebook. Other notebooks keep the tiles disabled
   // (the backend runs one generation per window) but paint no stream.
   const generatingKind = useStore((s) => s.generatingKind);
+  const genProgress = useStore((s) => s.genProgress);
+  const genStatus = useStore((s) => s.genStatus);
   const generatingHere = useStore(
     (s) => s.generatingFor === null || s.generatingFor === s.currentId,
   );
@@ -502,7 +504,7 @@ export function StudioPanel() {
                       label={a.label}
                       category={a.family}
                       tint={TINT_BY_FAMILY[a.family]}
-                      disabled={!hasSources || !!generatingKind}
+                      disabled={!hasSources}
                       onClick={() => generate(a.kind, instructions)}
                     />
                   ))}
@@ -519,7 +521,7 @@ export function StudioPanel() {
                     label={a.label}
                     category={a.family}
                     tint={TINT_BY_FAMILY[a.family]}
-                    disabled={!hasSources || !!generatingKind}
+                    disabled={!hasSources}
                     onClick={() => generate(a.kind, instructions)}
                   />
                 ))}
@@ -537,7 +539,7 @@ export function StudioPanel() {
                     title={`${t.description || t.name} — right-click to edit`}
                     category="template"
                     tint={TINT_TEMPLATES}
-                    disabled={!hasSources || !!generatingKind}
+                    disabled={!hasSources}
                     onClick={() => generateFromTemplate(t)}
                     onContextMenu={(e) => {
                       e.preventDefault();
@@ -666,6 +668,7 @@ export function StudioPanel() {
                     label={`Open note ${n.title}`}
                     onClick={(e) => {
                       if (justEnded()) return;
+                      if (n.status === "generating") return;
                       if (e.metaKey || e.ctrlKey) {
                         pickToggle("notes", n.id);
                         return;
@@ -686,7 +689,11 @@ export function StudioPanel() {
                       )}
                       title={KIND_LABEL[n.kind]}
                     >
-                      {kindIcon(n.kind)}
+                      {n.status === "generating" ? (
+                        <Spinner className="h-4 w-4" />
+                      ) : (
+                        kindIcon(n.kind)
+                      )}
                     </span>
                     <span className="min-w-0 flex-1 truncate text-body font-medium text-foreground">
                       {n.title}
@@ -711,7 +718,18 @@ export function StudioPanel() {
                         pickOne("notes", n.id);
                         return null;
                       }}
-                      items={[
+                      items={
+                        n.status === "generating"
+                          ? [
+                              {
+                                label: "Stop generating",
+                                icon: <Square className="h-3.5 w-3.5" />,
+                                danger: true,
+                                onClick: () =>
+                                  void api.cancelGenerationJob(n.id),
+                              },
+                            ]
+                          : [
                         {
                           label: "Copy text",
                           icon: <Copy className="h-3.5 w-3.5" />,
@@ -755,7 +773,8 @@ export function StudioPanel() {
                           danger: true,
                           onClick: () => void deleteNote(n.id),
                         },
-                      ]}
+                      ]
+                      }
                     />
                   </div>
                   <div className="pointer-events-none relative z-10 mt-1 flex items-center gap-1.5 pl-[22px]">
@@ -778,9 +797,49 @@ export function StudioPanel() {
                         <Badge>stale</Badge>
                       </span>
                     )}
-                    <span className="text-micro text-subtle-foreground">
-                      {relativeTime(n.updatedAt)}
-                    </span>
+                    {n.status === "generating" ? (
+                      <span className="pointer-events-auto flex items-center gap-1.5 text-micro text-subtle-foreground">
+                        {genStatus[n.id]?.status === "waiting"
+                          ? "Waiting for the model engine…"
+                          : n.kind === "audio_overview" && audioProgress
+                            ? `Voicing ${audioProgress.done}/${audioProgress.total}`
+                            : genProgress[n.id]
+                              ? `Generating — ${(genProgress[n.id] / 1000).toFixed(1)}k chars`
+                              : "Queued"}
+                        <button
+                          type="button"
+                          onClick={() => void api.cancelGenerationJob(n.id)}
+                          className="flex items-center gap-0.5 rounded px-1 py-0.5 text-destructive hover:bg-destructive/10"
+                          title="Stop this generation"
+                        >
+                          <Square className="h-2.5 w-2.5" />
+                          Stop
+                        </button>
+                      </span>
+                    ) : n.status === "error" ? (
+                      <span className="pointer-events-auto flex items-center gap-1.5 text-micro">
+                        <Badge>failed</Badge>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            void (async () => {
+                              await deleteNote(n.id);
+                              await useStore
+                                .getState()
+                                .generateArtifact(n.kind, n.prompt);
+                            })();
+                          }}
+                          className="rounded px-1 py-0.5 text-subtle-foreground hover:text-foreground"
+                          title="Delete this attempt and generate again"
+                        >
+                          Retry
+                        </button>
+                      </span>
+                    ) : (
+                      <span className="text-micro text-subtle-foreground">
+                        {relativeTime(n.updatedAt)}
+                      </span>
+                    )}
                   </div>
                 </div>
               ))}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -576,6 +576,22 @@ export const api = {
         sourceIds,
       }),
     ),
+  enqueueGeneration: (
+    notebookId: string,
+    kind: NoteKind,
+    prompt?: string,
+    sourceIds?: string[] | null,
+  ) =>
+    run(
+      cmd<Note>("enqueue_generation", {
+        notebookId,
+        kind,
+        prompt: prompt ?? "",
+        sourceIds,
+      }),
+    ),
+  cancelGenerationJob: (noteId: string) =>
+    run(cmd<void>("cancel_generation_job", { noteId })),
   rebuildNote: (
     noteId: string,
     notebookId: string,

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -685,14 +685,17 @@ export const useStore = create<AppState>((set, get) => {
         }
       }
       void api.rebuildAppMenu();
-      // Quiet update check, once per launch, main window only.
+      // Quiet update check on launch, then daily — the app lives open for
+      // days at a time, and a launch-only check never sees those releases.
       if (getCurrentWebview().label === "main" && autoUpdateEnabled()) {
-        setTimeout(() => {
+        const quietCheck = () => {
           // The title-bar UpdateBadge is the notice — it stays put, and
           // clicking it lands on Settings → General with the check already
           // run. No toast: a transient nag on top of a persistent badge.
           void checkForUpdatesQuietly((v) => set({ updateAvailable: v }));
-        }, 4000);
+        };
+        setTimeout(quietCheck, 4000);
+        setInterval(quietCheck, 24 * 60 * 60 * 1000);
       }
     },
 

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -35,6 +35,7 @@ import type {
   Message,
   MetaTurn,
   Note,
+  NoteKind,
   ReadingPrefs,
   Source,
 } from "./types";
@@ -444,6 +445,8 @@ export const useStore = create<AppState>((set, get) => {
     generatingKind: null,
     generatingFor: null,
     generatingTemplateId: null,
+    genProgress: {},
+    genStatus: {},
     ingestQueue: [],
     migration: null,
     draggingFiles: false,
@@ -765,9 +768,78 @@ export const useStore = create<AppState>((set, get) => {
           set({ artifactStreamText: get().artifactStreamText + chunk });
         });
       });
+      // Queue generations stream note-tagged tokens; only the char count
+      // reaches state (the pending card shows progress, not prose), batched
+      // per frame like the artifact buffer above.
+      let genBuffer: Record<string, number> = {};
+      let genFlush = 0;
+      void listen<{ noteId: string; content: string }>(
+        "generation://token",
+        (e) => {
+          genBuffer[e.payload.noteId] =
+            (genBuffer[e.payload.noteId] ?? 0) + e.payload.content.length;
+          if (genFlush !== 0) return;
+          genFlush = requestAnimationFrame(() => {
+            genFlush = 0;
+            const add = genBuffer;
+            genBuffer = {};
+            const cur = { ...get().genProgress };
+            for (const [nid, chars] of Object.entries(add))
+              cur[nid] = (cur[nid] ?? 0) + chars;
+            set({ genProgress: cur });
+          });
+        },
+      );
+      // Queue lifecycle: keep the pending note's row truthful and announce
+      // the endings. done upserts arrive separately via generate://done.
+      void listen<{
+        noteId: string;
+        notebookId: string;
+        status: string;
+        detail: string;
+        title: string;
+      }>("generation://status", (e) => {
+        const p = e.payload;
+        const prev = get().genStatus[p.noteId]?.status;
+        set({
+          genStatus: {
+            ...get().genStatus,
+            [p.noteId]: { status: p.status, detail: p.detail },
+          },
+        });
+        if (p.status === "cancelled") {
+          set({
+            notes: get().notes.filter((x) => x.id !== p.noteId),
+            audioProgress: null,
+          });
+          return;
+        }
+        if (get().currentId === p.notebookId && p.status === "error") {
+          set({
+            notes: get().notes.map((x) =>
+              x.id === p.noteId ? { ...x, status: "error", content: p.detail } : x,
+            ),
+          });
+        }
+        if (p.status === "done" && prev !== "done") {
+          set({ audioProgress: null });
+          get().pushToast("success", `${p.title} ready`);
+          playDone();
+          void notify("Document ready", `“${p.title}” finished generating.`);
+        }
+        if (p.status === "error" && prev !== "error") {
+          set({ audioProgress: null });
+          get().pushToast("error", p.detail || "Generation failed");
+        }
+        if (p.status === "waiting" && prev !== "waiting")
+          get().pushToast(
+            "info",
+            p.detail || "Waiting for the model engine to come back",
+          );
+      });
       // Audio Overview synthesis reports per-line progress after the script.
       void listen<{ done: number; total: number }>("audio://progress", (e) => {
-        if (get().generatingKind) set({ audioProgress: e.payload });
+        set({ audioProgress: e.payload });
       });
       // Folder scans report per-file ingest progress; the Sources panel shows it
       // on the active queue item. The final tick (done === total) clears it.
@@ -2680,112 +2752,49 @@ export const useStore = create<AppState>((set, get) => {
       }),
 
     generateArtifact: async (kind, prompt) => {
+      // Queue, don't block (docs/RFC-generation-queue.md): the pending
+      // note IS the result surface — it appears at once, progress lands on
+      // it, and the backend worker owns the run, so several can cook and a
+      // reload changes nothing.
       const id = get().currentId;
-      if (!id || get().generatingKind) return;
-      set({
-        generatingKind: kind,
-        generatingFor: id,
-        artifactStreamText: "",
-        error: null,
-      });
+      if (!id) return;
       try {
-        const note = await api.generateArtifact(
+        const note = await api.enqueueGeneration(
           id,
           kind,
           prompt,
           selectedIdsForIpc(),
         );
-        // Auto-open the new note so the outcome is visible where the user acted,
-        // not just appended to the Notes list below the fold.
-        // Filter by id before prepending: the note:// event listener may have
-        // upserted this note already, and an unfiltered prepend rendered the
-        // same note twice (deleting "one" then removed both cards — they were
-        // one row shown twice).
-        // The user may have navigated away while it generated — never write
-        // another notebook's note into the open one. The note is persisted;
-        // the toast is the way back.
         if (get().currentId === id) {
           set({
             notes: [note, ...get().notes.filter((n) => n.id !== note.id)],
-            justCreatedNoteId: note.id,
           });
-          get().pushToast("success", `${note.title} ready`);
-        } else {
-          get().pushToast(
-            "success",
-            `${note.title} ready — click to open`,
-            () =>
-              void get()
-                .selectNotebook(id)
-                .then(() => set({ justCreatedNoteId: note.id })),
-          );
         }
-        void get().refreshModelStats();
-        playDone();
-        void notify("Document ready", `“${note.title}” finished generating.`);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        // A user-initiated Stop isn't an error — surface it quietly.
-        if (msg.includes("Generation stopped"))
-          get().pushToast("info", "Generation stopped");
-        else set({ error: msg });
-      } finally {
-        set({
-          generatingKind: null,
-          generatingFor: null,
-          artifactStreamText: "",
-          audioProgress: null,
-        });
+        set({ error: e instanceof Error ? e.message : String(e) });
       }
     },
 
     generateFromTemplate: async (t) => {
+      // Templates ride the queue like every other kind: `template:<id>`
+      // resolves name and prompt at run time on the backend, so the
+      // pending note is born with the template's own title.
       const id = get().currentId;
-      if (!id || get().generatingKind) return;
-      set({
-        generatingKind: "template",
-        generatingFor: id,
-        generatingTemplateId: t.id,
-        artifactStreamText: "",
-        error: null,
-      });
+      if (!id) return;
       try {
-        const note = await api.generateArtifact(id, "template", t.prompt);
-        // The backend titles unknown kinds "Report" — rename to the template's name.
-        await api.updateNote(note.id, t.name, note.content);
-        const titled = { ...note, title: t.name };
+        const note = await api.enqueueGeneration(
+          id,
+          `template:${t.id}` as NoteKind,
+          "",
+          selectedIdsForIpc(),
+        );
         if (get().currentId === id) {
           set({
-            notes: [titled, ...get().notes.filter((n) => n.id !== note.id)],
-            justCreatedNoteId: note.id,
+            notes: [note, ...get().notes.filter((n) => n.id !== note.id)],
           });
-          get().pushToast("success", `${t.name} ready`);
-        } else {
-          get().pushToast(
-            "success",
-            `${t.name} ready — click to open`,
-            () =>
-              void get()
-                .selectNotebook(id)
-                .then(() => set({ justCreatedNoteId: note.id })),
-          );
         }
-        void get().refreshModelStats();
-        playDone();
-        void notify("Document ready", `“${t.name}” finished generating.`);
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        if (msg.includes("Generation stopped"))
-          get().pushToast("info", "Generation stopped");
-        else set({ error: msg });
-      } finally {
-        set({
-          generatingKind: null,
-          generatingFor: null,
-          generatingTemplateId: null,
-          artifactStreamText: "",
-          audioProgress: null,
-        });
+        set({ error: e instanceof Error ? e.message : String(e) });
       }
     },
 

--- a/src/lib/storeTypes.ts
+++ b/src/lib/storeTypes.ts
@@ -285,6 +285,10 @@ export interface AppState {
   pendingNewNote: boolean;
   artifactStreamText: string;
   audioProgress: { done: number; total: number } | null;
+  /** Streamed chars per pending note (generation queue). */
+  genProgress: Record<string, number>;
+  /** Latest queue status per pending note. */
+  genStatus: Record<string, { status: string; detail: string }>;
   kokoroStatus: KokoroStatus | null;
   kokoroBusy: boolean;
   /** Center-column reader: current doc + browser-style history. `open`


### PR DESCRIPTION
Post-release feedback, all four items, human-tested in the dev app.

- **Generation queue** (docs/RFC-generation-queue.md, now implemented): enqueueing creates the pending note immediately — the note is the queue UI — and a backend worker owns the run. The studio never locks, jobs run one-per-engine (parallel across engines), a reload or app restart re-queues whatever was mid-flight from a JSON sidecar, and an engine that refuses connections parks the job as "waiting" with 30s auto-resume. Pending rows show live progress with Stop; failed rows get Retry; MCP's detached generate rides the same queue. Verified live against a real Ollama outage: enqueue → park → auto-resume on `ollama serve` → app restart mid-run → re-queue → done.
- **Daily update checks**: the quiet check re-runs every 24h while the app stays open.
- **Wiki fold**: entity pages collapse behind "Wiki pages (N)" in Studio; the Notebook index note stays out front.
- **Gallery multi-select**: the sidebar's exact selection model — shared pick, cmd/shift/marquee, batch verbs — plus a `select-none` fix so the band never selects card text, and the Finder selection dialect written into DESIGN.md §9.

Gates: tsc clean, clippy clean, 417 tests (3 new for the queue: boot re-queue, cancel races, engine-down classifier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
