### PR TITLE
Agent loop repair turn; retry parity for Ollama and agent CLIs

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -175,6 +175,7 @@ pub async fn run(
         "readBudget": read_budget_total,
     }));
 
+    let mut repaired = false;
     for step0 in 0..MAX_STEPS {
         let step = step0 + 1;
         let messages = rag::build_agent_decision(
@@ -193,20 +194,44 @@ pub async fn run(
         let raw = ollama.chat_role(loop_role(), &messages).await?.text;
         let planner_ms = planned.elapsed().as_millis() as u64;
         phases.planner(planner_ms);
-        let action = parse_action(&raw);
+        let mut action = parse_action(&raw);
         trace(serde_json::json!({
             "event": "plan",
             "step": step,
             "ms": planner_ms,
-            "action": match &action {
-                Some(Action::Search(q)) => serde_json::json!({ "search": q }),
-                Some(Action::Read(ids)) => serde_json::json!({ "read": ids }),
-                Some(Action::Stop) => serde_json::json!("answer"),
-                // The raw output only when it didn't parse — that's the case
-                // replay and repair work need to see.
-                None => serde_json::json!({ "unparseable": truncate(&raw, 400) }),
-            },
+            "action": action_json(&action, &raw),
         }));
+        // Repair turn: unparseable planner output used to end the loop
+        // silently. One corrective turn (the model's own reply plus the
+        // grammar) per run; if that also fails to parse — or the call
+        // errors — the break below falls to the safety-net retrieval.
+        if action.is_none() && !repaired {
+            repaired = true;
+            emit_step(app, "Refining the plan".into());
+            let repair = rag::build_agent_repair(&messages, &raw);
+            let t = std::time::Instant::now();
+            match ollama.chat_role(loop_role(), &repair).await {
+                Ok(out) => {
+                    let ms = t.elapsed().as_millis() as u64;
+                    phases.planner(ms);
+                    action = parse_action(&out.text);
+                    trace(serde_json::json!({
+                        "event": "repair",
+                        "step": step,
+                        "ms": ms,
+                        "action": action_json(&action, &out.text),
+                    }));
+                }
+                Err(err) => {
+                    trace(serde_json::json!({
+                        "event": "repair",
+                        "step": step,
+                        "ms": t.elapsed().as_millis() as u64,
+                        "error": err.to_string(),
+                    }));
+                }
+            }
+        }
         match action {
             Some(Action::Search(query)) => {
                 let searched = std::time::Instant::now();
@@ -496,6 +521,17 @@ pub(crate) async fn distill_with(
 
 fn emit_step(app: &AppHandle, label: String) {
     let _ = app.emit("chat://step", StepEvent { label });
+}
+
+/// Trace encoding of one planner decision — the raw output rides along only
+/// when it didn't parse, which is the case replay and repair need to see.
+fn action_json(action: &Option<Action>, raw: &str) -> serde_json::Value {
+    match action {
+        Some(Action::Search(q)) => serde_json::json!({ "search": q }),
+        Some(Action::Read(ids)) => serde_json::json!({ "read": ids }),
+        Some(Action::Stop) => serde_json::json!("answer"),
+        None => serde_json::json!({ "unparseable": truncate(raw, 400) }),
+    }
 }
 
 /// Parse the planner's JSON action, tolerating surrounding prose/code fences.

--- a/src-tauri/src/inference/agent_cli.rs
+++ b/src-tauri/src/inference/agent_cli.rs
@@ -786,11 +786,58 @@ impl AgentCli {
     /// `chat_stream` plus progress: agent CLIs sit silent for long stretches
     /// while they plan and run tools, so their structured events double as
     /// in-progress status lines (`on_step`) instead of a mute spinner.
+    ///
+    /// Retry parity with the gateway's backoff, scoped to what is safe for
+    /// a subprocess that may run tools: ONE retry, and only when the first
+    /// attempt died quickly without producing any output — a spawn failure
+    /// or an instant crash, the transient class. A run that streamed
+    /// anything is never blindly repeated (duplicate tokens, repeated tool
+    /// side effects), and timeouts are not retried — doubling a 120s
+    /// silence hides a wedged CLI instead of surfacing it.
     pub async fn chat_stream_steps<F, S>(
         &self,
         messages: &[ChatTurn],
-        on_token: F,
-        on_step: S,
+        mut on_token: F,
+        mut on_step: S,
+    ) -> Result<ChatOutcome>
+    where
+        F: FnMut(&str),
+        S: FnMut(super::Step<'_>),
+    {
+        // A missing binary is deterministic — never worth a retry.
+        self.binary.as_ref().ok_or_else(|| {
+            anyhow!(
+                "{} CLI not found. {}",
+                self.kind.binary_name(),
+                self.kind.install_hint()
+            )
+        })?;
+        const QUICK_FAILURE: std::time::Duration = std::time::Duration::from_secs(20);
+        let mut saw_any = false;
+        let started = std::time::Instant::now();
+        match self
+            .chat_stream_once(messages, &mut on_token, &mut on_step, &mut saw_any)
+            .await
+        {
+            Err(err) if !saw_any && started.elapsed() < QUICK_FAILURE => {
+                crate::note!(
+                    "{} failed before any output ({err:#}); retrying once",
+                    self.kind.binary_name()
+                );
+                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                self.chat_stream_once(messages, &mut on_token, &mut on_step, &mut saw_any)
+                    .await
+            }
+            outcome => outcome,
+        }
+    }
+
+    async fn chat_stream_once<F, S>(
+        &self,
+        messages: &[ChatTurn],
+        on_token: &mut F,
+        on_step: &mut S,
+        saw_any: &mut bool,
     ) -> Result<ChatOutcome>
     where
         F: FnMut(&str),
@@ -1080,8 +1127,8 @@ impl AgentCli {
         let kind = self.kind;
         let run = async move {
             let mut lines = BufReader::new(stdout).lines();
-            let mut on_token = on_token;
-            let mut on_step = on_step;
+            let on_token = on_token;
+            let on_step = on_step;
             // Consecutive-duplicate guard: event streams repeat themselves
             // (several deltas per tool call), and the step trail shouldn't.
             // Transient lines skip the guard — their whole job is to change.
@@ -1149,6 +1196,7 @@ impl AgentCli {
                 }
             } {
                 saw_output = true;
+                *saw_any = true;
                 let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) else {
                     // Plain-text CLIs (gemini, bob) and stream-json builds
                     // that print bare text: pass the line through verbatim.

--- a/src-tauri/src/inference/ollama.rs
+++ b/src-tauri/src/inference/ollama.rs
@@ -75,6 +75,21 @@ impl Ollama {
         format!("{}{}", self.config.base_url.trim_end_matches('/'), path)
     }
 
+    /// Gateway-parity backoff for Ollama's idempotent perception calls
+    /// (chat, embed, OCR — generations mutate nothing): two short waits on
+    /// 429/5xx before giving up, so a model mid-load or a restarting server
+    /// doesn't kill a whole agentic run. Transport errors and timeouts are
+    /// deliberately NOT retried — the client timeout is long, and doubling
+    /// it would hide a wedged server instead of surfacing it.
+    async fn backoff_if_retryable(resp: &reqwest::Response, attempt: u32) -> bool {
+        let code = resp.status().as_u16();
+        if attempt >= 2 || !(code == 429 || (500..=503).contains(&code)) {
+            return false;
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(2 + 4 * attempt as u64)).await;
+        true
+    }
+
     /// Embed a batch of texts. Returns one vector per input, in order.
     ///
     /// Texts are sent in bounded sub-batches with a per-request timeout so a
@@ -100,20 +115,27 @@ impl Ollama {
         inputs: &[String],
         timeout: std::time::Duration,
     ) -> Result<EmbedResponse> {
-        let resp = self
-            .http
-            .post(self.url("/api/embed"))
-            .timeout(timeout)
-            .json(&json!({ "model": self.config.embed_model, "input": inputs }))
-            .send()
-            .await
-            .with_context(|| {
-                format!(
-                    "embedding request to Ollama failed or timed out — is `ollama serve` running \
-                     and is the model `{}` available? (a large chat model loading can also stall this)",
-                    self.config.embed_model
-                )
-            })?;
+        let mut attempt = 0;
+        let resp = loop {
+            let resp = self
+                .http
+                .post(self.url("/api/embed"))
+                .timeout(timeout)
+                .json(&json!({ "model": self.config.embed_model, "input": inputs }))
+                .send()
+                .await
+                .with_context(|| {
+                    format!(
+                        "embedding request to Ollama failed or timed out — is `ollama serve` running \
+                         and is the model `{}` available? (a large chat model loading can also stall this)",
+                        self.config.embed_model
+                    )
+                })?;
+            if resp.status().is_success() || !Self::backoff_if_retryable(&resp, attempt).await {
+                break resp;
+            }
+            attempt += 1;
+        };
 
         if !resp.status().is_success() {
             let status = resp.status();
@@ -133,24 +155,33 @@ impl Ollama {
                 "no vision model configured for OCR — set one in Settings"
             ));
         }
-        let resp = self
-            .http
-            .post(self.url("/api/chat"))
-            .timeout(std::time::Duration::from_secs(180))
-            .json(&json!({
-                "model": model,
-                "messages": [{
-                    "role": "user",
-                    "content": ocr_prompt(model),
-                    "images": [image_base64],
-                }],
-                "stream": false,
-            }))
-            .send()
-            .await
-            .with_context(|| {
-                format!("OCR request to Ollama failed — is the vision model `{model}` installed?")
-            })?;
+        let mut attempt = 0;
+        let resp = loop {
+            let resp = self
+                .http
+                .post(self.url("/api/chat"))
+                .timeout(std::time::Duration::from_secs(180))
+                .json(&json!({
+                    "model": model,
+                    "messages": [{
+                        "role": "user",
+                        "content": ocr_prompt(model),
+                        "images": [image_base64],
+                    }],
+                    "stream": false,
+                }))
+                .send()
+                .await
+                .with_context(|| {
+                    format!(
+                        "OCR request to Ollama failed — is the vision model `{model}` installed?"
+                    )
+                })?;
+            if resp.status().is_success() || !Self::backoff_if_retryable(&resp, attempt).await {
+                break resp;
+            }
+            attempt += 1;
+        };
 
         if !resp.status().is_success() {
             let status = resp.status();
@@ -175,17 +206,24 @@ impl Ollama {
 
     /// Non-streaming chat completion; used for one-shot artifact generation.
     pub async fn chat(&self, messages: &[ChatTurn]) -> Result<ChatOutcome> {
-        let resp = self
-            .http
-            .post(self.url("/api/chat"))
-            .json(&json!({
-                "model": self.config.chat_model,
-                "messages": messages,
-                "stream": false,
-            }))
-            .send()
-            .await
-            .context("ollama chat request failed")?;
+        let mut attempt = 0;
+        let resp = loop {
+            let resp = self
+                .http
+                .post(self.url("/api/chat"))
+                .json(&json!({
+                    "model": self.config.chat_model,
+                    "messages": messages,
+                    "stream": false,
+                }))
+                .send()
+                .await
+                .context("ollama chat request failed")?;
+            if resp.status().is_success() || !Self::backoff_if_retryable(&resp, attempt).await {
+                break resp;
+            }
+            attempt += 1;
+        };
 
         if !resp.status().is_success() {
             let status = resp.status();
@@ -218,25 +256,35 @@ impl Ollama {
     where
         F: FnMut(&str),
     {
-        let resp = self
-            .http
-            .post(self.url("/api/chat"))
-            .json(&{
-                let mut body = json!({
-                    "model": self.config.chat_model,
-                    "messages": messages,
-                    "stream": true,
-                });
-                // Only when the user asked for one: the parameter is absent by
-                // default, which is what every model expects.
-                if !self.config.effort.trim().is_empty() {
-                    body["think"] = json!(self.config.effort.trim());
-                }
-                body
-            })
-            .send()
-            .await
-            .context("ollama chat request failed")?;
+        let body = {
+            let mut body = json!({
+                "model": self.config.chat_model,
+                "messages": messages,
+                "stream": true,
+            });
+            // Only when the user asked for one: the parameter is absent by
+            // default, which is what every model expects.
+            if !self.config.effort.trim().is_empty() {
+                body["think"] = json!(self.config.effort.trim());
+            }
+            body
+        };
+        // Retries happen strictly before any body is consumed, so a retried
+        // stream can never emit duplicate tokens.
+        let mut attempt = 0;
+        let resp = loop {
+            let resp = self
+                .http
+                .post(self.url("/api/chat"))
+                .json(&body)
+                .send()
+                .await
+                .context("ollama chat request failed")?;
+            if resp.status().is_success() || !Self::backoff_if_retryable(&resp, attempt).await {
+                break resp;
+            }
+            attempt += 1;
+        };
 
         if !resp.status().is_success() {
             let status = resp.status();

--- a/src-tauri/src/rag.rs
+++ b/src-tauri/src/rag.rs
@@ -1043,6 +1043,23 @@ pub fn build_agent_decision(
     ]
 }
 
+/// One corrective turn after unparseable planner output: the decision
+/// prompt, the model's own reply, and a restatement of the grammar. One
+/// shot — the caller falls back to safety-net retrieval if this also
+/// fails to parse.
+pub fn build_agent_repair(decision: &[ChatTurn], raw: &str) -> Vec<ChatTurn> {
+    let mut messages = decision.to_vec();
+    messages.push(ChatTurn::assistant(raw));
+    messages.push(ChatTurn::user(
+        "That reply was not a single valid JSON action object. Respond again with EXACTLY ONE \
+         JSON object and nothing else — no prose, no code fences. Valid actions:\n\
+         {\"action\":\"search\",\"query\":\"<focused search phrase>\"}\n\
+         {\"action\":\"read\",\"sourceIds\":[\"<id from the source list>\"]}\n\
+         {\"action\":\"answer\"}",
+    ));
+    messages
+}
+
 /// Continuation prompt for an under-length Audio Overview script: more
 /// dialogue picking up mid-episode — never a restart.
 pub fn build_audio_continuation(
@@ -1129,6 +1146,34 @@ mod tests {
         assert!(user.contains("step 3 of 5"), "{user}");
         assert!(user.contains("read budget 800 of 12000 chars"), "{user}");
         assert!(user.contains("After step 5 the loop stops"), "{user}");
+    }
+
+    /// The repair turn replays the decision prompt, quotes the model its own
+    /// bad reply, and restates the grammar — nothing else changes.
+    #[test]
+    fn agent_repair_appends_reply_and_grammar() {
+        let status = AgentStatus {
+            step: 1,
+            max_steps: 5,
+            read_used: 0,
+            read_budget: 12_000,
+        };
+        let decision = build_agent_decision("q?", "- Doc (id: s1, 3 chunks)", "", 0, &status);
+        let messages = build_agent_repair(&decision, "I think I should search for things");
+        assert_eq!(messages.len(), decision.len() + 2);
+        assert_eq!(messages[decision.len()].role, "assistant");
+        assert_eq!(
+            messages[decision.len()].content,
+            "I think I should search for things"
+        );
+        let correction = &messages[decision.len() + 1];
+        assert_eq!(correction.role, "user");
+        assert!(
+            correction.content.contains("EXACTLY ONE"),
+            "{}",
+            correction.content
+        );
+        assert!(correction.content.contains("{\"action\":\"answer\"}"));
     }
 
     /// Lost-in-the-Middle ordering: strongest hits land first and last,


### PR DESCRIPTION
Two Reminders backlog items on loop resilience.

**Repair turn on unparseable planner output** — instead of a silent stop, the loop sends one corrective turn per run: the original decision prompt, the model's own bad reply as an assistant turn, and a restatement of the JSON grammar. If the repair also fails to parse (or the call errors), the existing safety-net retrieval still grounds the answer. Repair attempts are traced to `agent.jsonl` as `repair` events beside the `plan` they correct.

**Retry parity** — `gateway.rs` had 2-attempt backoff and FM had context-overflow retry; Ollama and the agent CLIs had none.
- Ollama: same 429/5xx backoff (2 retries, 2s/6s) on chat, chat_stream, embed, and OCR. Stream retries occur strictly before any body is consumed, so a retried stream can never emit duplicate tokens. Transport errors and timeouts are deliberately not retried — doubling a long timeout hides a wedged server.
- Agent CLIs: one retry, only when the first attempt died within 20s with zero output (spawn failure, instant crash — the transient class). A run that streamed anything is never blindly repeated, since these subprocesses can run tools; timeouts are not retried.

Gates: `cargo fmt` / `clippy -D warnings` clean, 420 lib tests passed (adds a repair-prompt test; two agent_cli error-path tests now deliberately pay the 2s retry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)