### PR TITLE
Flag error pages on import, batch and Grow over MCP, forge gate

### DIFF
--- a/skills/alchemy-pi/SKILL.md
+++ b/skills/alchemy-pi/SKILL.md
@@ -39,6 +39,22 @@ are missing entirely, run `/reload` to pick up the extension.
 4. Write findings with `alchemy_create_note` (markdown). Cite which sources
    informed each claim by title so the user can verify.
 
+## Filling a notebook from a list
+
+When the user hands you a list of things to cover, the work is finding the
+right page for each. Prefer each item's official page and check unsure
+URLs first (a quick search, or a HEAD request) instead of guessing paths.
+Read every result: a `title` like "Page Not Found", "Access Denied", or
+"Attention Required", or a `charCount` of a few hundred, is not content
+even when `status` says ready — delete it and try an alternate page, a
+support-center article, or a `text` source you write and label as your
+own summary. A two-segment path on an unfamiliar host can be mistaken for
+a git repo; if an add comes back with a clone error, re-add the URL with a
+`#fragment`. Add three to five at a time, then finish with an index note
+mapping each item the user named to its sources and gaps. Covers, tags,
+and notes on sources are yours to set (`set_source_image`,
+`set_source_tags`, `set_source_note` via `alchemy_call`).
+
 ## Sharp edges
 
 - **Duplicates are rejected, not silently merged.** Adding the same URL or

--- a/skills/alchemy-prime/SKILL.md
+++ b/skills/alchemy-prime/SKILL.md
@@ -61,6 +61,22 @@ useless without it.)
    find them in `list_sources` by a `url` starting with `cider://notes/note/`
    or `cider://reminders/list/`.
 
+## Filling a notebook from a list
+
+When the user hands you a list of things to cover, the work is finding the
+right page for each. Prefer each item's official page and check unsure
+URLs first (a quick search, or a HEAD request) instead of guessing paths.
+Read every result: a `title` like "Page Not Found", "Access Denied", or
+"Attention Required", or a `charCount` of a few hundred, is not content
+even when `status` says ready — delete it and try an alternate page, a
+support-center article, or a `text` source you write and label as your
+own summary. A two-segment path on an unfamiliar host can be mistaken for
+a git repo; if an add comes back with a clone error, re-add the URL with a
+`#fragment`. Add three to five at a time, then finish with an index note
+mapping each item the user named to its sources and gaps. Covers, tags,
+and notes on sources are yours to set (`set_source_image`,
+`set_source_tags`, `set_source_note`).
+
 ## Sharp edges
 
 - **Duplicates are rejected, not silently merged.** Adding the same URL or

--- a/skills/alchemy/SKILL.md
+++ b/skills/alchemy/SKILL.md
@@ -53,6 +53,44 @@ header. Do not replace that entry with a bare URL, which will be rejected.
    find them in `list_sources` by a `url` starting with `cider://notes/note/`
    or `cider://reminders/list/`.
 
+## Filling a notebook from a list
+
+When the user hands you a list of things to cover (programs, papers,
+vendors, places), the work is finding the right page for each, not just
+adding what comes to mind. Habits that keep the notebook clean:
+
+- **Prefer the official page for each item** — the program's own benefits or
+  membership page, not a news story about it. When you're unsure of the
+  URL, check it first (`curl -sI`, or a quick web search for the current
+  page) rather than guessing a path; guessed paths 404 or land on a
+  homepage.
+- **Read every result before moving on.** A source whose `title` says "Page
+  Not Found", "Access Denied", "Attention Required", or "Just a moment", or
+  whose `charCount` is a few hundred, is not content even when `status`
+  says ready. Delete it (`delete_source`) and try an alternate: a different
+  page on the same site, a sitemap, a support-center article, a partner's
+  page that mirrors the terms. A site that fetches nothing at all
+  (Cloudflare, Akamai) gets a `text` source you write from what you know,
+  clearly labeled as your summary, with the items the user should confirm.
+- **Two-segment paths on unfamiliar hosts** (`site.org/page/Join`) can be
+  mistaken for a git owner/repo and probed as a repository. If an add
+  comes back with a clone error, re-add with a `#fragment` on the URL —
+  the shape parser skips it and the page fetches normally.
+- **Add in small groups** (three to five at a time) and check the batch
+  before the next; the importer serializes heavy work and a wall of calls
+  just stretches every call's clock.
+- **Finish with an index note**: one table per category mapping each item
+  the user named to its source titles, what each page covers, what it
+  doesn't (login-gated perks, thin marketing pages), and which URLs would
+  not import and why. That note is how the user judges coverage.
+- **Covers are yours to set**: `set_source_image` puts a picked image on
+  the source's gallery card and reader header; `set_source_tags` and
+  `set_source_note` carry the user's own labels into retrieval.
+- **Keep the user's own lists in step.** If they track the same things in
+  an Apple Reminders list, update it as well — through `add_reminder` when
+  the list is a connected source, or the `cider` CLI otherwise — and say
+  which items you added.
+
 ## Sharing notebooks
 
 Notebooks travel as OKF bundles: the app exports a single `.okf.zip`

