### PR TITLE
Image picker in the reader for a source's gallery card

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2735,6 +2735,65 @@ pub(crate) async fn set_source_tags_impl(
     })
 }
 
+/// Candidate lead images for a URL source, for the reader's manual picker
+/// (docs: the ingest-time og:image pick misses some pages): fetch the live
+/// page once and return its meta images plus body `<img>` sources.
+#[tauri::command]
+pub async fn source_image_candidates(
+    state: State<'_, AppState>,
+    source_id: String,
+) -> Result<Vec<String>, String> {
+    let src =
+        e(state.db.get_source(&source_id).await)?.ok_or_else(|| "Source not found".to_string())?;
+    if !is_web_url(&src.url) {
+        return Err("Only web sources have page images".into());
+    }
+    let bytes = ingest::fetch_bytes(&src.url, 4 * 1024 * 1024)
+        .await
+        .ok_or_else(|| "Couldn't fetch the page".to_string())?;
+    let html = String::from_utf8_lossy(&bytes);
+    Ok(ingest::page_images(&html, &src.url))
+}
+
+/// Hand-pick a URL source's gallery lead image ("-" = show none, "" = back
+/// to unknown so the backfill may auto-pick again). Shared by the Tauri
+/// command and the MCP tool. Clears the cached og bytes so the next
+/// thumbnail render fetches the new pick.
+pub(crate) async fn set_source_image_impl(
+    state: &AppState,
+    source_id: &str,
+    image_url: &str,
+) -> anyhow::Result<Source> {
+    let existing = state
+        .db
+        .get_source(source_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("Source not found"))?;
+    if existing.source_type != "url" {
+        anyhow::bail!("Only URL sources carry a gallery image");
+    }
+    let image_url = image_url.trim();
+    if !image_url.is_empty() && image_url != "-" && !is_web_url(image_url) {
+        anyhow::bail!("image_url must be a web URL, \"-\" for none, or empty to re-auto-pick");
+    }
+    state.db.set_source_image(source_id, image_url).await?;
+    let _ = std::fs::remove_file(og_cache_path(state, source_id));
+    Ok(Source {
+        image_url: image_url.to_string(),
+        content: String::new(),
+        ..existing
+    })
+}
+
+#[tauri::command]
+pub async fn set_source_image(
+    state: State<'_, AppState>,
+    source_id: String,
+    image_url: String,
+) -> Result<Source, String> {
+    e(set_source_image_impl(&state, &source_id, &image_url).await)
+}
+
 /// Store the user's annotation on a source and (re)index it under
 /// `snote:<source_id>` so retrieval can surface "why I saved this"
 /// (docs/RFC-source-tags.md). Empty note = clear both row field and index.

--- a/src-tauri/src/ingest.rs
+++ b/src-tauri/src/ingest.rs
@@ -1894,6 +1894,90 @@ pub async fn fetch_lead_image(url: &str) -> Option<String> {
     og_image(&body, url)
 }
 
