### PR TITLE
Background work settles: card enrichment remembers, sweeps never borrow the chat provider

### DIFF
--- a/src-tauri/src/ai/mod.rs
+++ b/src-tauri/src/ai/mod.rs
@@ -573,6 +573,11 @@ pub struct AiRuntime {
 pub struct Ai {
     config: AiConfig,
     router: Router,
+    /// Background mode: the Small role never falls through to the chat
+    /// engine. A gateway or agent CLI is the user's *chat* spend; a sweep
+    /// that kept running while the local small model was down would spend
+    /// it silently, a dozen calls a minute (it did, 2026-09-01).
+    strict_small: bool,
     /// Ollama retained directly for the capabilities that haven't joined the
     /// router yet (OCR fallback, model listing).
     ollama: Ollama,
@@ -737,6 +742,7 @@ impl Ai {
             crate::inference::rerank::XencModel::Small,
         );
         Self {
+            strict_small: false,
             config,
             router,
             ollama,
@@ -1026,6 +1032,9 @@ impl Ai {
             if usable {
                 match engine.chat(messages).await {
                     Ok(out) => return Ok(out),
+                    Err(err) if self.strict_small => {
+                        return Err(err.context("small model unavailable; background work holds"));
+                    }
                     Err(err) => {
                         crate::note!("small-role engine failed, falling through: {err:#}");
                     }
@@ -1033,6 +1042,15 @@ impl Ai {
             }
         }
         self.router.chat_engine(Role::Chat).chat(messages).await
+    }
+
+    /// This handle for background work: sweeps, the nightly weave, card
+    /// enrichment. The Small role stays on the small engine or fails — it
+    /// never borrows the chat provider. Foreground callers keep the
+    /// fall-through, because a person is waiting on them.
+    pub fn background(mut self) -> Self {
+        self.strict_small = true;
+        self
     }
 
     pub async fn chat_stream<F>(&self, messages: &[ChatTurn], on_token: F) -> Result<ChatOutcome>

--- a/src-tauri/src/commands/registry.rs
+++ b/src-tauri/src/commands/registry.rs
@@ -493,7 +493,8 @@ fn build_enrich_messages(card: &RegistryCard, head: &str) -> Vec<crate::ai::Chat
 }
 
 /// Enrich owned cards with facts from their attached documents. Background
-/// only; returns how many facts landed.
+/// only; returns how many cards were read this pass (facts or not), so a
+/// caller can tell "still working through the Registry" from "converged".
 pub(crate) async fn enrich_card_facts(
     db: &crate::db::Db,
     ai: &crate::ai::Ai,
@@ -506,6 +507,7 @@ pub(crate) async fn enrich_card_facts(
     let mut state_dirty = false;
     let mut calls = 0usize;
     let mut added_total = 0usize;
+    let mut read = 0usize;
     for mut card in cards {
         if calls >= MAX_ENRICH_CALLS_PER_PASS {
             break;
@@ -532,6 +534,7 @@ pub(crate) async fn enrich_card_facts(
         // documents were read and held nothing; only new documents reopen it.
         state.insert(card.id.clone(), stamp);
         state_dirty = true;
+        read += 1;
         let mut candidates: Vec<CardFact> = Vec::new();
         for (source_id, _) in docs {
             if calls >= MAX_ENRICH_CALLS_PER_PASS {
@@ -574,7 +577,7 @@ pub(crate) async fn enrich_card_facts(
     if added_total > 0 {
         super::notify_changed("registry", None);
     }
-    Ok(added_total)
+    Ok(read)
 }
 
 // ---- The suggester -------------------------------------------------------
@@ -708,12 +711,17 @@ pub async fn suggest_cards(db: &crate::db::Db, ai: &crate::ai::Ai) -> anyhow::Re
     if let Err(err) = sweep_orphan_cards(db).await {
         crate::note!("registry orphan sweep failed: {err:#}");
     }
-    if let Err(err) = enrich_card_facts(db, ai).await {
-        crate::note!("registry fact enrichment failed: {err:#}");
+    // In quiet hours the sweep keeps looping while this reads cards, so the
+    // Registry converges overnight; by day one batch per hourly sweep.
+    let mut cards_read = 0usize;
+    match enrich_card_facts(db, ai).await {
+        Ok(n) if crate::freshness::is_quiet_hours(now()) => cards_read = n,
+        Ok(_) => {}
+        Err(err) => crate::note!("registry fact enrichment failed: {err:#}"),
     }
     let gists = db.list_gists().await?;
     if gists.is_empty() {
-        return Ok(0);
+        return Ok(cards_read);
     }
     let mut proposed = 0usize;
     // Once per notebook per run, AND only when the notebook's gists have
@@ -767,6 +775,9 @@ pub async fn suggest_cards(db: &crate::db::Db, ai: &crate::ai::Ai) -> anyhow::Re
     if let Err(err) = triage_suggested_cards(db, ai).await {
         crate::note!("registry triage failed: {err:#}");
     }
+    // What the sweep loop keys on: "did this pass do model work that could
+    // continue?" — proposals by day, proposals plus cards read by night.
+    proposed += cards_read;
     Ok(proposed)
 }
 

--- a/src-tauri/src/commands/registry.rs
+++ b/src-tauri/src/commands/registry.rs
@@ -367,9 +367,48 @@ const ENRICH_DOCS_PER_CARD: usize = 2;
 /// resumes where the budget stopped.
 const MAX_ENRICH_CALLS_PER_PASS: usize = 12;
 
-/// Cards enriched this app run — the pass converges (the SUGGESTED idiom).
-static ENRICHED: std::sync::Mutex<Option<std::collections::HashSet<String>>> =
-    std::sync::Mutex::new(None);
+/// Where a card's enrichment marker lives: `<app-data>/registry-enrichment.json`,
+/// card id → stamp of the confirmed attachments it was enriched from. On
+/// disk, not per app run: 168 owned cards re-asked one call per document
+/// on every launch was ten to thirty minutes of small-model churn each
+/// time either app started (2026-09-01). A card is asked again only when
+/// its confirmed attachments change.
+const ENRICH_STATE_FILE: &str = "registry-enrichment.json";
+
+fn load_enrich_state(dir: &std::path::Path) -> std::collections::HashMap<String, i32> {
+    std::fs::read_to_string(dir.join(ENRICH_STATE_FILE))
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+fn save_enrich_state(dir: &std::path::Path, state: &std::collections::HashMap<String, i32>) {
+    let write = || -> std::io::Result<()> {
+        std::fs::create_dir_all(dir)?;
+        std::fs::write(
+            dir.join(ENRICH_STATE_FILE),
+            serde_json::to_vec(state).unwrap_or_default(),
+        )
+    };
+    if let Err(err) = write() {
+        crate::note!("registry: enrichment marker write failed: {err}");
+    }
+}
+
+/// The stamp a card's enrichment carries: its confirmed attachments, order
+/// independent. Pending or removed attachments don't count — they're not
+/// read — so ruling on a suggestion re-opens the card exactly when it adds
+/// a document.
+fn enrich_stamp(card: &RegistryCard) -> i32 {
+    let mut ids: Vec<&str> = card
+        .attachments
+        .iter()
+        .filter(|a| a.status == "confirmed")
+        .map(|a| a.source_id.as_str())
+        .collect();
+    ids.sort_unstable();
+    crate::gist::content_hash(&ids.join("\n"))
+}
 
 /// Add candidate facts to a card: missing labels only, existing values
 /// never overwritten, duplicate values (under any label) skipped, capped.
@@ -422,6 +461,9 @@ pub(crate) async fn enrich_card_facts(
     use crate::inference::Role;
     const ENRICH_HEAD_CHARS: usize = 10_000;
     let cards = db.list_registry().await?;
+    let dir = ai.data_dir().to_path_buf();
+    let mut state = load_enrich_state(&dir);
+    let mut state_dirty = false;
     let mut calls = 0usize;
     let mut added_total = 0usize;
     for mut card in cards {
@@ -429,6 +471,10 @@ pub(crate) async fn enrich_card_facts(
             break;
         }
         if !card.origin.is_empty() || card.facts.len() >= MAX_CARD_FACTS {
+            continue;
+        }
+        let stamp = enrich_stamp(&card);
+        if state.get(&card.id) == Some(&stamp) {
             continue;
         }
         let docs: Vec<(String, i64)> = card
@@ -441,15 +487,11 @@ pub(crate) async fn enrich_card_facts(
         if docs.is_empty() {
             continue;
         }
-        // Marked only once actually processed — a budget-skipped card gets
-        // its turn on the next pass this run.
-        {
-            let mut guard = ENRICHED.lock().unwrap();
-            let seen = guard.get_or_insert_with(Default::default);
-            if !seen.insert(card.id.clone()) {
-                continue;
-            }
-        }
+        // Stamped only once actually processed — a budget-skipped card gets
+        // its turn on the next pass. A NONE from the model stamps too: the
+        // documents were read and held nothing; only new documents reopen it.
+        state.insert(card.id.clone(), stamp);
+        state_dirty = true;
         let mut candidates: Vec<CardFact> = Vec::new();
         for (source_id, _) in docs {
             if calls >= MAX_ENRICH_CALLS_PER_PASS {
@@ -485,6 +527,9 @@ pub(crate) async fn enrich_card_facts(
             db.update_registry_card(&card).await?;
             added_total += added;
         }
+    }
+    if state_dirty {
+        save_enrich_state(&dir, &state);
     }
     if added_total > 0 {
         super::notify_changed("registry", None);
@@ -1115,6 +1160,7 @@ pub(crate) async fn suggest_now(
     // strip re-sorts itself on the registry bump.
     let db = db.clone();
     tauri::async_runtime::spawn(async move {
+        let ai = ai.background();
         if let Err(err) = triage_suggested_cards(&db, &ai).await {
             crate::note!("registry triage failed: {err:#}");
         }
@@ -1731,6 +1777,33 @@ pub async fn rematch_registry(
 
 #[cfg(test)]
 mod tests {
+    /// The enrichment stamp follows the confirmed attachments only, in any
+    /// order: confirming a suggestion reopens a card, reordering or a
+    /// pending one does not, so a restart re-asks nothing already read.
+    #[test]
+    fn enrich_stamp_tracks_confirmed_attachments() {
+        let att = |id: &str, status: &str| CardAttachment {
+            source_id: id.into(),
+            notebook_id: "nb".into(),
+            status: status.into(),
+            matched: String::new(),
+            at: 0,
+        };
+        let mut card = card("Sea Otter", "");
+        card.attachments = vec![att("a", "confirmed"), att("b", "confirmed")];
+        let base = enrich_stamp(&card);
+        card.attachments.reverse();
+        assert_eq!(enrich_stamp(&card), base, "order independent");
+        card.attachments.push(att("c", "suggested"));
+        assert_eq!(enrich_stamp(&card), base, "pending attachments don't count");
+        card.attachments.push(att("c", "confirmed"));
+        assert_ne!(
+            enrich_stamp(&card),
+            base,
+            "a new confirmed document reopens the card"
+        );
+    }
+
     use super::*;
 
     fn card(name: &str, identifiers: &str) -> RegistryCard {

--- a/src-tauri/src/commands/registry.rs
+++ b/src-tauri/src/commands/registry.rs
@@ -395,6 +395,46 @@ fn save_enrich_state(dir: &std::path::Path, state: &std::collections::HashMap<St
     }
 }
 
+/// Card suggestions, same idea: `<app-data>/registry-suggested.json`,
+/// notebook id → stamp of the gists it was last asked about.
+const SUGGEST_STATE_FILE: &str = "registry-suggested.json";
+
+fn load_suggest_state(dir: &std::path::Path) -> std::collections::HashMap<String, i32> {
+    std::fs::read_to_string(dir.join(SUGGEST_STATE_FILE))
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+fn save_suggest_state(dir: &std::path::Path, state: &std::collections::HashMap<String, i32>) {
+    let write = || -> std::io::Result<()> {
+        std::fs::create_dir_all(dir)?;
+        std::fs::write(
+            dir.join(SUGGEST_STATE_FILE),
+            serde_json::to_vec(state).unwrap_or_default(),
+        )
+    };
+    if let Err(err) = write() {
+        crate::note!("registry: suggestion marker write failed: {err}");
+    }
+}
+
+/// What a notebook's suggestion pass saw: its sources' gists, by source
+/// and content hash, order independent. A new or re-distilled source
+/// changes it; so does removing one.
+fn suggest_stamp(
+    source_ids: &std::collections::HashSet<String>,
+    gists: &[crate::db::GistRow],
+) -> i32 {
+    let mut rows: Vec<String> = gists
+        .iter()
+        .filter(|g| source_ids.contains(&g.source_id))
+        .map(|g| format!("{}:{}", g.source_id, g.hash))
+        .collect();
+    rows.sort_unstable();
+    crate::gist::content_hash(&rows.join("\n"))
+}
+
 /// The stamp a card's enrichment carries: its confirmed attachments, order
 /// independent. Pending or removed attachments don't count — they're not
 /// read — so ruling on a suggestion re-opens the card exactly when it adds
@@ -676,6 +716,14 @@ pub async fn suggest_cards(db: &crate::db::Db, ai: &crate::ai::Ai) -> anyhow::Re
         return Ok(0);
     }
     let mut proposed = 0usize;
+    // Once per notebook per run, AND only when the notebook's gists have
+    // changed since it was last asked: the cast a notebook implies follows
+    // from its gists, so the same gists would draw the same proposals (and
+    // the same refusals). On disk, so a launch on an unchanged library
+    // asks nothing.
+    let dir = ai.data_dir().to_path_buf();
+    let mut asked = load_suggest_state(&dir);
+    let mut asked_dirty = false;
 
     for nb in db.list_notebooks().await? {
         {
@@ -685,6 +733,19 @@ pub async fn suggest_cards(db: &crate::db::Db, ai: &crate::ai::Ai) -> anyhow::Re
                 continue;
             }
         }
+        let source_ids: std::collections::HashSet<String> = db
+            .list_sources(&nb.id)
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .map(|s| s.id)
+            .collect();
+        let stamp = suggest_stamp(&source_ids, &gists);
+        if asked.get(&nb.id) == Some(&stamp) {
+            continue;
+        }
+        asked.insert(nb.id.clone(), stamp);
+        asked_dirty = true;
         // Fetched per notebook, not once for the sweep: a card proposed for
         // the previous notebook must block the same name here, or every
         // notebook that shares a dependency mints its own copy of it.
@@ -693,6 +754,9 @@ pub async fn suggest_cards(db: &crate::db::Db, ai: &crate::ai::Ai) -> anyhow::Re
             .await
             .unwrap_or_default()
             .len();
+    }
+    if asked_dirty {
+        save_suggest_state(&dir, &asked);
     }
     if proposed > 0 {
         super::notify_changed("registry", None);

--- a/src-tauri/src/commands/weave.rs
+++ b/src-tauri/src/commands/weave.rs
@@ -80,6 +80,7 @@ const MAX_NIGHTLY_SOURCES: usize = 8;
 /// Budget-checked per source rather than once up front, because the cost is
 /// per judgment and a night can run out halfway through the list.
 pub(crate) fn spawn_nightly(db: Arc<Db>, ai: Ai, since: i64, budget: String) {
+    let ai = ai.background();
     // One nightly pass at a time, and never blocked by arrival judgments:
     // the pass is serial internally, so it is not the pile-up the arrival
     // cap guards against.

--- a/src-tauri/src/freshness.rs
+++ b/src-tauri/src/freshness.rs
@@ -52,6 +52,18 @@ fn night_of(now: i64) -> i64 {
         .unwrap_or(now)
 }
 
+/// Quiet hours: 10 PM to 6 AM local. The heavy background stage (chunk
+/// enrichment over the whole corpus) runs only here. A laptop that is
+/// warm all afternoon because a sweep is polishing embeddings is a laptop
+/// whose owner turns the feature off; the polish can wait for the night.
+pub fn is_quiet_hours(now: i64) -> bool {
+    let dt = chrono::DateTime::from_timestamp_millis(now)
+        .map(|d| d.with_timezone(&chrono::Local))
+        .unwrap_or_else(chrono::Local::now);
+    let hour = chrono::Timelike::hour(&dt);
+    !(6..22).contains(&hour)
+}
+
 fn roll_if_new_night(now: i64) {
     let night = night_of(now);
     if NIGHT_STAMP.swap(night, Ordering::Relaxed) != night {
@@ -243,6 +255,28 @@ fn join_prose(parts: &[String]) -> String {
 
 #[cfg(test)]
 mod tests {
+    /// Quiet hours are a local-clock window: evenings and small hours in,
+    /// the working day out.
+    #[test]
+    fn quiet_hours_is_the_night_window() {
+        let at = |h: u32| {
+            chrono::Local::now()
+                .date_naive()
+                .and_hms_opt(h, 30, 0)
+                .expect("valid time")
+                .and_local_timezone(chrono::Local)
+                .earliest()
+                .expect("local time")
+                .timestamp_millis()
+        };
+        for h in [22, 23, 0, 3, 5] {
+            assert!(super::is_quiet_hours(at(h)), "{h}:30 is quiet");
+        }
+        for h in [6, 9, 12, 17, 21] {
+            assert!(!super::is_quiet_hours(at(h)), "{h}:30 is not quiet");
+        }
+    }
+
     use super::*;
 
     #[test]

--- a/src-tauri/src/gist.rs
+++ b/src-tauri/src/gist.rs
@@ -611,6 +611,7 @@ pub fn spawn_sweep(db: std::sync::Arc<Db>, ai: Ai) {
     if !ai.config().source_gists {
         return;
     }
+    let ai = ai.background();
     if SWEEPING
         .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
         .is_err()

--- a/src-tauri/src/gist.rs
+++ b/src-tauri/src/gist.rs
@@ -656,6 +656,12 @@ pub fn spawn_sweep(db: std::sync::Arc<Db>, ai: Ai) {
                         Ok(n) if n > 0 => {
                             tokio::time::sleep(std::time::Duration::from_millis(250)).await;
                         }
+                        // Chunk enrichment is the one stage that never
+                        // converges quickly — one small-model call per
+                        // chunk across the corpus — so it runs in quiet
+                        // hours only. The day's sweeps stop here, converged
+                        // on everything a person can see.
+                        Ok(_) if !crate::freshness::is_quiet_hours(crate::commands::now()) => break,
                         Ok(_) => match ensure_enrichment(&db, &ai).await {
                             Ok(0) => break,
                             Ok(_) => {

--- a/src-tauri/src/scheduler.rs
+++ b/src-tauri/src/scheduler.rs
@@ -41,6 +41,17 @@ const SNAPSHOT_EVERY_MS: i64 = 60 * 60 * 1000;
 static LAST_WEAVE: AtomicI64 = AtomicI64::new(0);
 const WEAVE_EVERY_MS: i64 = 60 * 60 * 1000;
 
+/// Epoch ms of the last tick-driven catch-up sweep (gists, tags, cards,
+/// hygiene). Imports and edits kick the same sweep the moment they land —
+/// that is the event path, and it is where almost all the work happens.
+/// The tick's copy exists for what those miss (a restart mid-sweep, a
+/// change made by another process), and once an hour is plenty for that.
+/// Every minute was a fan-spinning idle: a sweep that has converged still
+/// scans the corpus and asks the small model about anything new it finds,
+/// and the model it wakes stays resident for half an hour after.
+static LAST_SWEEP: AtomicI64 = AtomicI64::new(0);
+const SWEEP_EVERY_MS: i64 = 60 * 60 * 1000;
+
 /// Quit for real: mark the exit as intentional, then exit.
 pub fn request_quit(app: &AppHandle) {
     QUIT_REQUESTED.store(true, Ordering::Relaxed);
@@ -478,13 +489,19 @@ async fn run_pass(app: &AppHandle) {
     if crate::freshness::has_budget(&budget) {
         // Distillation, tags, and card suggestions converge even when no
         // fresh import kicks them — a restart mid-sweep used to strand
-        // untagged sources until the next import happened to arrive.
-        // Self-gating (SWEEPING), so a converged corpus is a cheap no-op.
-        crate::gist::spawn_sweep(state.db.clone(), state.ai.read().await.clone());
+        // untagged sources until the next import happened to arrive. Hourly
+        // from here (imports kick it immediately; see LAST_SWEEP), and the
+        // first tick after launch counts, so a restart still catches up.
+        if now_ms() - LAST_SWEEP.load(Ordering::Relaxed) >= SWEEP_EVERY_MS {
+            LAST_SWEEP.store(now_ms(), Ordering::Relaxed);
+            crate::gist::spawn_sweep(state.db.clone(), state.ai.read().await.clone());
 
-        // Source hygiene (docs/RFC-source-hygiene.md): re-fetch aging urls,
-        // count strikes on unreachable ones. Its own config gate lives inside.
-        crate::hygiene::spawn_sweep(app);
+            // Source hygiene (docs/RFC-source-hygiene.md): re-fetch aging
+            // urls, count strikes on unreachable ones. Its own config gate
+            // lives inside; the cadence it works to is days, so hourly is
+            // already generous.
+            crate::hygiene::spawn_sweep(app);
+        }
         // 2. Verification. The Weave already judges a source the moment it
         //    arrives; this catches the case that matters more — a watched
         //    page changed at 3 AM, and the conclusion it undermines was


### PR DESCRIPTION
Release blocker from the resource question: llama-server never idled with the apps open, and a per-minute tick that does inference can never settle.

- **Tick-driven inference is hourly at most.** The scheduler's minute tick respawned the catch-up sweep the moment the last one finished. Imports and edits already kick the sweep the instant they land (the event path); the tick's copy now runs at most once an hour, first tick after launch included.
- **Chunk enrichment waits for quiet hours** (10 PM to 6 AM local). It's one small-model call per chunk across the corpus, the one stage that never converges quickly.
- **Card-fact enrichment remembers across launches.** A per-run set meant every launch re-asked one call per attached document for all 168 owned cards at 12/min. The marker is on disk now (`registry-enrichment.json`); a card is re-asked only when a new document is confirmed onto it. During the day it advances 12 calls per hourly sweep; at night it runs to completion.
- **Card suggestions are stamped per notebook** on the gists they were asked about (`registry-suggested.json`), so a launch on an unchanged library asks nothing.
- **Background sweeps never fall through to the chat provider.** While Ollama was down today, 79 background Small-role calls went to Codex. `Ai::background()` makes the Small role fail instead; sweeps, the nightly weave, and card triage use it. Foreground callers keep the fall-through.

437 tests green; new unit tests for the enrichment stamp and the quiet-hours window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)