--- a/skills/alchemy/SKILL.md
+++ b/skills/alchemy/SKILL.md
@@ -29,7 +29,14 @@ header. Do not replace that entry with a bare URL, which will be rejected.
    deserves its own. Prefer reusing an existing notebook over creating
    near-duplicates.
 2. `add_source` for each URL, file path, or block of text worth keeping.
-   Ingestion extracts, titles, chunks, and embeds automatically.
+   Ingestion extracts, titles, chunks, and embeds automatically. A list of
+   URLs goes in one call as `urls` — you get one `{url, ok, source, error}`
+   per entry, and one bad page never fails the rest. Check `status` (or
+   `ok`) before trusting a result: a 404 page or a bot wall lands as
+   `status: "error"` with the reason, not as content.
+   `grow` tells you what a notebook is missing — questions it answered
+   thinly, links its own sources keep pointing at, matching files on this
+   Mac — each proposal ready to hand back to `add_source`.
 3. `search` to ground claims before writing — hybrid vector + keyword
    retrieval over the notebook's chunks. It runs on a local embedder and is
    effectively free; make several small queries rather than one broad one.

--- a/src-tauri/src/capture.rs
+++ b/src-tauri/src/capture.rs
@@ -371,6 +371,14 @@ pub async fn extract_url_rescued(url: &str) -> Result<Extracted> {
         }
     }
     let fast = ingest::extract_url(url).await;
