### PR TITLE
Eval harness gets the same engine discipline as the app

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2268,7 +2268,7 @@ pub async fn grep_sources(
 /// win came from). Returns the gap query for the retrieval trace; any
 /// failure leaves the pool untouched.
 #[allow(clippy::too_many_arguments)]
-async fn gap_retrieve(
+pub(crate) async fn gap_retrieve(
     ai: &crate::ai::Ai,
     db: &crate::db::Db,
     notebook_id: &str,

--- a/src-tauri/src/evals.rs
+++ b/src-tauri/src/evals.rs
@@ -216,6 +216,35 @@ fn flag_set(name: &str) -> bool {
     }
 }
 
+/// A raw Ollama engine for eval use, with the same discipline the app now
+/// ships: `num_predict` bounds a runaway reply (one was traced holding the
+/// server's single slot for 12k+ tokens, wedging everything behind it — an
+/// eval sweep hits the identical failure), and a SHORT residency window so
+/// a swept model expires right after its turn instead of stacking in
+/// unified memory at Ollama's 5m default while the next model loads.
+pub(crate) fn eval_ollama(model: &str) -> crate::ai::Ollama {
+    crate::ai::Ollama::new(crate::ai::OllamaConfig {
+        base_url: "http://localhost:11434".into(),
+        chat_model: model.into(),
+        keep_alive: Some("1m".into()),
+        num_predict: Some(2_048),
+        ..Default::default()
+    })
+}
+
+/// Release swept models at the end of a live eval — best-effort unloads so
+/// the machine comes back to the developer instead of holding 10-20 GB of
+/// eval models until their residency windows lapse. "fm" (the sidecar
+/// spelling in the planner A/B envs) is skipped — it isn't an Ollama tag.
+pub(crate) async fn release_models(models: &[&str]) {
+    for m in models {
+        if m.is_empty() || m.eq_ignore_ascii_case("fm") {
+            continue;
+        }
+        eval_ollama(m).unload_chat_model().await;
+    }
+}
+
 /// The embedder for a corpus eval: `builtin_ai`, behind [`evals_enabled`].
 /// The `#[ignore]`d evals call `builtin_ai` directly — `--ignored` is already
 /// an explicit ask, and gating those twice would make them silently no-op.
@@ -386,9 +415,13 @@ async fn eval_retrieval_recall() {
 #[tokio::test]
 #[ignore = "needs live Ollama; run explicitly — the silent skip made this pass green on CI without measuring anything"]
 async fn eval_distill_quality() {
+    // small_model, not just chat_model: distill runs on the Small role in
+    // the app, and that engine carries the runaway cap + residency window —
+    // the eval must exercise the same engine the loop does.
     let ai = Ai::new(
         AiConfig {
             chat_model: "digitsflow/bonsai-8b:latest".into(),
+            small_model: "digitsflow/bonsai-8b:latest".into(),
             ..Default::default()
         },
         AiRuntime::default(),
@@ -416,6 +449,7 @@ async fn eval_distill_quality() {
     .await;
 
     eprintln!("distill output ({} chars):\n{out}\n", out.chars().count());
+    release_models(&["digitsflow/bonsai-8b:latest"]).await;
     assert!(
         out.to_lowercase().contains("third thursday"),
         "distillate lost the key fact; got: {out}"
@@ -431,9 +465,12 @@ async fn eval_distill_quality() {
 #[tokio::test]
 #[ignore = "needs live Ollama; run explicitly — the silent skip made this pass green on CI without measuring anything"]
 async fn eval_rerank_surfaces_buried_hit() {
+    // small_model too — the loop's rerank call runs on the Small role, and
+    // only that engine carries the runaway cap + residency window.
     let ai = Ai::new(
         AiConfig {
             chat_model: "digitsflow/bonsai-8b:latest".into(),
+            small_model: "digitsflow/bonsai-8b:latest".into(),
             ..Default::default()
         },
         AiRuntime::default(),
@@ -482,6 +519,7 @@ async fn eval_rerank_surfaces_buried_hit() {
     );
 
     let kept = crate::agent::rerank(&ai, "what is the deductible for hail damage?", hits).await;
+    release_models(&["digitsflow/bonsai-8b:latest"]).await;
     eprintln!(
         "rerank kept: {:?}",
         kept.iter().map(|c| c.chunk_id.as_str()).collect::<Vec<_>>()
@@ -572,11 +610,9 @@ async fn eval_chat_grounding_across_models() {
 
     let mut failures: Vec<String> = Vec::new();
     for model in &models {
-        let ai = Ollama::new(OllamaConfig {
-            base_url: "http://localhost:11434".into(),
-            chat_model: model.clone(),
-            ..Default::default()
-        });
+        // The eval-tier engine: capped output (a rambling candidate must
+        // not wedge the whole sweep) and a short residency window.
+        let ai = eval_ollama(model);
         let (mut facts, mut marked, mut cited, mut tok_s) = (0, 0, 0, Vec::new());
         for (question, expects, excerpt) in qa {
             let messages = crate::rag::build_chat_messages(
@@ -601,6 +637,9 @@ async fn eval_chat_grounding_across_models() {
             marked += !markers.is_empty() as u32;
             cited += markers.contains(excerpt) as u32;
         }
+        // Release this candidate before the next loads — a sweep used to
+        // stack every swept model in unified memory for 5 minutes each.
+        ai.unload_chat_model().await;
         let speed = tok_s.iter().sum::<f64>() / tok_s.len().max(1) as f64;
         eprintln!(
             "{model}: facts {facts}/{n}, cited-at-all {marked}/{n}, cited-right-excerpt {cited}/{n}, {speed:.0} tok/s",

--- a/src-tauri/src/inference/ollama.rs
+++ b/src-tauri/src/inference/ollama.rs
@@ -347,6 +347,26 @@ impl Ollama {
         })
     }
 
+    /// Ask the server to release this engine's chat model now — a chat
+    /// request with `keep_alive: 0` and no messages is Ollama's documented
+    /// unload. Best-effort: eval sweeps call it between models so a swept
+    /// 10-20 GB model doesn't linger in unified memory while the next
+    /// loads; a failure just means the residency window expires instead.
+    #[cfg_attr(not(test), allow(dead_code))] // eval-harness hygiene, test builds only
+    pub async fn unload_chat_model(&self) {
+        let _ = self
+            .http
+            .post(self.url("/api/chat"))
+            .timeout(std::time::Duration::from_secs(10))
+            .json(&json!({
+                "model": self.config.chat_model,
+                "messages": [],
+                "keep_alive": 0,
+            }))
+            .send()
+            .await;
+    }
+
     /// The chat model this engine answers with — the name a loading status
     /// should show.
     pub fn chat_model_name(&self) -> &str {

--- a/src-tauri/src/retrieval_eval.rs
+++ b/src-tauri/src/retrieval_eval.rs
@@ -680,9 +680,12 @@ async fn eval_deep_rerank() {
 
     const KEEP: usize = 4;
     const POOL: usize = 16;
+    // small_model too: the loop's rerank runs on the Small role, and only
+    // that engine carries the runaway cap + residency window.
     let chat = crate::ai::Ai::new(
         crate::ai::AiConfig {
             chat_model: "digitsflow/bonsai-8b:latest".into(),
+            small_model: "digitsflow/bonsai-8b:latest".into(),
             ..Default::default()
         },
         crate::ai::AiRuntime::default(),
@@ -734,6 +737,9 @@ async fn eval_deep_rerank() {
                 rerank_sum += recall_at(&reranked, KEEP);
             }
         }
+    }
+    if ollama_up {
+        crate::evals::release_models(&["digitsflow/bonsai-8b:latest"]).await;
     }
     let fusion = fusion_sum / n as f64;
     let ceiling = ceiling_sum / n as f64;
@@ -2274,6 +2280,7 @@ async fn eval_agent_planner_roles() {
         "  (Small is the shipping default — agent::loop_role; \
          ALCHEMY_PLANNER_ROLE=chat restores the old behaviour.)"
     );
+    crate::evals::release_models(&[&chat_model, &small_model]).await;
 }
 
 /// Distillation probes: a question, the fixture document it should be read
@@ -2347,6 +2354,7 @@ async fn eval_agent_distill_roles() {
             total_ms / n as u128
         );
     }
+    crate::evals::release_models(&[&chat_model, &small_model]).await;
 }
 
 /// Per-phase cost of one deep-research step, so the next optimization aims
@@ -2449,10 +2457,21 @@ async fn eval_agent_phase_costs() {
                 .await
         });
     }
+
+    // Gap retrieval — the direct chat path's small-model call, timed here
+    // because the per-stage chat trace convicted it of a 591s runaway
+    // before its output was capped. Runs on the same pool the search made.
+    let gap = timed!("gap retrieve", {
+        let mut pool = picked.clone();
+        crate::commands::gap_retrieve(&ai, &db, nb, question, &mut pool, 4, 20, None).await
+    });
+    eprintln!("     (gap query: {gap:?})");
+
     eprintln!(
         "  (cold-warm gap is model load. A turn pays planner+action per step, \n\
           up to MAX_STEPS, then streams the answer.)"
     );
+    crate::evals::release_models(&[&chat_model, &small_model]).await;
 }
 
 /// Rerank probes: a question and the fixture document whose passage must
@@ -2544,4 +2563,5 @@ async fn eval_agent_rerank_paths() {
         xe_ms / n as u128,
         xe_n as f64 / n as f64
     );
+    crate::evals::release_models(&[&chat_model, &small_model]).await;
 }

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -27,8 +27,10 @@ async fn rag_round_trip() {
         embed_model: "nomic-embed-text".into(),
         vision_model: String::new(),
         effort: String::new(),
-        keep_alive: None,
-        num_predict: None,
+        // Eval-tier discipline (see evals::eval_ollama): short residency
+        // and a runaway cap, so a rambling reply can't wedge the suite.
+        keep_alive: Some("1m".into()),
+        num_predict: Some(2_048),
     });
     if !crate::evals::ollama_tests_enabled() {
         eprintln!("SKIP: set ALCHEMY_OLLAMA_TESTS=1 to run the Ollama round trip");


### PR DESCRIPTION
Follow-through on the runaway-generation fixes: the evals still built raw, uncapped Ollama engines, so a rambling model could wedge the suite exactly the way it wedged the app — and swept models stacked in unified memory at Ollama's 5m default residency.

- **`evals::eval_ollama(model)`** — shared eval-tier constructor: `num_predict: 2048`, `keep_alive: "1m"`.
- **`Ollama::unload_chat_model()` + `evals::release_models()`** — explicit best-effort unloads. The chat-grounding model sweep releases each candidate before the next loads; the planner/distill/rerank A/B evals and phase-costs eval release their model pair at the end ("fm" sidecar spelling skipped).
- **Distill/rerank evals set `small_model`**, not just `chat_model` — in the app those calls run on the Small role, and only that engine carries the cap and residency window, so the evals now measure the engine the loop actually runs.
- **`eval_agent_phase_costs` gains a "gap retrieve" row** (via `pub(crate) gap_retrieve`) — the stage the per-stage chat trace convicted of a 591s runaway previously had no eval timing.
- **`rag_round_trip`** adopts the same cap + short residency.

Verified live: `eval_distill_quality` passes (15.7s incl. model load) and `ollama ps` shows the model stopping immediately after the eval instead of lingering.

Gates: `cargo fmt` / `clippy -D warnings` clean, 420 lib tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)