### PR TITLE
Perf: cap small-model output, keep it warm, name cold loads, time stages

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -175,6 +175,14 @@ pub async fn run(
         "readBudget": read_budget_total,
     }));
 
+    // A cold planner model is the measured tail of a run (595s once, under
+    // load) — name it while it loads instead of letting it read as a hang.
+    // The keep_alive on the small engine makes this rare, not impossible.
+    if let Some(model) = ollama.cold_ollama_model(loop_role()).await {
+        emit_step(app, format!("Starting {model}…"));
+        trace(serde_json::json!({ "event": "cold_model", "model": model, "role": "small" }));
+    }
+
     let mut repaired = false;
     for step0 in 0..MAX_STEPS {
         let step = step0 + 1;
@@ -384,6 +392,12 @@ pub async fn run(
         "msToAnswer": t_run.elapsed().as_millis() as u64,
     }));
 
+    // Same honesty for the answer model — the loop may have run entirely on
+    // the small tier while the chat model sat unloaded.
+    if let Some(model) = ollama.cold_ollama_model(crate::inference::Role::Chat).await {
+        emit_step(app, format!("Starting {model}…"));
+        trace(serde_json::json!({ "event": "cold_model", "model": model, "role": "chat" }));
+    }
     emit_step(app, "Writing answer".into());
     let source_manifest: Vec<(String, String, String)> = sources
         .iter()

--- a/src-tauri/src/ai/mod.rs
+++ b/src-tauri/src/ai/mod.rs
@@ -584,6 +584,8 @@ pub(crate) fn ollama_config(config: &AiConfig) -> OllamaConfig {
         vision_model: config.vision_model.clone(),
         // Effort is a per-provider choice; the shared slice carries none.
         effort: String::new(),
+        keep_alive: None,
+        num_predict: None,
     }
 }
 
