### PR TITLE
Chat font, size, and alignment move to Settings → Chat

### DIFF
--- a/src/components/settings/SettingsTabs.tsx
+++ b/src/components/settings/SettingsTabs.tsx
@@ -298,25 +298,6 @@ export function AppearanceTab() {
       </Field>
       <div className="h-px bg-border" />
       <Field
-        label="Reader"
-        hint="What the document reader shows around the text."
-      >
-        <div className="flex flex-wrap gap-1.5">
-          <Pill
-            active={reading.showToc}
-            onClick={() => setReading({ showToc: !reading.showToc })}
-          >
-            Table of contents
-          </Pill>
-          <Pill
-            active={reading.showRelated}
-            onClick={() => setReading({ showRelated: !reading.showRelated })}
-          >
-            Related passages
-          </Pill>
-        </div>
-      </Field>
-      <Field
         label="Glass chrome"
         hint="Experimental: the desktop blurs through the chrome like native macOS apps. Tinted keeps more body; Clear lets more through."
       >

--- a/src/components/settings/SettingsTabs.tsx
+++ b/src/components/settings/SettingsTabs.tsx
@@ -93,6 +93,8 @@ export function styleHint(styleId: string, assistantName: string | undefined): s
 
 export function ChatTab() {
   const assistantName = useStore((state) => state.aiConfig?.profile?.assistantName);
+  const reading = useStore((state) => state.reading);
+  const setReading = useStore((state) => state.setReading);
   const chatConfig = useStore((state) => state.chatConfig);
   const setChatConfig = useStore((state) => state.setChatConfig);
   const currentId = useStore((state) => state.currentId);
@@ -158,6 +160,39 @@ export function ChatTab() {
           ))}
         </div>
         {lengthHint && <span className="text-micro text-subtle-foreground">{lengthHint}</span>}
+      </Field>
+      <div className="h-px bg-border" />
+      {/* How answers look, as distinct from how they read. Every notebook
+          shares these — they're display, and the model never sees them. */}
+      <div className="mt-1 px-1 text-micro font-semibold uppercase tracking-wide text-subtle-foreground">
+        Appearance · every notebook
+      </div>
+      <Field label="Chat font" hint="Display only; this does not change the model.">
+        <div className="flex flex-wrap gap-1.5">
+          {CHAT_FONTS.map((font) => (
+            <Pill key={font.id} active={reading.font === font.id} onClick={() => setReading({ font: font.id })}>
+              <span className={font.className}>{font.label}</span>
+            </Pill>
+          ))}
+        </div>
+      </Field>
+      <Field label="Text size">
+        <div className="flex flex-wrap gap-1.5">
+          {CHAT_SIZES.map((size) => (
+            <Pill key={size.id} active={reading.fontSize === size.id} onClick={() => setReading({ fontSize: size.id })}>
+              {size.label}
+            </Pill>
+          ))}
+        </div>
+      </Field>
+      <Field label="Alignment">
+        <div className="flex flex-wrap gap-1.5">
+          {CHAT_ALIGNS.map((alignment) => (
+            <Pill key={alignment.id} active={reading.textAlign === alignment.id} onClick={() => setReading({ textAlign: alignment.id })}>
+              {alignment.label}
+            </Pill>
+          ))}
+        </div>
       </Field>
     </div>
   );
@@ -260,34 +295,6 @@ export function AppearanceTab() {
     <div className="flex flex-col gap-4">
       <Field label="Theme">
         <ThemePicker />
-      </Field>
-      <div className="h-px bg-border" />
-      <Field label="Chat font" hint="Display only; this does not change the model.">
-        <div className="flex flex-wrap gap-1.5">
-          {CHAT_FONTS.map((font) => (
-            <Pill key={font.id} active={reading.font === font.id} onClick={() => setReading({ font: font.id })}>
-              <span className={font.className}>{font.label}</span>
-            </Pill>
-          ))}
-        </div>
-      </Field>
-      <Field label="Text size">
-        <div className="flex flex-wrap gap-1.5">
-          {CHAT_SIZES.map((size) => (
-            <Pill key={size.id} active={reading.fontSize === size.id} onClick={() => setReading({ fontSize: size.id })}>
-              {size.label}
-            </Pill>
-          ))}
-        </div>
-      </Field>
-      <Field label="Alignment">
-        <div className="flex flex-wrap gap-1.5">
-          {CHAT_ALIGNS.map((alignment) => (
-            <Pill key={alignment.id} active={reading.textAlign === alignment.id} onClick={() => setReading({ textAlign: alignment.id })}>
-              {alignment.label}
-            </Pill>
-          ))}
-        </div>
       </Field>
       <div className="h-px bg-border" />
       <Field


### PR DESCRIPTION
Pre-release tidy of Settings.

- **Chat font, text size, and alignment** move from Appearance to the Chat tab, under style and length, in an "Appearance · every notebook" section. They tune how answers look; they belong next to how answers read.
- **Reader toggles leave Appearance.** Table of contents and related passages toggle in the reader itself, where you can see what they do.

What's left under Appearance is strictly how the app looks: theme and glass chrome. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)