+/// Every plausible lead-image candidate on a page, for the reader's manual
+/// picker (the auto `og_image` pick misses some pages): meta og/twitter
+/// images first, then body `<img>` sources (data-src lazy-load variants
+/// included via the attribute scan), resolved against the page URL, with
+/// obvious chrome (SVGs, sprites, favicons, pixels) dropped. Deduped,
+/// capped, never fetches anything.
+pub fn page_images(html: &str, base_url: &str) -> Vec<String> {
+    const MAX_CANDIDATES: usize = 24;
+    let cap = html
+        .char_indices()
+        .nth(1_000_000)
+        .map(|(i, _)| i)
+        .unwrap_or(html.len());
+    let hay = &html[..cap];
+    let lower = hay.to_lowercase();
+    let mut out: Vec<String> = Vec::new();
+    if lower.len() != hay.len() {
+        // See og_image: shared byte indices below need same-length lowering.
+        out.extend(og_image(html, base_url));
+        return out;
+    }
+    let base = reqwest::Url::parse(base_url).ok();
+    let mut seen = std::collections::HashSet::new();
+    let mut push = |raw: &str, out: &mut Vec<String>| {
+        let candidate = decode_entities(raw.trim());
+        if candidate.is_empty() || candidate.starts_with("data:") {
+            return;
+        }
+        let resolved = base
+            .as_ref()
+            .and_then(|b| b.join(&candidate).ok())
+            .map(|u| u.to_string())
+            .unwrap_or(candidate);
+        if !resolved.starts_with("http://") && !resolved.starts_with("https://") {
+            return;
+        }
+        let l = resolved.to_lowercase();
+        if l.ends_with(".svg")
+            || ["sprite", "favicon", "pixel.", "1x1", "spacer"]
+                .iter()
+                .any(|w| l.contains(w))
+        {
+            return;
+        }
+        if seen.insert(l) {
+            out.push(resolved);
+        }
+    };
+    // Meta tags first — they're the page's own pick of a representative image.
+    for key in ["<meta", "<img"] {
+        let mut pos = 0;
+        while out.len() < MAX_CANDIDATES {
+            let Some(off) = lower[pos..].find(key) else {
+                break;
+            };
+            let start = pos + off;
+            let Some(end) = lower[start..].find('>').map(|e| start + e + 1) else {
+                break;
+            };
+            pos = end;
+            let tag = &hay[start..end];
+            if key == "<meta" {
+                const KEYS: &[&str] = &[
+                    "og:image",
+                    "og:image:url",
+                    "og:image:secure_url",
+                    "twitter:image",
+                    "twitter:image:src",
+                ];
+                let name = meta_attr(tag, "property").or_else(|| meta_attr(tag, "name"));
+                if !name.is_some_and(|k| KEYS.contains(&k.to_lowercase().as_str())) {
+                    continue;
+                }
+                if let Some(content) = meta_attr(tag, "content") {
+                    push(content, &mut out);
+                }
+            } else if let Some(src) = meta_attr(tag, "src") {
+                push(src, &mut out);
+            }
+        }
+    }
+    out
+}
+
 /// The page's lead image from raw HTML meta tags — `og:image` (and its
 /// `:url`/`:secure_url` variants) or `twitter:image`, first hit wins —
 /// resolved against the page URL. Head-only scan; never fetches anything.