@@ -681,6 +683,20 @@ impl Ai {
         let small = if !config.small_model.trim().is_empty() {
             let mut oc = ollama_config(&config);
             oc.chat_model = config.small_model.trim().to_string();
+            // Hold the small model resident well past Ollama's 5m default:
+            // its cold load is the measured tail of deep research and gap
+            // retrieval (595s once, under load; 21s typical), and an 8B
+            // model kept warm after real use is cheap — unlike predictive
+            // preloading, which this deliberately is not.
+            oc.keep_alive = Some("30m".into());
+            // And cap its output: every small-role call is short by
+            // contract (a JSON action, a query line, a distillate whose
+            // consumer truncates at 4,000 chars). One runaway response was
+            // traced holding Ollama's single slot for 12k+ tokens (~600s)
+            // with the whole app queued behind it; 2,048 tokens is roomy
+            // for the longest legitimate reply and bounds that tail at
+            // ~20s on an 8B model.
+            oc.num_predict = Some(2_048);
             Some(ChatEngine::Ollama(Ollama::new(oc)))
         } else {
             runtime
@@ -947,6 +963,32 @@ impl Ai {
     #[cfg(test)]
     pub fn has_small_role(&self) -> bool {
         self.router.has_small()
+    }
+
+    /// The Ollama model `chat_role(role)` would run that is NOT currently
+    /// resident in the server — so a caller about to pay the cold load can
+    /// say "Starting {model}…" instead of letting it read as a hang. None
+    /// when the resolved engine isn't Ollama, the model is already loaded,
+    /// or the probe fails (status must never block a run).
+    pub async fn cold_ollama_model(&self, role: Role) -> Option<String> {
+        // Mirror chat_role's resolution: Small falls through to the chat
+        // engine when no small engine is configured.
+        let engine = match role {
+            Role::Small if !self.router.has_small() => self.router.chat_engine(Role::Chat),
+            r => self.router.chat_engine(r),
+        };
+        let ChatEngine::Ollama(o) = engine else {
+            return None;
+        };
+        let model = o.chat_model_name().to_string();
+        let loaded = self.ollama.ps().await.ok()?;
+        // `ps` reports fully tagged names; configs may omit `:latest`.
+        let norm = |s: &str| s.trim_end_matches(":latest").to_string();
+        if loaded.iter().any(|m| norm(m) == norm(&model)) {
+            None
+        } else {
+            Some(model)
+        }
     }
 
     pub async fn chat_role(&self, role: Role, messages: &[ChatTurn]) -> Result<ChatOutcome> {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -428,6 +428,8 @@ async fn readiness_for_entry(
                 embed_model: config.embed_model.clone(),
                 vision_model: config.vision_model.clone(),
                 effort: String::new(),
+                keep_alive: None,
+                num_predict: None,
             };
             if !entry.base_url.trim().is_empty() {
                 cfg.base_url = entry.base_url.clone();
@@ -8271,6 +8273,10 @@ pub async fn send_message(
     // recall from hybrid search, precision from the cross-encoder
     // (BEIR-measured in beir_eval.rs; tier choice in Router::xenc_model).
     let fetch_k = if ai.has_xenc() { k * 3 } else { k };
+    // Per-stage clocks: retrievalMs alone showed 1.6-9.2s per turn with no
+    // way to say which stage — hybrid search, the grep leg, the gap
+    // retrieval's model call, or the rerank — was eating it.
+    let t_stage = std::time::Instant::now();
     let search = e(state
         .db
         .search_chunks_trace(
@@ -8281,16 +8287,20 @@ pub async fn send_message(
             source_ids.as_deref(),
         )
         .await)?;
+    let search_ms = t_stage.elapsed().as_millis() as u64;
     // The ripgrep leg (RFC-git-sources §6): code-shaped queries also
     // exact-match over the notebook's repo-backed files, and the windows
     // join the fusion as ordinary citations.
+    let t_stage = std::time::Instant::now();
     let grep_hits = grep_leg(&state, &notebook_id, &content, source_ids.as_deref()).await;
+    let grep_ms = t_stage.elapsed().as_millis() as u64;
     // Iterative retrieval (RFC-judged-evals §4.3, measured before shipped):
     // the small tier names the evidence still missing, one more search
     // fetches it, and the merged pool reranks. Self-gating — the model
     // answers NONE when the first pass suffices — and it lifted multi-hop
     // gold-evidence citation 48%→60% with zero single-hop regression.
     let mut pool = search.final_hits;
+    let t_stage = std::time::Instant::now();
     let gap_query = gap_retrieve(
         &ai,
         &state.db,
@@ -8302,6 +8312,7 @@ pub async fn send_message(
         source_ids.as_deref(),
     )
     .await;
+    let gap_ms = t_stage.elapsed().as_millis() as u64;
     crate::trace::log(
         &state.trace_dir,
         serde_json::json!({
@@ -8320,7 +8331,9 @@ pub async fn send_message(
     );
     let pool_cap = pool.len() + grep_hits.len();
     let citations = fuse_grep_hits(pool, grep_hits, pool_cap);
+    let t_stage = std::time::Instant::now();
     let citations = ai.rerank_hits(&content, citations, k).await;
+    let rerank_ms = t_stage.elapsed().as_millis() as u64;
     let retrieval_ms = (t0.elapsed().as_millis() as u64).saturating_sub(embed_ms);
     bump_note_usage(&state.db, &citations, "retrieval_hits").await;
 
@@ -8432,6 +8445,21 @@ pub async fn send_message(
         // the same step trail the deep-research loop uses — a long silent
         // spinner otherwise reads as a hang.
         let app_for_steps = app.clone();
+        // Cold-model honesty (UX for the measured cold-load tail): if the
+        // chat model has to load first, say whose startup the wait is.
+        // Ollama default engine only — overrides carry their own engines,
+        // and non-Ollama engines return None before any probe.
+        if override_engine.is_none() {
+            if let Some(m) = ai.cold_ollama_model(crate::inference::Role::Chat).await {
+                let _ = app.emit(
+                    "chat://step",
+                    StepEvent {
+                        label: format!("Starting {m}…"),
+                        transient: false,
+                    },
+                );
+            }
+        }
         let streamed = tokio::select! {
             out = engine.chat_stream_steps(&messages, |tok| {
                 ttft_cb.mark();
@@ -8482,6 +8510,10 @@ pub async fn send_message(
             Some(serde_json::json!({
                 "embedMs": embed_ms,
                 "retrievalMs": retrieval_ms,
+                "searchMs": search_ms,
+                "grepMs": grep_ms,
+                "gapMs": gap_ms,
+                "rerankMs": rerank_ms,
             })),
         );
     }

--- a/src-tauri/src/inference/mod.rs
+++ b/src-tauri/src/inference/mod.rs
@@ -202,6 +202,19 @@ pub struct OllamaConfig {
     /// with no thinking mode ignores it rather than erroring (verified live
     /// against laguna-s-2.1, which simply answers without a thinking block).
     pub effort: String,
+    /// Residency window sent as Ollama's `keep_alive` on chat requests; None
+    /// keeps the server default (5m). The Small engine sets this: its cold
+    /// load is the measured tail of every deep-research run and gap
+    /// retrieval, and an 8B model held warm is cheap where predictively
+    /// preloading one would not be.
+    pub keep_alive: Option<String>,
+    /// Output-token ceiling sent as Ollama's `num_predict`; None = server
+    /// default (unbounded). The Small engine sets this: its calls are short
+    /// by contract (a JSON action, a query line, a ~500-word distillate),
+    /// and one runaway response was measured holding Ollama's single slot
+    /// for 12,000+ tokens — ~600s — with every other request queued behind
+    /// it. A cap turns that failure mode into a ~20s worst case.
+    pub num_predict: Option<u32>,
 }
 
 /// Reasoning-effort levels for the two engines that take it as a request

--- a/src-tauri/src/inference/ollama.rs
+++ b/src-tauri/src/inference/ollama.rs
@@ -204,18 +204,32 @@ impl Ollama {
         Ok(parsed.embeddings.first().map(|v| v.len()).unwrap_or(0))
     }
 
+    /// The configured residency window and output cap, as body fragments.
+    /// Both absent unless set — the server defaults are what every other
+    /// request expects.
+    fn apply_keep_alive(&self, body: &mut serde_json::Value) {
+        if let Some(ka) = &self.config.keep_alive {
+            body["keep_alive"] = json!(ka);
+        }
+        if let Some(n) = self.config.num_predict {
+            body["options"] = json!({ "num_predict": n });
+        }
+    }
+
     /// Non-streaming chat completion; used for one-shot artifact generation.
     pub async fn chat(&self, messages: &[ChatTurn]) -> Result<ChatOutcome> {
+        let mut body = json!({
+            "model": self.config.chat_model,
+            "messages": messages,
+            "stream": false,
+        });
+        self.apply_keep_alive(&mut body);
         let mut attempt = 0;
         let resp = loop {
             let resp = self
                 .http
                 .post(self.url("/api/chat"))
-                .json(&json!({
-                    "model": self.config.chat_model,
-                    "messages": messages,
-                    "stream": false,
-                }))
+                .json(&body)
                 .send()
                 .await
                 .context("ollama chat request failed")?;
@@ -267,6 +281,7 @@ impl Ollama {
             if !self.config.effort.trim().is_empty() {
                 body["think"] = json!(self.config.effort.trim());
             }
+            self.apply_keep_alive(&mut body);
             body
         };
         // Retries happen strictly before any body is consumed, so a retried

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -27,6 +27,8 @@ async fn rag_round_trip() {
         embed_model: "nomic-embed-text".into(),
         vision_model: String::new(),
         effort: String::new(),
+        keep_alive: None,
+        num_predict: None,
     });
     if !crate::evals::ollama_tests_enabled() {
         eprintln!("SKIP: set ALCHEMY_OLLAMA_TESTS=1 to run the Ollama round trip");


### PR DESCRIPTION
The performance batch the new tracing asked for — and the diagnosis it rewrote along the way.

**The real 600s tail was a runaway generation, not a cold load.** The per-stage retrieval clocks added here (`searchMs` / `grepMs` / `gapMs` / `rerankMs` in the chat-timing trace) pinned 591s of a 592s retrieval on the gap stage; the Ollama server log then showed the small model 12k–25k tokens into answering a prompt that asked for "a search query or NONE", holding the single GPU slot until the 600s client timeout with every other request queued behind it. The installed app's background sweeps make the same uncapped calls, and three consecutive runaways were observed wedging Ollama back-to-back.

Fixes:
- **`num_predict: 2048` on the small engine** — small-role calls (planner JSON, gap query, rerank picks, ≤4,000-char distillates) are short by contract; the cap turns a runaway from ~600s into ~20s worst case.
- **`keep_alive: 30m` on the small engine** — stays resident after real use instead of unloading at Ollama's 5m default. Deliberately not predictive preloading.
- **Cold-load honesty (UX)** — when a run is about to pay an Ollama model load, the step trail says "Starting {model}…" (deep research: small tier at loop start, chat tier before the answer; direct chat: before streaming). `cold_model` events land in `agent.jsonl`.
- **Per-stage retrieval clocks** as above.

Verified live: cold-start deep research showed the `cold_model` event + step, `ollama ps` reported the 30m residency, and post-fix generations run 300–650 tokens with a 38s end-to-end run where the same question previously took 600s.

**Note:** the installed production app still runs uncapped — its sweeps can re-wedge Ollama until the next release ships this.

Gates: `cargo fmt` / `clippy -D warnings` clean, 420 lib tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)