### PR TITLE
Fixture cache self-heals when CI's cargo cache guts it

### DIFF
--- a/src-tauri/src/fixtures.rs
+++ b/src-tauri/src/fixtures.rs
@@ -86,9 +86,25 @@ pub(crate) async fn library(sources: usize) -> Option<Library> {
         .join(format!("store-g{GENERATION}-{sources}"));
     // The marker guards against a half-seeded cache left by an aborted run.
     let marker = dir.join("seeded.ok");
-    let cached = marker.exists();
+    let mut cached = marker.exists();
 
-    let db = Db::open(&dir).await.expect("open fixture db");
+    // CI's cargo cache can restore this directory gutted — the marker
+    // survives while Lance's own files were pruned, and the store fails to
+    // load ("Table 'notebooks' exists but could not be loaded", seen live
+    // on GitHub runners). A cache that won't open is a miss, not a failure:
+    // wipe and reseed.
+    let db = match Db::open(&dir).await {
+        Ok(db) => db,
+        Err(err) => {
+            eprintln!(
+                "fixture cache at {} unusable ({err:#}); reseeding",
+                dir.display()
+            );
+            std::fs::remove_dir_all(&dir).ok();
+            cached = false;
+            Db::open(&dir).await.expect("open fixture db after reset")
+        }
+    };
     db.set_fusion(ai.fusion_params());
 
     let notebook_id = "fixture-nb".to_string();


### PR DESCRIPTION
Autofix follow-up: `build-and-test` failed on the #36/#37 branch runs (and main's post-merge run is headed the same way). Not the UI changes — CI's cargo cache restored `target/fixture-cache/` with the `seeded.ok` marker intact but the Lance dataset pruned underneath it (`notebooks.lance/_versions` missing), and `fixtures::library()` trusted the marker and `expect`'ed the open.

Fix: a fixture cache that fails `Db::open` is treated as a miss — log, wipe the directory, reseed. Reproduced the exact corruption locally (removed `_versions` under an intact marker): the old code panics identically to CI; the new path logs "unusable … reseeding" and the test passes.

Test-harness code only; no product behavior changes.

Gates: `cargo fmt` / `clippy -D warnings` clean, 420 lib tests passed, plus the corrupted-cache reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)