### PR TITLE
Deep research: planner status line + durable run traces

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -14,7 +14,7 @@ use crate::db::Db;
 use crate::models::Citation;
 use crate::rag;
 
-const MAX_STEPS: usize = 5;
+pub(crate) const MAX_STEPS: usize = 5;
 
 /// Which model role runs the loop's internal calls — planning, reranking,
 /// and per-source distillation.
@@ -149,13 +149,65 @@ pub async fn run(
     let mut seen: HashSet<String> = HashSet::new();
     let mut transcript = String::new();
 
-    for _ in 0..MAX_STEPS {
-        let messages =
-            rag::build_agent_decision(question, &source_list, &transcript, gathered.len());
+    // Run trace (docs/RFC-retrieval-maturity.md): every plan/search/read step
+    // lands in agent.jsonl under one run id, so a bad run can be replayed,
+    // its first wrong step named, and its shape turned into an eval fixture.
+    // chat://step events are ephemeral; this is the durable record.
+    let run_id = uuid::Uuid::new_v4().to_string();
+    let t_run = std::time::Instant::now();
+    let trace = |record: serde_json::Value| {
+        if let Some(dir) = crate::trace::dir() {
+            let mut record = record;
+            if let Some(obj) = record.as_object_mut() {
+                obj.insert("ts".into(), chrono::Utc::now().timestamp_millis().into());
+                obj.insert("run".into(), run_id.clone().into());
+            }
+            crate::trace::log_file(dir, "agent.jsonl", record);
+        }
+    };
+    let read_budget_total = read_remaining;
+    trace(serde_json::json!({
+        "event": "start",
+        "notebookId": notebook_id,
+        "question": question,
+        "sources": sources.len(),
+        "scoped": source_ids.is_some(),
+        "readBudget": read_budget_total,
+    }));
+
+    for step0 in 0..MAX_STEPS {
+        let step = step0 + 1;
+        let messages = rag::build_agent_decision(
+            question,
+            &source_list,
+            &transcript,
+            gathered.len(),
+            &rag::AgentStatus {
+                step,
+                max_steps: MAX_STEPS,
+                read_used: read_budget_total - read_remaining,
+                read_budget: read_budget_total,
+            },
+        );
         let planned = std::time::Instant::now();
         let raw = ollama.chat_role(loop_role(), &messages).await?.text;
-        phases.planner(planned.elapsed().as_millis() as u64);
-        match parse_action(&raw) {
+        let planner_ms = planned.elapsed().as_millis() as u64;
+        phases.planner(planner_ms);
+        let action = parse_action(&raw);
+        trace(serde_json::json!({
+            "event": "plan",
+            "step": step,
+            "ms": planner_ms,
+            "action": match &action {
+                Some(Action::Search(q)) => serde_json::json!({ "search": q }),
+                Some(Action::Read(ids)) => serde_json::json!({ "read": ids }),
+                Some(Action::Stop) => serde_json::json!("answer"),
+                // The raw output only when it didn't parse — that's the case
+                // replay and repair work need to see.
+                None => serde_json::json!({ "unparseable": truncate(&raw, 400) }),
+            },
+        }));
+        match action {
             Some(Action::Search(query)) => {
                 let searched = std::time::Instant::now();
                 emit_step(app, format!("Searching: {query}"));
@@ -166,6 +218,7 @@ pub async fn run(
                 // Retrieve wide, then let the model pick the few passages that
                 // actually answer — recall from hybrid search, precision from
                 // the rerank.
+                let pool = hits.len();
                 if hits.len() > SEARCH_K {
                     emit_step(app, "Ranking results".into());
                     // The local cross-encoder when there is one: measured
@@ -182,6 +235,7 @@ pub async fn run(
                     hits = rerank_for_search(ollama, &query, hits).await;
                 }
                 transcript.push_str(&format!("SEARCH \"{query}\":\n"));
+                let before = gathered.len();
                 for h in &hits {
                     if seen.insert(h.chunk_id.clone()) {
                         gathered.push(h.clone());
@@ -193,7 +247,17 @@ pub async fn run(
                     ));
                 }
                 transcript.push('\n');
-                phases.search(searched.elapsed().as_millis() as u64);
+                let search_ms = searched.elapsed().as_millis() as u64;
+                trace(serde_json::json!({
+                    "event": "search",
+                    "step": step,
+                    "query": query,
+                    "pool": pool,
+                    "kept": hits.len(),
+                    "new": gathered.len() - before,
+                    "ms": search_ms,
+                }));
+                phases.search(search_ms);
             }
             Some(Action::Read(source_ids)) => {
                 let readed = std::time::Instant::now();
@@ -238,8 +302,14 @@ pub async fn run(
                     .buffered(DISTILL_CONCURRENCY)
                     .collect()
                     .await;
+                let mut read_log: Vec<serde_json::Value> = Vec::new();
                 for (source_id, title, evidence) in distilled {
                     transcript.push_str(&format!("READ \"{title}\":\n{evidence}\n\n"));
+                    read_log.push(serde_json::json!({
+                        "sourceId": source_id,
+                        "title": title,
+                        "evidenceChars": evidence.chars().count(),
+                    }));
                     let read_id = format!("read:{source_id}");
                     if seen.insert(read_id.clone()) {
                         gathered.push(Citation {
@@ -256,7 +326,15 @@ pub async fn run(
                         });
                     }
                 }
-                phases.read(readed.elapsed().as_millis() as u64);
+                let read_ms = readed.elapsed().as_millis() as u64;
+                trace(serde_json::json!({
+                    "event": "read",
+                    "step": step,
+                    "sources": read_log,
+                    "readBudgetLeft": read_remaining,
+                    "ms": read_ms,
+                }));
+                phases.read(read_ms);
             }
             Some(Action::Stop) | None => break,
         }
@@ -270,7 +348,16 @@ pub async fn run(
         gathered = db
             .search_chunks(notebook_id, qvec, question, 8, source_ids)
             .await?;
+        trace(serde_json::json!({
+            "event": "fallback_search",
+            "kept": gathered.len(),
+        }));
     }
+    trace(serde_json::json!({
+        "event": "answer",
+        "citations": crate::trace::cite_summaries(&gathered),
+        "msToAnswer": t_run.elapsed().as_millis() as u64,
+    }));
 
     emit_step(app, "Writing answer".into());
     let source_manifest: Vec<(String, String, String)> = sources

--- a/src-tauri/src/rag.rs
+++ b/src-tauri/src/rag.rs
@@ -996,23 +996,48 @@ and distilled in parallel, so one read of four sources is far faster than four r
 Guidance: break multi-part questions into several searches across turns. Prefer distinct queries that cover \
 different facets. Choose \"answer\" once the gathered excerpts can support a complete, grounded response.";
 
+/// Loop-position numbers for the planner's status line — the loop has
+/// always tracked these; the model just never saw them. `step` is 1-based;
+/// the read fields are chars.
+pub struct AgentStatus {
+    pub step: usize,
+    pub max_steps: usize,
+    pub read_used: usize,
+    pub read_budget: usize,
+}
+
 /// Build the planner prompt for one step of the agentic retrieval loop.
+///
+/// The status line (agent-status-bar pattern) tells the model where it is
+/// in the loop, so it can pace its remaining steps and knows the loop
+/// hard-stops rather than planning as if steps were unlimited.
 pub fn build_agent_decision(
     question: &str,
     source_list: &str,
     transcript: &str,
     gathered_count: usize,
+    status: &AgentStatus,
 ) -> Vec<ChatTurn> {
     let gathered = if transcript.trim().is_empty() {
         "(nothing yet)".to_string()
     } else {
         transcript.to_string()
     };
+    let AgentStatus {
+        step,
+        max_steps,
+        read_used,
+        read_budget,
+    } = status;
     vec![
         ChatTurn::system(AGENT_SYSTEM),
         ChatTurn::user(format!(
             "Question: {question}\n\nAvailable sources:\n{source_list}\n\n\
              Evidence gathered so far ({gathered_count} excerpts):\n{gathered}\n\n\
+             Status: step {step} of {max_steps}; read budget {read_used} of \
+             {read_budget} chars used. After step {max_steps} the loop stops and \
+             the answer is written from the evidence above — choose \
+             {{\"action\":\"answer\"}} sooner the moment it suffices.\n\n\
              Next action (one JSON object):"
         )),
     ]
@@ -1087,6 +1112,23 @@ mod tests {
             snippet: snippet.into(),
             distance: 0.0,
         }
+    }
+
+    /// The planner sees its own status: step position, read budget, and the
+    /// hard-stop warning, so it can pace the remaining steps.
+    #[test]
+    fn agent_decision_carries_status_line() {
+        let status = AgentStatus {
+            step: 3,
+            max_steps: 5,
+            read_used: 800,
+            read_budget: 12_000,
+        };
+        let messages = build_agent_decision("q?", "- Doc (id: s1, 3 chunks)", "", 0, &status);
+        let user = &messages[1].content;
+        assert!(user.contains("step 3 of 5"), "{user}");
+        assert!(user.contains("read budget 800 of 12000 chars"), "{user}");
+        assert!(user.contains("After step 5 the loop stops"), "{user}");
     }
 
     /// Lost-in-the-Middle ordering: strongest hits land first and last,

--- a/src-tauri/src/retrieval_eval.rs
+++ b/src-tauri/src/retrieval_eval.rs
@@ -2227,7 +2227,18 @@ async fn eval_agent_planner_roles() {
     for role in [crate::inference::Role::Small, crate::inference::Role::Chat] {
         let (mut parsed, mut on_target, mut total_ms) = (0usize, 0usize, 0u128);
         for (question, marker) in PLANNER_PROBES {
-            let messages = crate::rag::build_agent_decision(question, &source_list, "", 0);
+            let messages = crate::rag::build_agent_decision(
+                question,
+                &source_list,
+                "",
+                0,
+                &crate::rag::AgentStatus {
+                    step: 1,
+                    max_steps: crate::agent::MAX_STEPS,
+                    read_used: 0,
+                    read_budget: crate::agent::READ_CHARS_LOCAL,
+                },
+            );
             let t = std::time::Instant::now();
             let raw = match ai.chat_role(role, &messages).await {
                 Ok(out) => out.text,
@@ -2392,7 +2403,18 @@ async fn eval_agent_phase_costs() {
     }
 
     // Planner decision (Small role — the shipping default).
-    let messages = crate::rag::build_agent_decision(question, &source_list, "", 0);
+    let messages = crate::rag::build_agent_decision(
+        question,
+        &source_list,
+        "",
+        0,
+        &crate::rag::AgentStatus {
+            step: 1,
+            max_steps: crate::agent::MAX_STEPS,
+            read_used: 0,
+            read_budget: crate::agent::READ_CHARS_LOCAL,
+        },
+    );
     let _ = timed!("planner (small)", {
         ai.chat_role(crate::inference::Role::Small, &messages)
             .await


### PR DESCRIPTION
Two Reminders backlog items on the deep-research agent loop.

**Status line in the planner prompt** (agent-status-bar pattern): each decision prompt now carries "step k of N; read budget X of Y chars used" plus the hard-stop warning. The loop always tracked these numbers; the model never saw them, so it couldn't pace remaining steps or know the loop ends. Grouped into a `rag::AgentStatus` struct; eval callers updated; unit test pins the line's presence.

**Run traces to `traces/agent.jsonl`**: every run logs under one run id — `start` (question, scope, budget), `plan` per step (parsed action, or the raw output truncated when unparseable), `search` (query, pool/kept/new counts), `read` (per-source evidence chars, budget remaining), `fallback_search`, and `answer` (citations, total ms). Same rotation/swallow contract as the other trace files. `chat://step` events were ephemeral; this is the durable record for replay, first-wrong-step attribution, and turning bad runs into eval fixtures.

Verified live: a real deep-research run produced the full chain, and the trace immediately attributed 595s of the 598s run to a cold small-model planner call — the kind of finding it exists to surface.

Gates: `cargo fmt` / `clippy -D warnings` clean, 419 lib tests passed (adds the status-line test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)