@@ -2001,6 +2085,28 @@ mod tests {
         assert_eq!(
             og_image(twitter, "https://ex.com/"),
             Some("https://ex.com/t.png".to_string())
+        );
+    }
+
+    #[test]
+    fn page_images_collects_meta_then_body_and_filters_chrome() {
+        let html = r#"<html><head>
+            <meta property="og:image" content="https://ex.com/hero.jpg">
+        </head><body>
+            <img src="/photos/a.png" alt="">
+            <img src="https://ex.com/sprite-sheet.png">
+            <img src="https://ex.com/logo.svg">
+            <img src="data:image/gif;base64,R0lGOD">
+            <img data-src="../b.webp" src="https://ex.com/1x1.gif">
+            <img src="/photos/a.png">
+        </body></html>"#;
+        assert_eq!(
+            page_images(html, "https://ex.com/articles/page"),
+            vec![
+                "https://ex.com/hero.jpg".to_string(),
+                "https://ex.com/photos/a.png".to_string(),
+                "https://ex.com/b.webp".to_string(),
+            ]
         );
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -444,6 +444,8 @@ pub fn run() {
             commands::update_source_text,
             commands::set_source_tags,
             commands::set_source_note,
+            commands::set_source_image,
+            commands::source_image_candidates,
             commands::refresh_source_url,
             commands::refresh_sources,
             commands::get_source_content,

--- a/src-tauri/src/mcp/sources.rs
+++ b/src-tauri/src/mcp/sources.rs
@@ -133,6 +133,15 @@ struct SetNoteReq {
 }
 
 #[derive(serde::Deserialize, schemars::JsonSchema)]
+struct SetImageReq {
+    /// Source id (from list_sources); must be a URL source.
+    source_id: String,
+    /// Web URL of the image to show on the source's gallery card, "-" to
+    /// show none, or "" to forget the pick and let the backfill auto-pick.
+    image_url: String,
+}
+
+#[derive(serde::Deserialize, schemars::JsonSchema)]
 struct ActivityReq {
     /// Look-back window in hours (default 24, capped to the 30-day event
     /// window the table keeps).
@@ -385,6 +394,24 @@ impl AlchemyMcp {
     ) -> Result<CallToolResult, McpError> {
         let state = self.state();
         let source = commands::set_source_note_impl(&state, &source_id, &note)
+            .await
+            .map_err(internal)?;
+        self.changed("sources", Some(&source.notebook_id));
+        json_result(&source)
+    }
+
+    #[tool(
+        description = "Set a URL source's gallery card image by hand — the ingest-time og:image pick misses some pages. image_url is a web image URL, \"-\" for none, or \"\" to forget the pick so the backfill can auto-pick again. Returns the updated source."
+    )]
+    async fn set_source_image(
+        &self,
+        Parameters(SetImageReq {
+            source_id,
+            image_url,
+        }): Parameters<SetImageReq>,
+    ) -> Result<CallToolResult, McpError> {
+        let state = self.state();
+        let source = commands::set_source_image_impl(&state, &source_id, &image_url)
             .await
             .map_err(internal)?;
         self.changed("sources", Some(&source.notebook_id));

--- a/src/components/GalleryPane.tsx
+++ b/src/components/GalleryPane.tsx
@@ -23,6 +23,7 @@ import {
   useSourceMetaModals,
 } from "./SourceMetaModals";
 import { sourceIcon } from "@/lib/sourceIcon";
+import { thumbMemory } from "@/lib/thumbCache";
 import { GraphView } from "./GraphView";
 import {
   ArrowLeft,
@@ -48,10 +49,8 @@ const sweptNotebooks = new Set<string>();
 /* Scroll positions per notebook+level ride the persistent scrollMemory in
  * lib/utils — Reader round-trips AND relaunches come back to the same place. */
 
-/** Resolved card visuals (data URIs) per source id, so reopening the
- *  gallery paints instantly instead of re-running IPC + image fetches.
- *  "" = checked, none. The backend also disk-caches og downloads. */
-const thumbMemory = new Map<string, string>();
+/* Resolved card visuals ride lib/thumbCache's thumbMemory — shared so the
+ * reader's image picker can invalidate a card after a hand-pick. */
 
 /** At most this many thumbnail IPC calls in flight. Every mounted card used
  *  to fire its own immediately — a large gallery meant hundreds of parallel

--- a/src/components/ReaderPane.tsx
+++ b/src/components/ReaderPane.tsx
@@ -26,6 +26,7 @@ import { RichEditor } from "./RichEditor";
 import { StreamingBody } from "./StudioNoteViewer";
 import { KIND_LABEL } from "./studioArtifacts";
 import { Favicon } from "./SourcesPanel";
+import { SourceImagePicker } from "./SourceImagePicker";
 import { sourceIcon } from "@/lib/sourceIcon";
 import { Button, Input, RowMenu, Spinner, Textarea, useDelayedFlag } from "./ui";
 import {
@@ -50,6 +51,7 @@ import {
   ExternalLink,
   FileInput,
   FolderOpen,
+  Image as ImageIcon,
   LayoutGrid,
   MessageSquare,
   MessageSquarePlus,
@@ -560,6 +562,7 @@ export function ReaderPane() {
   const compact = paneWidth > 0 && paneWidth < 560;
   const [findOpen, setFindOpen] = useState(false);
   const [syncing, setSyncing] = useState(false);
+  const [imagePickerOpen, setImagePickerOpen] = useState(false);
   const [refreshTick, setRefreshTick] = useState(0);
   const [editing, setEditing] = useState(false);
   const [liveMode, setLiveMode] = useState(false);
@@ -707,6 +710,16 @@ export function ReaderPane() {
           },
         }
       : null;
+  // Hand-pick the gallery card's image (url sources only — that's the type
+  // whose card leads with one): rare enough to live in the overflow menu.
+  const cardImageAction =
+    source && source.sourceType === "url"
+      ? {
+          label: "Choose card image…",
+          icon: <ImageIcon className="h-3.5 w-3.5" />,
+          onClick: () => setImagePickerOpen(true),
+        }
+      : null;
   // Roomy: source actions all inline (no menu at all); notes keep only the
   // rare actions behind the menu. Compact: secondaries fold into the menu.
   const inlineActions = compact
@@ -716,6 +729,7 @@ export function ReaderPane() {
       );
   const overflowItems = [
     ...(copyLinkAction ? [copyLinkAction] : []),
+    ...(cardImageAction ? [cardImageAction] : []),
     ...(compact
       ? [askAction, originAction, refreshAction].filter(
           (a): a is NonNullable<typeof a> => a !== null,
@@ -997,6 +1011,13 @@ export function ReaderPane() {
         <div className="flex flex-1 items-center justify-center text-body text-muted-foreground">
           This document no longer exists — it may have been deleted.
         </div>
+      )}
+      {source && source.sourceType === "url" && (
+        <SourceImagePicker
+          source={source}
+          open={imagePickerOpen}
+          onClose={() => setImagePickerOpen(false)}
+        />
       )}
     </div>
   );

--- a/src/components/SourceImagePicker.tsx
+++ b/src/components/SourceImagePicker.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+import { useStore } from "@/lib/store";
+import { thumbMemory } from "@/lib/thumbCache";
+import type { Source } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import { Button, Input, Modal, Spinner } from "./ui";
+
+/** Hand-pick a URL source's gallery card image: the ingest-time og:image
+ *  pick misses some pages, so this offers the page's own images to choose
+ *  from, plus a paste-a-URL escape hatch. "-" stores checked-none. */
+export function SourceImagePicker({
+  source,
+  open,
+  onClose,
+}: {
+  source: Source;
+  open: boolean;
+  onClose: () => void;
+}) {
+  const [candidates, setCandidates] = useState<string[] | null>(null);
+  const [fetchFailed, setFetchFailed] = useState(false);
+  const [manual, setManual] = useState("");
+  const [saving, setSaving] = useState<string | null>(null);
+  const [broken, setBroken] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    if (!open) return;
+    setCandidates(null);
+    setFetchFailed(false);
+    setManual("");
+    setBroken({});
+    let stale = false;
+    api
+      .sourceImageCandidates(source.id)
+      .then((urls) => {
+        if (!stale) setCandidates(urls);
+      })
+      .catch(() => {
+        if (!stale) {
+          setCandidates([]);
+          setFetchFailed(true);
+        }
+      });
+    return () => {
+      stale = true;
+    };
+  }, [open, source.id]);
+
+  const choose = (url: string) => {
+    setSaving(url);
+    api
+      .setSourceImage(source.id, url)
+      .then((updated) => {
+        useStore.setState((st) => ({
+          sources: st.sources.map((s) =>
+            s.id === updated.id ? { ...s, imageUrl: updated.imageUrl } : s,
+          ),
+        }));
+        // The gallery's session cache holds the old visual — forget it so
+        // the card re-resolves through the (also cleared) disk cache.
+        thumbMemory.delete(source.id);
+        useStore
+          .getState()
+          .pushToast(
+            "success",
+            url === "-" ? "Card image removed" : "Card image set",
+          );
+        onClose();
+      })
+      .catch(() => undefined) // surfaced by the api layer's toast path
+      .finally(() => setSaving(null));
+  };
+
+  const visible = (candidates ?? []).filter((u) => !broken[u]);
+  const manualTrimmed = manual.trim();
+  const manualOk = /^https?:\/\//.test(manualTrimmed);
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title="Card image"
+      width="max-w-lg"
+      footer={
+        <div className="flex w-full items-center gap-2">
+          {source.imageUrl !== "" && source.imageUrl !== "-" && (
+            <Button
+              variant="ghost"
+              onClick={() => choose("-")}
+              disabled={saving !== null}
+              title="Show no image on this source's card"
+            >
+              No image
+            </Button>
+          )}
+          <div className="ml-auto flex items-center gap-2">
+            <Input
+              value={manual}
+              onChange={(e) => setManual(e.target.value)}
+              placeholder="Or paste an image URL…"
+              className="w-56"
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && manualOk) choose(manualTrimmed);
+              }}
+            />
+            <Button
+              variant="secondary"
+              disabled={!manualOk || saving !== null}
+              loading={saving === manualTrimmed}
+              onClick={() => choose(manualTrimmed)}
+            >
+              Use
+            </Button>
+          </div>
+        </div>
+      }
+    >
+      <div className="flex flex-col gap-3">
+        <p className="text-caption text-muted-foreground">
+          The image on this source's gallery card. These are the images on the
+          page itself — pick one, or paste any image URL below.
+        </p>
+        {candidates === null ? (
+          <div className="flex items-center gap-2 py-6 text-caption text-muted-foreground">
+            <Spinner className="h-3.5 w-3.5" /> Reading the page…
+          </div>
+        ) : visible.length === 0 ? (
+          <div className="rounded-md border border-dashed border-border px-3 py-2.5 text-caption text-subtle-foreground">
+            {fetchFailed
+              ? "Couldn't reach the page — paste an image URL below instead."
+              : "No images found on the page — paste an image URL below instead."}
+          </div>
+        ) : (
+          <div className="grid grid-cols-3 gap-2">
+            {visible.map((u) => (
+              <button
+                key={u}
+                type="button"
+                onClick={() => choose(u)}
+                disabled={saving !== null}
+                title={u}
+                className={cn(
+                  "relative overflow-hidden rounded-md border bg-surface-2 transition-colors",
+                  u === source.imageUrl
+                    ? "border-primary"
+                    : "border-border hover:border-border-strong",
+                )}
+              >
+                <img
+                  src={u}
+                  alt=""
+                  loading="lazy"
+                  onError={() => setBroken((m) => ({ ...m, [u]: true }))}
+                  className="h-24 w-full object-cover"
+                />
+                {saving === u && (
+                  <span className="absolute inset-0 flex items-center justify-center bg-surface/60">
+                    <Spinner className="h-4 w-4" />
+                  </span>
+                )}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -223,6 +223,14 @@ export const api = {
    *  annotation for retrieval, hence the ai budget. */
   setSourceNote: (sourceId: string, note: string) =>
     run(ai<Source>("set_source_note", { sourceId, note })),
+  /** Candidate lead images scraped live from a URL source's page, for the
+   *  reader's manual picker. */
+  sourceImageCandidates: (sourceId: string) =>
+    run(slow<string[]>("source_image_candidates", { sourceId })),
+  /** Hand-pick a URL source's gallery card image ("-" = none, "" = let the
+   *  backfill auto-pick again). Returns the updated source, content stripped. */
+  setSourceImage: (sourceId: string, imageUrl: string) =>
+    run(cmd<Source>("set_source_image", { sourceId, imageUrl })),
   refreshSourceUrl: (sourceId: string) =>
     run(ai<Source>("refresh_source_url", { sourceId })),
   /** Batch refresh (RFC-multi-select): returns immediately; the backend

--- a/src/lib/thumbCache.ts
+++ b/src/lib/thumbCache.ts
@@ -1,0 +1,6 @@
+// Resolved gallery-card visuals (data URIs) per source id, so reopening the
+// gallery paints instantly instead of re-running IPC + image fetches.
+// "" = checked, none. The backend also disk-caches og downloads. Lives
+// outside GalleryPane so the reader's image picker can invalidate a card
+// after the user hand-picks a new image.
+export const thumbMemory = new Map<string, string>();


### PR DESCRIPTION
Reminders backlog item, human-tested in the dev app.

The ingest-time og:image pick misses some pages. URL sources get "Choose card image…" in the reader's overflow menu: a grid of the page's own images (og/twitter meta first, then body `<img>`s including lazy-load `data-src`, sprites/favicons/SVGs filtered), a paste-a-URL field, and a "No image" option storing the `-` sentinel. Picking clears the backend og cache and the gallery's session thumbnail memory so the card updates immediately.

Agent parity: new `set_source_image` MCP tool; the Tauri command and the tool share `set_source_image_impl`.

Gates: typecheck + vite build clean, `cargo fmt` / `clippy -D warnings` clean, 418 lib tests passed (adds a `page_images` unit test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)