+    if let Err(err) = &fast {
+        if err.downcast_ref::<ingest::HttpErrorPage>().is_some() {
+            // The server said the page is gone and the body agreed. Rendering
+            // the same 404 layout can only make it longer, never real, and
+            // "longer" is exactly what the acceptance rule below rewards.
+            return fast;
+        }
+    }
     let fast_chars = fast.as_ref().map(|ex| ex.text.chars().count()).unwrap_or(0);
     let trigger = match &fast {
         Ok(ex) => match ingest::looks_blocked(&ex.text) {

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -426,9 +426,34 @@ fn looks_auth_error(stderr: &str) -> bool {
         || s.contains("403")
 }
 
+/// Does the hostname itself say "forge"? A label like `github`, `gitlab`,
+/// or `git` anywhere in it (github.ibm.com, gitlab.example.org,
+/// git.sr.ht, code.company.com). Any two-segment path parses as
+/// owner/repo, so without this a benefits page at club.org/page/Join was
+/// getting an eight-second `ls-remote`, and one misread answer poisoned
+/// the host for the TTL and sent the next add off to clone it.
+fn forge_like(host: &str) -> bool {
+    const LABELS: &[&str] = &[
+        "github",
+        "gitlab",
+        "gitea",
+        "gogs",
+        "forgejo",
+        "bitbucket",
+        "codeberg",
+        "git",
+        "code",
+        "scm",
+        "sr",
+    ];
+    host.split('.').any(|label| LABELS.contains(&label))
+}
+
 /// Shape-parse plus host gating: github.com is trusted, clone URLs are
 /// unambiguous, and unknown hosts get one remembered `ls-remote` probe —
 /// zero-config GHE (github.ibm.com works because the user's git does).
+/// A bare owner/repo shape on a host that doesn't look like a forge isn't
+/// probed at all; an explicit /blob/ or /tree/ path still is.
 pub async fn detect_target(data_dir: &Path, url: &str) -> Option<GitTarget> {
     let target = parse_git_url(url)?;
     if matches!(target, GitTarget::CloneAll { .. }) {
@@ -437,6 +462,9 @@ pub async fn detect_target(data_dir: &Path, url: &str) -> Option<GitTarget> {
     let host = host_of(target.remote());
     if host == "github.com" {
         return Some(target);
+    }
+    if matches!(target, GitTarget::RepoHome { .. }) && !forge_like(&host) {
+        return None;
     }
     if let Some(v) = host_verdict(data_dir, &host) {
         return v.then_some(target);
@@ -965,5 +993,35 @@ mod tests {
         ));
         assert!(looks_auth_error("git@host: Permission denied (publickey)."));
         assert!(!looks_auth_error("fatal: repository 'x' not found"));
+    }
+}
+
+#[cfg(test)]
+mod forge_gate_tests {
+    use super::*;
+
+    #[test]
+    fn forge_hosts_by_label() {
+        assert!(forge_like("github.ibm.com"));
+        assert!(forge_like("gitlab.example.org"));
+        assert!(forge_like("git.sr.ht"));
+        assert!(forge_like("code.company.com"));
+        assert!(!forge_like("ferrariclubofamerica.org"));
+        assert!(!forge_like("parks.sonomacounty.ca.gov"));
+        // Substrings don't count — only whole labels.
+        assert!(!forge_like("digital.example.com"));
+    }
+
+    #[tokio::test]
+    async fn bare_owner_repo_on_a_plain_host_is_not_probed() {
+        let dir = tempfile::tempdir().unwrap();
+        // No git_hosts.json is written, which proves no probe ran.
+        let got = detect_target(
+            dir.path(),
+            "https://ferrariclubofamerica.org/page/MembershipMain",
+        )
+        .await;
+        assert!(got.is_none());
+        assert!(!hosts_path(dir.path()).exists());
     }
 }

--- a/src-tauri/src/growth.rs
+++ b/src-tauri/src/growth.rs
@@ -95,10 +95,16 @@ fn extract_links(text: &str) -> Vec<(String, String)> {
             .unwrap_or(rest.len());
         let raw = rest[..end].trim_end_matches(['.', ',', ';', ']', '}']);
         // Markdown anchor: the "](url" shape puts "[anchor]" just before.
+        // Emphasis wraps the anchor, not the words ("**The Mart**" is a bold
+        // link to The Mart) — strip it so the proposal reads as a title.
         let anchor = if start >= 2 && &bytes[start - 2..start] == b"](" {
             text[..start - 2]
                 .rfind('[')
-                .map(|open| text[open + 1..start - 2].to_string())
+                .map(|open| {
+                    text[open + 1..start - 2]
+                        .trim_matches(['*', '_', '`', ' '])
+                        .to_string()
+                })
                 .unwrap_or_default()
         } else {
             String::new()

--- a/src-tauri/src/ingest.rs
+++ b/src-tauri/src/ingest.rs
@@ -18,6 +18,7 @@ fn chunk_words() -> usize {
         .unwrap_or(280)
 }
 
+#[derive(Debug)]
 pub struct Extracted {
     pub title: String,
     pub source_type: String,
@@ -707,9 +708,10 @@ pub async fn extract_url(raw_url: &str) -> Result<Extracted> {
         .with_context(|| format!("could not reach {url}"))?;
 
     // The status is advisory, not gating: some sites serve the complete
-    // article with a 500 (broken SSR that still renders — cerebras.ai) or a
-    // 404 (soft-deleted pages with full layouts). Fetch the body regardless
-    // and let readability decide; only give up when there's nothing to read.
+    // article with a 500 (broken SSR that still renders — cerebras.ai).
+    // Fetch the body regardless and let readability decide; give up when
+    // there's nothing to read, or when a failing status comes with a body
+    // that reads as the error page itself (`looks_like_error_page`).
     let status = resp.status();
 
     // Not every URL serves HTML. A link straight to a PDF (arxiv.org/pdf/...
@@ -778,6 +780,56 @@ fn url_file_title(url: &str) -> String {
         .unwrap_or_else(|| url.to_string())
 }
 
+/// A 4xx/5xx response whose body reads as the server's error page. Its own
+/// type so the rendered-capture rescue (capture.rs) can recognize it and
+/// stop: rendering a 404 layout yields the same 404 layout, only longer,
+/// and the rescue's "strictly better than the fast path" rule would take it.
+#[derive(Debug)]
+pub struct HttpErrorPage {
+    pub status: u16,
+    pub url: String,
+}
+
+impl std::fmt::Display for HttpErrorPage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} returned HTTP {} and the page is an error page, not the content",
+            self.url, self.status
+        )
+    }
+}
+
+impl std::error::Error for HttpErrorPage {}
+
+/// Does a failing response's extracted page read as the error page rather
+/// than content that merely shipped with a broken status? The title is the
+/// tell: a soft-deleted page keeps its whole layout — nav, footer, sidebars,
+/// thousands of chars — around a "Page Not Found" heading, so length alone
+/// can't catch it. A short body under a failing status is an error page too.
+/// Only consulted once the status already says failure, so a real article
+/// titled "404" served with a 200 is never touched.
+pub fn looks_like_error_page(title: &str, text: &str) -> bool {
+    const THIN: usize = 2_000;
+    if text.trim().chars().count() < THIN {
+        return true;
+    }
+    let lower = title.trim().to_lowercase();
+    const MARKERS: &[&str] = &[
+        "not found",
+        "404",
+        "410",
+        "doesn't exist",
+        "does not exist",
+        "can't be found",
+        "cannot be found",
+        "no longer available",
+        "something went wrong",
+        "server error",
+    ];
+    lower.starts_with("error") || MARKERS.iter().any(|m| lower.contains(m))
+}
+
 /// The HTML arm of `extract_url`: readability over a fetched page body.
 fn readable_page(body: String, status: reqwest::StatusCode, url: String) -> Result<Extracted> {
     let (article_title, text) = readable_text(&body, &url);
@@ -792,6 +844,13 @@ fn readable_page(body: String, status: reqwest::StatusCode, url: String) -> Resu
     let title = article_title
         .or_else(|| extract_title(&body))
         .unwrap_or_else(|| url.clone());
+    if !status.is_success() && looks_like_error_page(&title, &text) {
+        return Err(HttpErrorPage {
+            status: status.as_u16(),
+            url,
+        }
+        .into());
+    }
     let image_url = og_image(&body, &url).unwrap_or_default();
     Ok(Extracted {
         author: String::new(),
@@ -3008,5 +3067,75 @@ mod tests {
         std::fs::write(&other, b"https://paper.dropbox.com/doc/x").unwrap();
         assert_eq!(dropbox_paper_url(&other.to_string_lossy()), None);
         let _ = std::fs::remove_file(&other);
+    }
+}
+
+#[cfg(test)]
+mod error_page_tests {
+    use super::*;
+
+    fn page(title: &str, paragraphs: usize) -> String {
+        let para = "<p>The membership includes a parking pass and discounts at partner businesses across the county.</p>".repeat(paragraphs);
+        format!("<html><head><title>{title}</title></head><body><main><article><h1>{title}</h1>{para}</article></main></body></html>")
+    }
+
+    #[test]
+    fn failing_status_with_error_title_is_an_error_page() {
+        // A soft-404 keeps its whole layout, so the body is long — the title
+        // is what gives it away.
+        let err = readable_page(
+            page("Page Not Found - Error 404 | Regional Parks", 200),
+            reqwest::StatusCode::NOT_FOUND,
+            "https://example.org/gone".into(),
+        )
+        .unwrap_err();
+        let page = err.downcast_ref::<HttpErrorPage>().expect("typed error");
+        assert_eq!(page.status, 404);
+        assert!(err.to_string().contains("HTTP 404"), "{err}");
+    }
+
+    #[test]
+    fn failing_status_with_a_real_article_still_imports() {
+        // Broken SSR that still renders (cerebras.ai): the status lies, the
+        // body doesn't.
+        let ok = readable_page(
+            page("Inference at the speed of thought", 200),
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            "https://example.org/post".into(),
+        )
+        .unwrap();
+        assert!(ok.title.contains("Inference"), "{}", ok.title);
+    }
+
+    #[test]
+    fn success_status_never_consults_the_title() {
+        let ok = readable_page(
+            page("404: why the page-not-found problem persists", 200),
+            reqwest::StatusCode::OK,
+            "https://example.org/essay".into(),
+        )
+        .unwrap();
+        assert!(ok.text.chars().count() > 1_000);
+    }
+
+    #[test]
+    fn error_page_rule_covers_thin_bodies_and_error_titles() {
+        assert!(looks_like_error_page("Error", "Something short."));
+        assert!(looks_like_error_page(
+            "Ducati Page Not Found",
+            &"word ".repeat(1_000)
+        ));
+        assert!(looks_like_error_page(
+            "Error | Costco",
+            &"word ".repeat(1_000)
+        ));
+        assert!(!looks_like_error_page(
+            "A fine title",
+            &"word ".repeat(1_000)
+        ));
+        assert!(!looks_like_error_page(
+            "Terror at the summit",
+            &"word ".repeat(1_000)
+        ));
     }
 }

--- a/src-tauri/src/ingest.rs
+++ b/src-tauri/src/ingest.rs
@@ -1186,6 +1186,7 @@ pub fn blocked_marker(text: &str) -> Option<String> {
         "are you a robot",
         "checking your browser",
         "just a moment",
+        "attention required",
         "access denied",
         "captcha",
         "sign in to continue",

--- a/src-tauri/src/mcp/growth.rs
+++ b/src-tauri/src/mcp/growth.rs
@@ -1,0 +1,91 @@
+//! Grow tools — what a notebook is hungry for, and where it could be fed
+//! (docs/RFC-living-notebook.md Pillar 2). The same tiers the Grow pane
+//! shows: standing queries from thin retrievals, outbound links the
+//! notebook's own sources keep pointing at, Spotlight matches on this Mac,
+//! and — only when the notebook has it switched on — the metered open-web
+//! search. Nothing here fetches; hand a proposal's url to add_source.
+
+use super::*;
+use crate::growth::{self, GrowthProposal, GrowthWebSearch};
+use rmcp::{handler::server::wrapper::Parameters, tool, tool_router, ErrorData as McpError};
+
+#[derive(serde::Deserialize, schemars::JsonSchema)]
+struct GrowReq {
+    /// Notebook id (from list_notebooks).
+    notebook_id: String,
+    /// Also run the open-web tier (a Firecrawl search per standing query,
+    /// metered against the monthly cap). Honored only when the notebook has
+    /// web growth switched on in its Grow pane; otherwise `web` is omitted
+    /// and `webEnabled` is false.
+    #[serde(default)]
+    web: bool,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct GrowResult {
+    /// Recent questions the notebook answered thinly — what it is hungry for.
+    queries: Vec<String>,
+    /// Link tier: URLs the notebook's own sources point at but don't contain,
+    /// ranked by mentions, spread across sources, and overlap with `queries`.
+    proposals: Vec<GrowthProposal>,
+    /// Local tier: files on this Mac that Spotlight matched to the queries
+    /// (url is an on-disk path — pass it to add_source as file_path).
+    local: Vec<GrowthProposal>,
+    web_enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    web: Option<GrowthWebSearch>,
+}
+
+#[tool_router(router = growth_router, vis = "pub(super)")]
+impl AlchemyMcp {
+    #[tool(
+        description = "What a notebook is hungry for and where to feed it — the Grow pane over MCP. Returns queries (recent questions the notebook answered thinly), proposals (URLs its own sources keep linking to but that aren't in the notebook, ranked), local (files on this Mac Spotlight matched to those questions; their url is a path), and webEnabled. Pass web:true to also run the open-web search tier when the notebook has it switched on — it costs metered credits, so only when the link and local tiers came up empty. Nothing is fetched here: add a proposal with add_source (url for web, file_path for local), and prefer proposals that name a matchedQuery."
+    )]
+    async fn grow(
+        &self,
+        Parameters(GrowReq { notebook_id, web }): Parameters<GrowReq>,
+    ) -> Result<CallToolResult, McpError> {
+        let state = self.state();
+        let now = commands::now();
+        let queries = growth::standing_queries(&state.trace_dir, &notebook_id, now);
+        // The link frontier lives in the extracted text, which list_sources
+        // strips; the other tiers only need metadata.
+        let with_content = state
+            .db
+            .sources_with_content(&notebook_id)
+            .await
+            .map_err(internal)?;
+        let proposals = growth::proposals(&with_content, &queries);
+        let sources = state
+            .db
+            .list_sources(&notebook_id)
+            .await
+            .map_err(internal)?;
+        let local = growth::local_proposals(&sources, &queries).await;
+        let web_enabled = growth::web_enabled(&state.db, &notebook_id).await;
+        let web = if web && web_enabled {
+            let enabled = growth::web_enabled_count(&state.db).await;
+            Some(
+                growth::web_search(
+                    &state.trace_dir,
+                    &notebook_id,
+                    &sources,
+                    &queries,
+                    enabled,
+                    now,
+                )
+                .await,
+            )
+        } else {
+            None
+        };
+        json_result(&GrowResult {
+            queries,
+            proposals,
+            local,
+            web_enabled,
+            web,
+        })
+    }
+}

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -21,6 +21,7 @@ use crate::db::NOTEBOOK_PALETTE;
 use crate::models::{Note, Notebook, Source};
 
 mod diagnostics;
+mod growth;
 mod homechat;
 mod ledger;
 mod mac;
@@ -349,6 +350,7 @@ impl AlchemyMcp {
     + Self::registry_router()
     + Self::settings_router()
     + Self::homechat_router()
+    + Self::growth_router()
     + Self::diagnostics_router()))]
 impl ServerHandler for AlchemyMcp {
     fn get_info(&self) -> ServerInfo {
@@ -359,9 +361,10 @@ impl ServerHandler for AlchemyMcp {
             .with_instructions(
                 "Alchemy is the user's local-first research notebook: notebooks hold sources \
                  (documents, web pages, pasted text) and notes. Typical flow: list_notebooks \
-                 (or create_notebook) → add_source for each URL/file/text → search to find \
-                 relevant passages → write findings with create_note. Everything runs on the \
-                 user's machine; search is cheap, call it freely.",
+                 (or create_notebook) → add_source for each URL/file/text (a list of URLs \
+                 goes in one call as urls) → search to find relevant passages → write \
+                 findings with create_note. grow says what a notebook is missing. Everything \
+                 runs on the user's machine; search is cheap, call it freely.",
             )
     }
 }

--- a/src-tauri/src/mcp/sources.rs
+++ b/src-tauri/src/mcp/sources.rs
@@ -49,6 +49,63 @@ impl Drop for Heartbeat {
     }
 }
 
+/// One web or Mac-item import — the `url` arm of add_source, shared with
+/// the `urls` batch.
+async fn import_url(
+    state: &AppState,
+    notebook_id: &str,
+    url: &str,
+    title: Option<&str>,
+) -> anyhow::Result<Source> {
+    if crate::mac::is_mac_uri(url) {
+        // Mac items connect as living, auto-syncing sources — never through
+        // the web fetcher, which can't reach cider:// origins.
+        commands::ingest_mac(state, notebook_id, url, title.unwrap_or("")).await
+    } else {
+        commands::ingest_url(state, notebook_id, url, None).await
+    }
+}
+
+/// One entry of a batch add. `ok` is false both when the import errored out
+/// (a duplicate, an unreachable host) and when it landed as an error-status
+/// source (a 404 page, a bot wall): either way `error` says why and there is
+/// no searchable content behind it.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BatchItem {
+    url: String,
+    ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source: Option<Source>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+impl BatchItem {
+    fn new(url: String, outcome: anyhow::Result<Source>) -> Self {
+        match outcome {
+            Ok(source) if source.status == "error" => Self {
+                url,
+                ok: false,
+                error: Some(source.error.clone()),
+                source: Some(source),
+            },
+            Ok(source) => Self {
+                url,
+                ok: true,
+                source: Some(source),
+                error: None,
+            },
+            Err(err) => Self {
+                url,
+                ok: false,
+                source: None,
+                error: Some(format!("{err:#}")),
+            },
+        }
+    }
+}
+
 #[derive(serde::Deserialize, schemars::JsonSchema)]
 struct AddSourceReq {
     /// Notebook to add the source to.
@@ -58,6 +115,12 @@ struct AddSourceReq {
     /// (exactly one of url / text / file_path).
     #[serde(default)]
     url: Option<String>,
+    /// Several web URLs (or cider:// origins) to import in one call. Each
+    /// takes the same path as `url`; the result is one entry per URL —
+    /// {url, ok, source, error} — so a 404, a bot wall, or a duplicate
+    /// fails only its own entry. Not combinable with url, text, or file_path.
+    #[serde(default)]
+    urls: Option<Vec<String>>,
     /// Raw text/markdown content to store as a source.
     #[serde(default)]
     text: Option<String>,
@@ -222,13 +285,14 @@ impl AlchemyMcp {
     }
 
     #[tool(
-        description = "Add a source to a notebook. Provide exactly one of: url (fetched + article-extracted), text (pasted content; give a title), or file_path (local pdf/md/txt/csv, the whole Office family incl. legacy doc/ppt/xls, OpenDocument, rtf, epub, or an image — images and scanned PDFs are OCR'd when a vision model is configured; office formats extract as markdown). url also accepts a cider:// origin to connect a Mac item as a living, auto-syncing source: cider://reminders/list/<list name>, cider://calendar/upcoming/<days>, cider://notes/note/<note id>, or cider://stocks/watchlist/<name>. Content is chunked and embedded automatically. Duplicate content or an already-added URL is rejected with an error naming the existing source — treat that as already done. Examples: {\"notebook_id\":\"<id>\",\"url\":\"https://example.com/paper\"} · {\"notebook_id\":\"<id>\",\"text\":\"pasted content…\",\"title\":\"Meeting notes\"} · {\"notebook_id\":\"<id>\",\"file_path\":\"/Users/me/Reports/q3.docx\"}"
+        description = "Add a source to a notebook. Provide exactly one of: url (fetched + article-extracted), urls (a batch of such URLs — one result per entry, see below), text (pasted content; give a title), or file_path (local pdf/md/txt/csv, the whole Office family incl. legacy doc/ppt/xls, OpenDocument, rtf, epub, or an image — images and scanned PDFs are OCR'd when a vision model is configured; office formats extract as markdown). url also accepts a cider:// origin to connect a Mac item as a living, auto-syncing source: cider://reminders/list/<list name>, cider://calendar/upcoming/<days>, cider://notes/note/<note id>, or cider://stocks/watchlist/<name>. Content is chunked and embedded automatically. Duplicate content or an already-added URL is rejected with an error naming the existing source — treat that as already done. A page that fetches but is a 404/error page or a bot wall lands with status \"error\" and a reason — check status before trusting a result. With urls, the response is a list of {url, ok, source, error}: ok is false for anything that isn't searchable content, and one bad URL never fails the rest. Examples: {\"notebook_id\":\"<id>\",\"url\":\"https://example.com/paper\"} · {\"notebook_id\":\"<id>\",\"urls\":[\"https://a.com/x\",\"https://b.org/y\"]} · {\"notebook_id\":\"<id>\",\"text\":\"pasted content…\",\"title\":\"Meeting notes\"} · {\"notebook_id\":\"<id>\",\"file_path\":\"/Users/me/Reports/q3.docx\"}"
     )]
     async fn add_source(
         &self,
         Parameters(AddSourceReq {
             notebook_id,
             url,
+            urls,
             text,
             file_path,
             title,
@@ -236,12 +300,40 @@ impl AlchemyMcp {
         ctx: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
         let state = self.state();
+        if let Some(urls) = urls {
+            if url.is_some() || text.is_some() || file_path.is_some() {
+                return Err(invalid(
+                    "urls is a batch on its own — don't combine it with url, text, or file_path",
+                ));
+            }
+            if urls.is_empty() {
+                return Err(invalid("urls is empty"));
+            }
+            let total = urls.len();
+            let mut results = Vec::with_capacity(total);
+            for (i, url) in urls.into_iter().enumerate() {
+                let _heartbeat =
+                    Heartbeat::start(&ctx, format!("importing {}/{total}: {url}", i + 1));
+                // One permit per item, not per batch, so another client's
+                // small add slips in between two of a long batch's fetches.
+                let _permit = IMPORT_GATE
+                    .acquire()
+                    .await
+                    .expect("import gate never closes");
+                let outcome = import_url(&state, &notebook_id, &url, title.as_deref()).await;
+                results.push(BatchItem::new(url, outcome));
+            }
+            self.changed("sources", Some(&notebook_id));
+            return json_result(&results);
+        }
         let provided = [url.is_some(), text.is_some(), file_path.is_some()]
             .iter()
             .filter(|b| **b)
             .count();
         if provided != 1 {
-            return Err(invalid("provide exactly one of url, text, or file_path"));
+            return Err(invalid(
+                "provide exactly one of url, urls, text, or file_path",
+            ));
         }
         let what = url
             .clone()
@@ -254,17 +346,9 @@ impl AlchemyMcp {
             .await
             .expect("import gate never closes");
         let source = if let Some(url) = url {
-            if crate::mac::is_mac_uri(&url) {
-                // Mac items connect as living, auto-syncing sources — never
-                // through the web fetcher, which can't reach cider:// origins.
-                commands::ingest_mac(&state, &notebook_id, &url, title.as_deref().unwrap_or(""))
-                    .await
-                    .map_err(internal)?
-            } else {
-                commands::ingest_url(&state, &notebook_id, &url, None)
-                    .await
-                    .map_err(internal)?
-            }
+            import_url(&state, &notebook_id, &url, title.as_deref())
+                .await
+                .map_err(internal)?
         } else if let Some(text) = text {
             let title = title.unwrap_or_else(|| "Untitled source".into());
             let extracted = crate::ingest::extract_pasted(&title, &text).map_err(internal)?;

--- a/src/components/GrowPane.tsx
+++ b/src/components/GrowPane.tsx
@@ -377,6 +377,43 @@ export function GrowPane() {
           {title}
         </span>
         <span className="text-caption text-subtle-foreground">{hint}</span>
+        {/* Whole-section verdicts, same shape as the retirement pass: a
+            long list of citations is usually all-or-nothing. */}
+        {!busy && items.length > 1 && (
+          <div className="ml-auto flex shrink-0 items-center gap-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                // Files go as one drop; pages queue one at a time — the
+                // ingest queue keys items by millisecond, and a tight loop
+                // of adds would share one.
+                const files = items
+                  .filter((p) => p.kind === "local")
+                  .map((p) => p.url);
+                const pages = items.filter((p) => p.kind !== "local");
+                for (const p of items) dismiss(p.url);
+                if (files.length > 0) void addSourceFiles(files);
+                void (async () => {
+                  for (const p of pages) await addSourceUrl(p.url);
+                })();
+              }}
+              title={`Add all ${items.length} to this notebook`}
+            >
+              Add all
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                for (const p of items) dismiss(p.url);
+              }}
+              title="Hide every proposal below for 30 days"
+            >
+              Dismiss all
+            </Button>
+          </div>
+        )}
       </div>
       {busy ? (
         <div className="flex items-center gap-2 px-1 py-2 text-caption text-muted-foreground">

--- a/src/components/ReaderPane.tsx
+++ b/src/components/ReaderPane.tsx
@@ -1715,7 +1715,20 @@ function DocProperties({
   return (
     // data-doc-meta: excluded from find-in-source and citation anchoring —
     // matching "example.com" against the Site row would be noise.
-    <div data-doc-meta className="mb-6 border-b border-border pb-4">
+    <div data-doc-meta className="mb-6 flex items-start gap-6 border-b border-border pb-4">
+      {/* The cover the gallery shows — a picked image is a decision the
+          reader should honor too, not a gallery-only decoration. "-" means
+          checked and none. */}
+      {source?.imageUrl && source.imageUrl !== "-" && (
+        <img
+          src={source.imageUrl}
+          alt=""
+          className="order-last ml-auto h-20 w-28 shrink-0 rounded-md border border-border object-cover"
+          onError={(e) => {
+            e.currentTarget.hidden = true;
+          }}
+        />
+      )}
       <div className="grid w-fit max-w-full grid-cols-[auto_1fr] gap-x-6 gap-y-1 text-caption">
         {rows.map((r) => (
           <Fragment key={r.label}>

--- a/src/components/SourcesPanel.tsx
+++ b/src/components/SourcesPanel.tsx
@@ -360,9 +360,16 @@ export function SourcesPanel() {
   // Dismissals come from the store (per-notebook, persisted there) so the
   // Grow pane clearing its last proposal also drops this door live.
   const growthDismissed = useStore((s) => s.growthDismissed);
+  // The frontier is mined from source text, so it moves whenever a source
+  // finishes importing — re-read on the ready count, not just the notebook,
+  // or the door's number drifts from what the Grow pane shows after a batch
+  // of adds.
+  const readyCount = sources.filter((s) => s.status === "ready").length;
   useEffect(() => {
-    setGrowth([]);
-    if (!currentId) return;
+    if (!currentId) {
+      setGrowth([]);
+      return;
+    }
     let stale = false;
     api
       .growthProposals(currentId)
@@ -373,7 +380,7 @@ export function SourcesPanel() {
     return () => {
       stale = true;
     };
-  }, [currentId]);
+  }, [currentId, readyCount]);
   const existingUrls = useMemo(
     () => new Set(sources.map((s) => s.url).filter(Boolean)),
     [sources],

--- a/src/components/StudioPanel.tsx
+++ b/src/components/StudioPanel.tsx
@@ -81,11 +81,14 @@ const TINT_DISCLOSURE: Tint = {
   icon: "text-muted-foreground",
 };
 
-/** Wiki entity pages are numerous by design — one per registry entity —
- *  and would drown the handful of notes a person actually wrote. The
- *  "Notebook index" note stays in the main list as the wiki's front door;
- *  its entity pages live behind this fold. */
+/** Wiki pages are numerous by design — one per registry entity plus the
+ *  "Notebook index" that links them — and would drown the handful of
+ *  notes a person actually wrote, so the whole wiki lives behind this
+ *  fold, index first. */
+const WIKI_INDEX_TITLE = "Notebook index";
 const isEntityPage = (n: Note) => n.title.startsWith("Entity: ");
+const isWikiPage = (n: Note) =>
+  isEntityPage(n) || n.title === WIKI_INDEX_TITLE;
 
 function WikiNotes({
   notes,
@@ -111,7 +114,7 @@ function WikiNotes({
       </button>
       {open && (
         <div className="mt-1 flex flex-col gap-1.5">
-          {notes.map((n) => (
+          {[...notes.filter((n) => !isEntityPage(n)), ...notes.filter(isEntityPage)].map((n) => (
             <button
               type="button"
               key={n.id}
@@ -122,7 +125,10 @@ function WikiNotes({
                 {n.title.replace(/^Entity: /, "")}
               </span>
               <span className="text-micro text-subtle-foreground">
-                {relativeTime(n.updatedAt)} · linked from the notebook index
+                {relativeTime(n.updatedAt)}
+                {isEntityPage(n)
+                  ? " · linked from the notebook index"
+                  : " · the wiki's front door"}
               </span>
             </button>
           ))}
@@ -225,7 +231,7 @@ export function StudioPanel() {
     [picked],
   );
   const visibleNoteIds = notes
-    .filter((n) => n.status !== "archived" && !isEntityPage(n))
+    .filter((n) => n.status !== "archived" && !isWikiPage(n))
     .map((n) => n.id);
   const visibleNoteIdsRef = useRef(visibleNoteIds);
   visibleNoteIdsRef.current = visibleNoteIds;
@@ -635,7 +641,7 @@ export function StudioPanel() {
           ) : (
             <div className="flex flex-col gap-1.5">
               {notes
-                .filter((n) => n.status !== "archived" && !isEntityPage(n))
+                .filter((n) => n.status !== "archived" && !isWikiPage(n))
                 .map((n) => (
                 <div
                   key={n.id}
@@ -847,7 +853,7 @@ export function StudioPanel() {
           )}
           <WikiNotes
             notes={notes.filter(
-              (n) => n.status !== "archived" && isEntityPage(n),
+              (n) => n.status !== "archived" && isWikiPage(n),
             )}
             onOpen={openNoteCard}
           />


### PR DESCRIPTION
Fallout from filling a Benefits notebook through MCP (30 sources, ~20 programs).

## Import correctness
- **4xx/5xx error pages now land as `status: "error"`** with the HTTP code, instead of a ready source titled "Page Not Found" with the error layout embedded. A 500 that still serves the article (cerebras.ai) keeps importing. The rendered-capture rescue leaves these alone — rendering a 404 only makes it longer.
- **Plain hosts are no longer probed as git forges.** Every `https://host/a/b` was getting an 8s `ls-remote`; one misread answer sent `ferrariclubofamerica.org/page/MembershipMain` off to clone over ssh. Bare owner/repo shapes need a forge-looking hostname label now; `/blob/` and `/tree/` paths still probe.

## MCP
- `add_source` accepts `urls: [...]` — one `{url, ok, source, error}` per entry, one bad page never fails the rest, heartbeat shows `3/12`.
- New `grow` tool: standing queries, link-tier and Spotlight proposals, optional web tier when the notebook has it on.

## Grow pane
- Add all / Dismiss all per section.
- Sidebar "Grow this notebook · N" re-reads on the ready-source count so it stops drifting from the pane after a batch of imports.
- Link anchors drop their markdown emphasis (`**The Mart**`).

## Studio
- "Notebook index" joins the Wiki pages fold, listed first.

Gates: `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test` (6 new tests) and `pnpm build` green. Not yet run in the app — needs a human pass before merge.

Closes alchemy-release-vm4, alchemy-release-jve, alchemy-release-yuk, alchemy-release-j6v, alchemy-release-9t9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)