### PR TITLE
Outline index, phases 1 and 1.5: the heading chain in embeddings and in BM25

### DIFF
--- a/docs/RFC-outline-index.md
+++ b/docs/RFC-outline-index.md
@@ -1,6 +1,6 @@
 # RFC: Outline Index — long documents by their own structure
 
-Status: implementing (Phase 1). Companion to `RFC-retrieval-maturity.md`
+Status: implemented through Phase 3, on branch for review. Companion to `RFC-retrieval-maturity.md`
 (how we search) and `RFC-infinite-context.md` (gists, enrichment). Gated
 end to end on `evals/datasets/fixture-outline.json`: each phase merges
 only if the outline numbers move.
@@ -95,20 +95,43 @@ seeding; production takes the incremental path after every import
 
 ### Phase 3 — outline-guided retrieval as silent escalation
 
-Hybrid search stays the fast default. Escalate when the answer would be
-thin (the existing `citations.len() < 3 || snippet_chars < 700` gate
-in `rag::build_chat_messages`) or the top hits are all from one long
-structured source with near-tied scores: hand the Small role the
-notebook's outlines (chains + section summaries, capped), ask it to
-pick sections, pull those sections' chunks by `(source_id, ordinal
-range)`, and merge them into the excerpt pool ahead of the rerank.
-Same escalation shape as `second_look` and the deep rerank: invisible
-to the user, one extra small-model call, traced in
-`traces/retrieval.jsonl` with `stage: "outline"`.
+Hybrid search stays the fast default. `outline_index::escalate` runs in
+the chat retrieval path beside the gap query, after fusion and before
+the rerank, and fires when the pool is thin (the same `< 3 citations ||
+< 700 chars` bar `rag::build_chat_messages` uses to ask a clarifying
+question) or the top five hits are the same subsection of different
+chapters — chains from one source ending alike, the look-alike shape.
+It hands the Small role the notebook's outline (`db::notebook_outline`:
+one line per section row, chain plus the first line of its summary,
+capped at 80), asks for at most two section numbers or NONE, pulls each
+pick's two best passages with the same in-span scored search Phase 2
+expands with (`db::section_passages`), and fuses them into the pool.
+One extra small-model call, silent, traced as `outlinePick` on the
+chat retrieval line; a failure leaves the pool untouched.
+
+Three shapes measured wrong before the numbers below (the on/off eval
+is `eval_outline_escalation`, Ollama-gated, handwritten summaries so
+the escalation is measured and not the generator):
+
+- *Prepending the picks* ahead of the flat pool. Under bonsai's wrong
+  picks the exact kind fell 1.00 → 0.20: a guess displaced a rank-one
+  hit both legs agreed on. Fusion (RRF of the flat pool with the
+  outline's passages) keeps a passage both sides vouch for on top and
+  lands an outline-only passage behind the flat leader: topic 0.88 vs
+  0.82, exact 0.33 vs 0.20 for bonsai; gemma the same either way.
+- *Escalating over a literal match.* "what is part FM-2041?" quotes an
+  identifier the flat leader carries verbatim; no summary can beat that,
+  and bonsai's guess (already deep in the flat pool as a look-alike)
+  still won the fusion. The trigger now stays quiet when a digit-bearing
+  token from the question appears in the leader's snippet — exact back
+  to 1.00.
+- *Trusting a shotgun.* Bonsai answers "1,2,3,…,14" when the summaries
+  cannot say; more than four numbers reads as NONE.
 
 Citations gain `section` (the chain) so a long-document citation reads
 "Fleet Maintenance Manual › Chapter 2: Landing Gear › Torque Values"
-instead of a page of look-alike prose.
+instead of a page of look-alike prose. The page range the Reminders
+item asked for is not here: chunk rows carry ordinals, not pages.
 
 ## How Phases 2 and 3 get measured
 
@@ -156,7 +179,8 @@ Phase 2.
 | 1 — heading chain | 0.91 | 1.00 | 0.62 | 0.71 |
 | 1.5 — chain in the BM25 document | 1.00 | 1.00 | 0.92 | 0.94 |
 | 2 — section summaries (mechanics, handwritten fixtures) | 0.95 | 1.00 | 0.89 | 0.92 |
-| 3 — escalation | | | | |
+| 3 — escalation, bonsai-8b | 1.00 | 1.00 | 0.91 | 0.93 |
+| 3 — escalation, gemma4 12B | 1.00 | 1.00 | 0.93 | 0.95 |
 
 The `topic` kind (chapter paraphrases: undercarriage, de-icing,
 Portugal) is Phase 2's own measurement:
@@ -167,6 +191,8 @@ Portugal) is Phase 2's own measurement:
 | 2 — section rows + scored expansion, handwritten summaries | 0.85 | 1.00 | 0.79 | 0.83 |
 | 2 — the generator, bonsai-8b (Small role) | 0.77 | 0.92 | 0.54–0.61 | 0.63 |
 | 2 — the generator, gemma4 12B, thinking off | 0.85 | 0.92 | 0.60 | 0.68 |
+| 3 — escalation on, bonsai-8b (handwritten summaries) | 1.00 | 1.00 | 0.88 | 0.91 |
+| 3 — escalation on, gemma4 12B (handwritten summaries) | 1.00 | 1.00 | 0.88 | 0.91 |
 
 The generator's eval (`eval_section_gists_model`, Ollama-gated) scores the
 topic kind three ways on one store: no rows, the handwritten fixtures,
@@ -184,7 +210,10 @@ Ollama `think: false` (ignored by models without a thinking mode); the
 same prompt answers in under a second.
 
 Controls (`chapter`, `exact`) must stay at 1.00; the golden datasets'
-floors are unchanged.
+floors are unchanged. Phase 3's rows are on/off on one seeded store
+(`eval_outline_escalation`); the escalation fires on every topic and
+outline query of this corpus (they all land on look-alike chains) and
+on neither control kind.
 
 Phase 1 note: the vector leg alone reaches R@10 1.00 / MRR 0.95 on the
 outline kind once it carries the chain; hybrid lands lower (MRR 0.62)

--- a/docs/RFC-outline-index.md
+++ b/docs/RFC-outline-index.md
@@ -1,0 +1,115 @@
+# RFC: Outline Index — long documents by their own structure
+
+Status: implementing (Phase 1). Companion to `RFC-retrieval-maturity.md`
+(how we search) and `RFC-infinite-context.md` (gists, enrichment). Gated
+end to end on `evals/datasets/fixture-outline.json`: each phase merges
+only if the outline numbers move.
+
+## Problem
+
+A 300-page structured document — a maintenance manual, a policy binder,
+a standard — is the case hybrid search handles worst. Every chapter
+repeats the same subsections in the same words; only the numbers and
+the chapter name differ. The chapter name lives in a heading the chunker
+had already replaced by the time the subsection's chunk was cut, so
+forty chunks embed and index as near-duplicates and the one the question
+wants is a coin flip.
+
+Measured (v0.53.0 baseline, hybrid, outline kind, @10): R@5 0.55, R@10
+0.68, MRR 0.23, nDCG 0.34 — against 1.00 on every control kind in the
+same corpus. Vector alone does better (R@10 0.82) than hybrid, which
+says the BM25 leg is actively confused: the subsection words match
+everywhere.
+
+PageIndex's insight applies: a long document has a tree, and reasoning
+over the tree beats searching a flat bag of look-alike chunks. We keep
+the embedding floor — local models need it, and it is what makes short
+documents instant — and add the tree on top.
+
+## Design
+
+Three phases, each a Reminders item, each behind the gate.
+
+### Phase 1 — the heading chain (persist the outline at ingest)
+
+`chunk_text` tracks the open heading chain by level instead of the last
+heading seen. A chunk under `## Torque Values` inside `# Chapter 2:
+Landing Gear` embeds as `[Manual › Chapter 2: Landing Gear › Torque
+Values]`, and `Chunk.section` carries the chain. Layout-derived, no
+model, free at import.
+
+The outline itself is *derivable*: heading chunks keep their heading
+line verbatim (`## …`), so a source's outline is a scan of its chunk
+rows in ordinal order — level from the `#` count, span from the
+ordinals between headings. Phase 1 stores nothing new; `outline_of`
+builds the tree on demand from `source_chunk_rows`. A persisted table
+arrives only if Phase 3's escalation needs it across a whole notebook
+faster than a scan gives it.
+
+What this buys on the gate: the vector leg now carries the chapter
+name. What it cannot buy: the BM25 leg still indexes chunk `text`,
+which does not contain the chain. That is deliberate — display text is
+what a citation quotes and what click-to-highlight matches; polluting
+it with a heading path would show up in the reader.
+
+### Phase 2 — per-section summaries (hierarchical gists)
+
+`gist.rs` distills one gist per source. For a long structured source
+(outline depth ≥ 2 and ≥ N sections), distill one short summary per
+top-level section with the Small role, stored as chunk rows with owner
+`section:<source_id>` and `ordinal` = section index, text
+`"<chain>: <summary>"`. Embedded like gists, so a section summary is
+itself searchable; retrieval treats them like gist rows (capped,
+flagged) and a hit on one expands to the section's chunks the way
+neighbor expansion widens a hit today.
+
+Budget: sections, not chunks — a 300-page manual with 14 chapters is
+14 calls, once, refreshed on content hash like gists. Runs in the same
+sweep slot as gists (event on import; hourly catch-up; never per
+minute — `RFC-night-shift-area.md`, background-settle rules).
+
+### Phase 3 — outline-guided retrieval as silent escalation
+
+Hybrid search stays the fast default. Escalate when the answer would be
+thin (the existing `citations.len() < 3 || snippet_chars < 700` gate
+in `rag::build_chat_messages`) or the top hits are all from one long
+structured source with near-tied scores: hand the Small role the
+notebook's outlines (chains + section summaries, capped), ask it to
+pick sections, pull those sections' chunks by `(source_id, ordinal
+range)`, and merge them into the excerpt pool ahead of the rerank.
+Same escalation shape as `second_look` and the deep rerank: invisible
+to the user, one extra small-model call, traced in
+`traces/retrieval.jsonl` with `stage: "outline"`.
+
+Citations gain `section` (the chain) so a long-document citation reads
+"Fleet Maintenance Manual › Chapter 2: Landing Gear › Torque Values"
+instead of a page of look-alike prose.
+
+## Non-goals
+
+- Not vectorless. The tree is a second signal, not a replacement.
+- No UI in Phases 1–3. The citation chain is the only visible change.
+- No re-chunking of existing stores on upgrade. Existing chunks keep
+  their old embed context until the source is refreshed; the eval seeds
+  fresh, so the gate measures the new path.
+
+## Gate
+
+`ALCHEMY_EVALS=1 cargo test --lib eval_retrieval_datasets -- --nocapture`
+
+| phase | hybrid outline R@5 | R@10 | MRR | nDCG |
+| --- | --- | --- | --- | --- |
+| baseline (v0.53.0) | 0.55 | 0.68 | 0.23 | 0.34 |
+| 1 — heading chain | 0.91 | 1.00 | 0.62 | 0.71 |
+| 2 — section summaries | | | | |
+| 3 — escalation | | | | |
+
+Controls (`chapter`, `exact`) must stay at 1.00; the golden datasets'
+floors are unchanged.
+
+Phase 1 note: the vector leg alone reaches R@10 1.00 / MRR 0.95 on the
+outline kind once it carries the chain; hybrid lands lower (MRR 0.62)
+because the BM25 leg, which indexes chunk `text` without the chain, is
+still confused by look-alike subsections and fusion averages that in.
+Giving BM25 the chain (a `context` column, or the chain in the FTS
+document) is the obvious Phase 1.5 and is measurable the same way.

--- a/docs/RFC-outline-index.md
+++ b/docs/RFC-outline-index.md
@@ -129,6 +129,7 @@ Phase 2.
 | --- | --- | --- | --- | --- |
 | baseline (v0.53.0) | 0.55 | 0.68 | 0.23 | 0.34 |
 | 1 — heading chain | 0.91 | 1.00 | 0.62 | 0.71 |
+| 1.5 — chain in the BM25 document | 1.00 | 1.00 | 0.92 | 0.94 |
 | 2 — section summaries | | | | |
 | 3 — escalation | | | | |
 
@@ -139,5 +140,21 @@ Phase 1 note: the vector leg alone reaches R@10 1.00 / MRR 0.95 on the
 outline kind once it carries the chain; hybrid lands lower (MRR 0.62)
 because the BM25 leg, which indexes chunk `text` without the chain, is
 still confused by look-alike subsections and fusion averages that in.
-Giving BM25 the chain (a `context` column, or the chain in the FTS
-document) is the obvious Phase 1.5 and is measurable the same way.
+Phase 1.5 did that, and the *shape* mattered more than the weight. Two
+nullable columns join `chunks` — `context` ("title › chain", read back
+onto `Citation.section`) and `bm25` (`"{context}\n{text}"`, the one
+document the FTS index covers); older tables gain both through
+`add_columns`, with `bm25` seeded from `text` so no existing row drops
+out of BM25, and older builds' appends conform with "". Two shapes were
+measured:
+
+- *Separate context leg* (a second FTS index, a third RRF list): outline
+  MRR 0.72 / 0.79 / 0.87 / 0.86 at weights 0.25 / 0.5 / 1.0 / 2.0 — but
+  hard-exact MRR fell 1.00 → 0.78, because a context-only match ("Port
+  Forwarding" for "which port does the badge console use") gets a full
+  rank-one vote of its own.
+- *One BM25 document per chunk* (chain prepended to the text, single
+  index, two legs as before): outline MRR 0.92, R@5 and R@10 1.00, and
+  the golden datasets return exactly to their Phase 1 numbers. Text and
+  chain terms combine in one score, which is the field weighting BM25
+  was built for. This shipped.

--- a/docs/RFC-outline-index.md
+++ b/docs/RFC-outline-index.md
@@ -85,6 +85,34 @@ Citations gain `section` (the chain) so a long-document citation reads
 "Fleet Maintenance Manual › Chapter 2: Landing Gear › Torque Values"
 instead of a page of look-alike prose.
 
+## How Phases 2 and 3 get measured
+
+Phase 1 leaves the gate's recall saturated (R@10 1.00) and its ranking
+limited by the BM25 leg. Two consequences:
+
+1. **Section summaries cannot move `fixture-outline` by themselves.**
+   Its `must_contain` strings are numbers inside chunks; a summary row
+   never contains them, and `db.search_chunks` does no expansion. Phase 2
+   needs its own cases: *section-topic* queries whose answer is "which
+   section covers X" — `kind: "topic"`, relevant = the section summary
+   row (or the section's heading chunk). The dataset grows those cases
+   before Phase 2 lands, the same way the outline kind preceded Phase 1.
+2. **Escalation is a model-in-the-loop change** and measures like
+   `eval_deep_rerank`: an `ALCHEMY_OLLAMA_TESTS=1` half that runs the
+   real Small role over the outline, plus a deterministic half that
+   checks the trigger fires on the thin/near-tied cases and stays quiet
+   on the golden ones. The number to report is MRR on the outline kind
+   with escalation on versus off, on the same seeded store.
+
+The cheaper lever for ranking is **Phase 1.5**: give the BM25 leg the
+chain. The FTS index is on `text`; the chain would need a `context`
+column on `chunks` (a schema addition on a store shared by prod and dev
+builds — `add_batch` conforms batches to the table it finds, but the
+index and the query must tolerate its absence on old tables) or a
+second FTS leg over a chain-only column fused at RRF. Measurable on the
+existing gate with no new cases; it is the first thing to try before
+Phase 2.
+
 ## Non-goals
 
 - Not vectorless. The tree is a second signal, not a replacement.

--- a/docs/RFC-outline-index.md
+++ b/docs/RFC-outline-index.md
@@ -54,19 +54,44 @@ it with a heading path would show up in the reader.
 
 ### Phase 2 — per-section summaries (hierarchical gists)
 
-`gist.rs` distills one gist per source. For a long structured source
-(outline depth ≥ 2 and ≥ N sections), distill one short summary per
-top-level section with the Small role, stored as chunk rows with owner
-`section:<source_id>` and `ordinal` = section index, text
-`"<chain>: <summary>"`. Embedded like gists, so a section summary is
-itself searchable; retrieval treats them like gist rows (capped,
-flagged) and a hit on one expands to the section's chunks the way
-neighbor expansion widens a hit today.
+`gist.rs` distills one gist per source. For a long structured source,
+distill one short summary per top-level section with the Small role —
+what the section covers in plain words *plus the other names a reader
+might use for it* — stored as chunk rows with owner `section:<source_id>`,
+chunk id `section:<source_id>:<start>-<end>` (the passage span), the
+chain as context, the summary as text. Embedded and BM25-indexed like a
+gist, so a section summary is itself a hit.
+
+**Expansion is scored, not positional.** A section hit is swapped, in
+place, for the top two passages of a mini hybrid search (both legs,
+filtered to the span, RRF) — "the answer is in this section" becomes
+"this passage". Two things measured wrong first: dumping the section in
+document order (topic MRR 0.50 → 0.44), and leaving a vouched-for
+passage "at its own rank" when the flat search had it deep in the pool
+(the promotion is the point). Every section hit expands; gating on the
+row's rank measured no better. The rows themselves never leave
+`search_chunks_trace`: the per-notebook chat path stays verbatim-only.
+
+Mechanics landed with handwritten fixture summaries so the measurement
+is deterministic; the model-written variant is the generator's own
+Ollama-gated eval. The generator (`gist::ensure_section_gists`) runs in
+the gist sweep right after gists converge: sources with 3–40 top-level
+sections, six sources per pass, stamped on disk by heading-and-span hash
+(`section-gists.json`) so an unchanged source costs nothing and a
+re-chunk reopens it. Section rows go with the chunks on refresh and with
+the source on delete.
 
 Budget: sections, not chunks — a 300-page manual with 14 chapters is
 14 calls, once, refreshed on content hash like gists. Runs in the same
 sweep slot as gists (event on import; hourly catch-up; never per
 minute — `RFC-night-shift-area.md`, background-settle rules).
+
+Found on the way: appending rows after an FTS index exists and taking
+the incremental `optimize` path ranked one BM25-dependent query
+differently run to run, and differently from a from-scratch index over
+the same rows. The eval builds its index once, from scratch, after
+seeding; production takes the incremental path after every import
+(issue filed).
 
 ### Phase 3 — outline-guided retrieval as silent escalation
 
@@ -130,8 +155,33 @@ Phase 2.
 | baseline (v0.53.0) | 0.55 | 0.68 | 0.23 | 0.34 |
 | 1 — heading chain | 0.91 | 1.00 | 0.62 | 0.71 |
 | 1.5 — chain in the BM25 document | 1.00 | 1.00 | 0.92 | 0.94 |
-| 2 — section summaries | | | | |
+| 2 — section summaries (mechanics, handwritten fixtures) | 0.95 | 1.00 | 0.89 | 0.92 |
 | 3 — escalation | | | | |
+
+The `topic` kind (chapter paraphrases: undercarriage, de-icing,
+Portugal) is Phase 2's own measurement:
+
+| phase | topic R@5 | R@10 | MRR | nDCG |
+| --- | --- | --- | --- | --- |
+| after 1.5 (no section rows) | 0.69 | 0.85 | 0.50 | 0.59 |
+| 2 — section rows + scored expansion, handwritten summaries | 0.85 | 1.00 | 0.79 | 0.83 |
+| 2 — the generator, bonsai-8b (Small role) | 0.77 | 0.92 | 0.54–0.61 | 0.63 |
+| 2 — the generator, gemma4 12B, thinking off | 0.85 | 0.92 | 0.60 | 0.68 |
+
+The generator's eval (`eval_section_gists_model`, Ollama-gated) scores the
+topic kind three ways on one store: no rows, the handwritten fixtures,
+the model's. Handwritten is the ceiling to report against, not a floor
+to fail on; the bar is "beats no rows", and both models clear it. Bonsai
+never reaches "undercarriage" or "Portugal" and its runs spread 0.54–0.61
+at Ollama's default temperature; gemma writes exactly the names the
+queries use and lands 0.60 — the rest of the gap to 0.79 is the
+summaries' length and phrasing against BM25, not their content.
+
+Found on the way, and fixed: a thinking model as the Small role (gemma4)
+spent the whole `num_predict` cap on hidden reasoning and returned empty
+text — 35 s per section, nothing to show. The Small engine now sends
+Ollama `think: false` (ignored by models without a thinking mode); the
+same prompt answers in under a second.
 
 Controls (`chapter`, `exact`) must stay at 1.00; the golden datasets'
 floors are unchanged.

--- a/src-tauri/evals/datasets/fixture-outline.json
+++ b/src-tauri/evals/datasets/fixture-outline.json
@@ -1,6 +1,6 @@
 {
   "name": "fixture-outline",
-  "description": "Gate for the outline index (docs: Reminders 'Outline eval cases before outline work'). Two long structured documents from retrieval_eval.rs outline_corpus(): every chapter repeats the same subsections with the same vocabulary and different numbers, so the chapter name \u2014 present only in a heading the chunker has already replaced \u2014 is the only thing that tells look-alike chunks apart. 'outline' queries are the measurement; 'chapter' and 'exact' are seeding controls. floors: false \u2014 the numbers are reported and diffed, not asserted, and the outline work merges only if they improve.",
+  "description": "Gate for the outline index (docs: Reminders 'Outline eval cases before outline work'). Two long structured documents from retrieval_eval.rs outline_corpus(): every chapter repeats the same subsections with the same vocabulary and different numbers, so the chapter name \u2014 present only in a heading the chunker has already replaced \u2014 is the only thing that tells look-alike chunks apart. 'outline' queries are the measurement for the heading chain; 'topic' queries paraphrase the chapter (undercarriage, de-icing, Portugal) and are the measurement for section summaries and outline-guided escalation; 'chapter' and 'exact' are seeding controls. floors: false \u2014 the numbers are reported and diffed, not asserted, and the outline work merges only if they improve.",
   "corpus": "outline",
   "floors": false,
   "queries": [
@@ -271,6 +271,136 @@
         {
           "source_title": "Fleet Maintenance Manual",
           "must_contain": "SK-1305"
+        }
+      ]
+    },
+    {
+      "query": "undercarriage hinge bolt torque",
+      "kind": "topic",
+      "relevant": [
+        {
+          "source_title": "Fleet Maintenance Manual",
+          "must_contain": "to 31 N"
+        }
+      ]
+    },
+    {
+      "query": "de-icing union nut torque",
+      "kind": "topic",
+      "relevant": [
+        {
+          "source_title": "Fleet Maintenance Manual",
+          "must_contain": "to 148 N"
+        }
+      ]
+    },
+    {
+      "query": "how often to check the cabin air conditioning",
+      "kind": "topic",
+      "relevant": [
+        {
+          "source_title": "Fleet Maintenance Manual",
+          "must_contain": "every 500 flight hours"
+        }
+      ]
+    },
+    {
+      "query": "engine cover replacement part",
+      "kind": "topic",
+      "relevant": [
+        {
+          "source_title": "Fleet Maintenance Manual",
+          "must_contain": "FM-2330"
+        }
+      ]
+    },
+    {
+      "query": "ground power unit part number",
+      "kind": "topic",
+      "relevant": [
+        {
+          "source_title": "Fleet Maintenance Manual",
+          "must_contain": "FM-1823"
+        }
+      ]
+    },
+    {
+      "query": "tiller seal kit",
+      "kind": "topic",
+      "relevant": [
+        {
+          "source_title": "Fleet Maintenance Manual",
+          "must_contain": "SK-2209"
+        }
+      ]
+    },
+    {
+      "query": "outflow valve inspection interval",
+      "kind": "topic",
+      "relevant": [
+        {
+          "source_title": "Fleet Maintenance Manual",
+          "must_contain": "every 300 flight hours"
+        }
+      ]
+    },
+    {
+      "query": "emergency O2 seal kit",
+      "kind": "topic",
+      "relevant": [
+        {
+          "source_title": "Fleet Maintenance Manual",
+          "must_contain": "SK-2041"
+        }
+      ]
+    },
+    {
+      "query": "gear retraction pump mounting bolt torque",
+      "kind": "topic",
+      "relevant": [
+        {
+          "source_title": "Fleet Maintenance Manual",
+          "must_contain": "to 23 N"
+        }
+      ]
+    },
+    {
+      "query": "days off for national holidays at the Portugal office",
+      "kind": "topic",
+      "relevant": [
+        {
+          "source_title": "Regional Employee Policy Manual",
+          "must_contain": "observe 13 paid"
+        }
+      ]
+    },
+    {
+      "query": "how much notice when quitting in Germany",
+      "kind": "topic",
+      "relevant": [
+        {
+          "source_title": "Regional Employee Policy Manual",
+          "must_contain": "is 8 weeks"
+        }
+      ]
+    },
+    {
+      "query": "max nightly hotel spend in Canada",
+      "kind": "topic",
+      "relevant": [
+        {
+          "source_title": "Regional Employee Policy Manual",
+          "must_contain": "$140"
+        }
+      ]
+    },
+    {
+      "query": "resignation notice in Japan",
+      "kind": "topic",
+      "relevant": [
+        {
+          "source_title": "Regional Employee Policy Manual",
+          "must_contain": "is 10 weeks"
         }
       ]
     }

--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -356,6 +356,7 @@ pub async fn run(
                             ordinal: 0,
                             snippet: evidence,
                             distance: 0.0,
+                            section: String::new(),
                         });
                     }
                 }

--- a/src-tauri/src/ai/mod.rs
+++ b/src-tauri/src/ai/mod.rs
@@ -611,6 +611,7 @@ pub(crate) fn ollama_config(config: &AiConfig) -> OllamaConfig {
         effort: String::new(),
         keep_alive: None,
         num_predict: None,
+        think: None,
     }
 }
 
@@ -722,6 +723,9 @@ impl Ai {
             // for the longest legitimate reply and bounds that tail at
             // ~20s on an 8B model.
             oc.num_predict = Some(2_048);
+            // And no hidden thinking: a thinking model spends that cap on
+            // reasoning and hands back nothing (see OllamaConfig::think).
+            oc.think = Some(false);
             Some(ChatEngine::Ollama(Ollama::new(oc)))
         } else {
             runtime

--- a/src-tauri/src/beir_eval.rs
+++ b/src-tauri/src/beir_eval.rs
@@ -499,7 +499,7 @@ pub(crate) async fn seeded_dataset(
         seeded_docs += 1;
         if rows.len() >= SEED_BATCH {
             let embeddings = ai.embed(&inputs).await.expect("embed corpus batch");
-            db.add_chunk_rows(name, &rows, &embeddings)
+            db.add_chunk_rows(name, &rows, &[], &embeddings)
                 .await
                 .expect("seed chunk rows");
             rows.clear();
@@ -509,7 +509,7 @@ pub(crate) async fn seeded_dataset(
     }
     if !rows.is_empty() {
         let embeddings = ai.embed(&inputs).await.expect("embed corpus tail");
-        db.add_chunk_rows(name, &rows, &embeddings)
+        db.add_chunk_rows(name, &rows, &[], &embeddings)
             .await
             .expect("seed chunk tail");
     }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -430,6 +430,7 @@ async fn readiness_for_entry(
                 effort: String::new(),
                 keep_alive: None,
                 num_predict: None,
+                think: None,
             };
             if !entry.base_url.trim().is_empty() {
                 cfg.base_url = entry.base_url.clone();

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1484,8 +1484,15 @@ pub(crate) async fn spawn_embed_stage(
                 .enumerate()
                 .map(|(i, c)| (new_id(), i as i32, c.text.clone()))
                 .collect();
-            db.add_chunks(&source.notebook_id, &source.id, &tuples, &embeddings)
-                .await?;
+            let contexts: Vec<String> = chunks.iter().map(|c| c.context.clone()).collect();
+            db.add_chunks_ctx(
+                &source.notebook_id,
+                &source.id,
+                &tuples,
+                &contexts,
+                &embeddings,
+            )
+            .await?;
             Ok(Some(tuples.len()))
         }
         .await;
@@ -2400,6 +2407,7 @@ async fn grep_leg(
                 // Not a vector hit — match count carried the ranking; the
                 // field only feeds trace summaries.
                 distance: 0.0,
+                section: String::new(),
             }
         })
         .collect()
@@ -2849,12 +2857,14 @@ async fn index_snote(state: &AppState, source: &Source, note: &str) -> anyhow::R
         .enumerate()
         .map(|(j, c)| (new_id(), j as i32, c.text.clone()))
         .collect();
+    let contexts: Vec<String> = chunks.iter().map(|c| c.context.clone()).collect();
     state
         .db
-        .add_chunks(
+        .add_chunks_ctx(
             &source.notebook_id,
             &format!("{}{}", crate::db::SNOTE_CHUNK_PREFIX, source.id),
             &tuples,
+            &contexts,
             &embeddings,
         )
         .await
@@ -5612,9 +5622,10 @@ pub async fn reembed_all(app: AppHandle, state: State<'_, AppState>) -> Result<u
             .enumerate()
             .map(|(j, c)| (new_id(), j as i32, c.text.clone()))
             .collect();
+        let contexts: Vec<String> = chunks.iter().map(|c| c.context.clone()).collect();
         e(state
             .db
-            .add_chunks(notebook_id, owner_id, &tuples, &embeddings)
+            .add_chunks_ctx(notebook_id, owner_id, &tuples, &contexts, &embeddings)
             .await)?;
     }
 
@@ -9404,12 +9415,14 @@ async fn try_index_note(state: &AppState, note: &Note) -> anyhow::Result<()> {
         .enumerate()
         .map(|(j, c)| (new_id(), j as i32, c.text.clone()))
         .collect();
+    let contexts: Vec<String> = chunks.iter().map(|c| c.context.clone()).collect();
     state
         .db
-        .add_chunks(
+        .add_chunks_ctx(
             &note.notebook_id,
             &format!("{}{}", crate::db::NOTE_CHUNK_PREFIX, note.id),
             &tuples,
+            &contexts,
             &embeddings,
         )
         .await

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -8596,6 +8596,7 @@ pub async fn send_message(
     // way to say which stage — hybrid search, the grep leg, the gap
     // retrieval's model call, or the rerank — was eating it.
     let t_stage = std::time::Instant::now();
+    let query_vec_for_outline = query_vec.clone();
     let search = e(state
         .db
         .search_chunks_trace(
@@ -8632,6 +8633,27 @@ pub async fn send_message(
     )
     .await;
     let gap_ms = t_stage.elapsed().as_millis() as u64;
+    // Outline-guided escalation (RFC-outline-index Phase 3): when the pool
+    // is thin or sits on look-alike sections of a structured source, the
+    // Small role picks sections from the notebook's outline and their best
+    // passages lead the pool. Self-gating and silent; a failure leaves the
+    // pool as it was.
+    let outline_pick = match crate::outline_index::escalate(
+        &state.db,
+        &ai,
+        &notebook_id,
+        &content,
+        &query_vec_for_outline,
+        &mut pool,
+    )
+    .await
+    {
+        Ok(pick) => pick,
+        Err(err) => {
+            crate::note!("outline: escalation failed: {err:#}");
+            None
+        }
+    };
     crate::trace::log(
         &state.trace_dir,
         serde_json::json!({
@@ -8644,6 +8666,7 @@ pub async fn send_message(
             "fusedHits": search.fused_hits.len(),
             "grepHits": grep_hits.len(),
             "gapQuery": gap_query,
+            "outlinePick": outline_pick,
             "warnings": search.warnings,
             "citations": crate::trace::cite_summaries(&pool),
         }),

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -211,6 +211,9 @@ pub struct Db {
     /// only marks the index dirty; `flush_fts` rebuilds once at the end.
     fts_deferred: std::sync::atomic::AtomicBool,
     fts_dirty: std::sync::atomic::AtomicBool,
+    /// The chunks table has been seen with its context column (Phase 1.5);
+    /// see `has_chunk_context`.
+    chunk_context_seen: std::sync::atomic::AtomicBool,
     /// Nudged on every non-deferred chunk write; the debounced flusher task
     /// (lib.rs) listens and rebuilds once per burst.
     fts_notify: tokio::sync::Notify,
@@ -288,6 +291,7 @@ impl Db {
             fts_lock: tokio::sync::Mutex::new(()),
             fts_deferred: std::sync::atomic::AtomicBool::new(false),
             fts_dirty: std::sync::atomic::AtomicBool::new(false),
+            chunk_context_seen: std::sync::atomic::AtomicBool::new(false),
             fts_notify: tokio::sync::Notify::new(),
             fusion_vector_weight: std::sync::atomic::AtomicU32::new(1.0f32.to_bits()),
             fusion_rrf_k: std::sync::atomic::AtomicU32::new(60.0f32.to_bits()),
@@ -1460,12 +1464,31 @@ impl Db {
         chunks: &[(String, i32, String)],
         embeddings: &[Vec<f32>],
     ) -> Result<()> {
+        self.insert_source_ctx(source, chunks, &[], embeddings)
+            .await
+    }
+
+    /// `insert_source` with each chunk's context ("title › chain") stored
+    /// beside it; an empty `contexts` stores blanks.
+    pub async fn insert_source_ctx(
+        &self,
+        source: &Source,
+        chunks: &[(String, i32, String)],
+        contexts: &[String],
+        embeddings: &[Vec<f32>],
+    ) -> Result<()> {
         // Source row.
         let schema = sources_schema();
         let batch = source_batch(&schema, std::slice::from_ref(source))?;
         self.add_batch(T_SOURCES, schema, batch).await?;
-        self.add_chunks(&source.notebook_id, &source.id, chunks, embeddings)
-            .await
+        self.add_chunks_ctx(
+            &source.notebook_id,
+            &source.id,
+            chunks,
+            contexts,
+            embeddings,
+        )
+        .await
     }
 
     /// Append chunk rows (with embeddings) for a source. Creates the chunks
@@ -1477,6 +1500,94 @@ impl Db {
         chunks: &[(String, i32, String)],
         embeddings: &[Vec<f32>],
     ) -> Result<()> {
+        self.add_chunks_ctx(notebook_id, source_id, chunks, &[], embeddings)
+            .await
+    }
+
+    /// Does the live chunks table carry the context column? Tables from
+    /// before Phase 1.5 don't until `ensure_chunk_context_column` runs.
+    /// Remembered once seen: a column never goes away, and every search
+    /// asks — a schema read per query would be a needless round trip.
+    async fn has_chunk_context(&self) -> Result<bool> {
+        if self
+            .chunk_context_seen
+            .load(std::sync::atomic::Ordering::Relaxed)
+        {
+            return Ok(true);
+        }
+        if !self.table_exists(T_CHUNKS).await? {
+            return Ok(false);
+        }
+        let tbl = self.conn.open_table(T_CHUNKS).execute().await?;
+        let has = tbl
+            .schema()
+            .await?
+            .fields()
+            .iter()
+            .any(|f| f.name() == CHUNK_CONTEXT_COL);
+        if has {
+            self.chunk_context_seen
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+        }
+        Ok(has)
+    }
+
+    /// Probe for tests: (chunk rows, rows whose context is non-empty).
+    #[cfg(test)]
+    pub async fn context_fill(&self) -> Result<(usize, usize)> {
+        if !self.table_exists(T_CHUNKS).await? {
+            return Ok((0, 0));
+        }
+        let batches = self
+            .collect_cols(T_CHUNKS, None, &["id", CHUNK_CONTEXT_COL])
+            .await?;
+        let mut rows = 0usize;
+        let mut filled = 0usize;
+        for b in &batches {
+            rows += b.num_rows();
+            if let Some(col) = b
+                .column_by_name(CHUNK_CONTEXT_COL)
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            {
+                filled += (0..b.num_rows())
+                    .filter(|&i| !col.value(i).is_empty())
+                    .count();
+            }
+        }
+        Ok((rows, filled))
+    }
+
+    /// One-time schema evolution: give an older chunks table the context
+    /// column, blank for every existing row. Older builds sharing the store
+    /// keep working — their appends conform to the live schema with "".
+    async fn ensure_chunk_context_column(&self) -> Result<()> {
+        if self.has_chunk_context().await? {
+            return Ok(());
+        }
+        let tbl = self.conn.open_table(T_CHUNKS).execute().await?;
+        // Existing rows: no chain to give them, but their BM25 document is
+        // still their text — the index must not lose them.
+        tbl.add_columns()
+            .transform(lancedb::table::NewColumnTransform::SqlExpressions(vec![
+                (CHUNK_CONTEXT_COL.to_string(), "''".to_string()),
+                (CHUNK_BM25_COL.to_string(), "text".to_string()),
+            ]))
+            .execute()
+            .await?;
+        crate::note!("chunks: added the context and bm25 columns");
+        Ok(())
+    }
+
+    /// `add_chunks` with contexts. `contexts[i]` belongs to `chunks[i]`;
+    /// a short or empty slice stores "" for the rest.
+    pub async fn add_chunks_ctx(
+        &self,
+        notebook_id: &str,
+        source_id: &str,
+        chunks: &[(String, i32, String)],
+        contexts: &[String],
+        embeddings: &[Vec<f32>],
+    ) -> Result<()> {
         if chunks.is_empty() {
             return Ok(());
         }
@@ -1485,6 +1596,7 @@ impl Db {
             .map(|v| v.len())
             .ok_or_else(|| anyhow!("no embeddings for chunks"))? as i32;
         self.ensure_table(T_CHUNKS, chunks_schema(dim)).await?;
+        self.ensure_chunk_context_column().await?;
 
         let schema = chunks_schema(dim);
         let ids: Vec<String> = chunks.iter().map(|c| c.0.clone()).collect();
@@ -1492,6 +1604,14 @@ impl Db {
         let sids: Vec<String> = chunks.iter().map(|_| source_id.to_string()).collect();
         let ords: Vec<i32> = chunks.iter().map(|c| c.1).collect();
         let texts: Vec<String> = chunks.iter().map(|c| c.2.clone()).collect();
+        let ctxs: Vec<String> = (0..chunks.len())
+            .map(|i| contexts.get(i).cloned().unwrap_or_default())
+            .collect();
+        let docs: Vec<String> = ctxs
+            .iter()
+            .zip(chunks.iter())
+            .map(|(c, ch)| bm25_doc(c, &ch.2))
+            .collect();
         let vectors = FixedSizeListArray::from_iter_primitive::<Float32Type, _, _>(
             embeddings
                 .iter()
@@ -1507,6 +1627,8 @@ impl Db {
                 Arc::new(Int32Array::from(ords)),
                 Arc::new(StringArray::from(texts)),
                 Arc::new(vectors),
+                Arc::new(StringArray::from(ctxs)),
+                Arc::new(StringArray::from(docs)),
             ],
         )?;
         self.add_batch(T_CHUNKS, schema, batch).await?;
@@ -1544,6 +1666,7 @@ impl Db {
         &self,
         notebook_id: &str,
         rows: &[(String, String, i32, String)],
+        contexts: &[String],
         embeddings: &[Vec<f32>],
     ) -> Result<()> {
         if rows.is_empty() {
@@ -1554,12 +1677,21 @@ impl Db {
             .map(|v| v.len())
             .ok_or_else(|| anyhow!("no embeddings for chunk rows"))? as i32;
         self.ensure_table(T_CHUNKS, chunks_schema(dim)).await?;
+        self.ensure_chunk_context_column().await?;
         let schema = chunks_schema(dim);
         let ids: Vec<String> = rows.iter().map(|r| r.1.clone()).collect();
         let nbs: Vec<String> = rows.iter().map(|_| notebook_id.to_string()).collect();
         let sids: Vec<String> = rows.iter().map(|r| r.0.clone()).collect();
         let ords: Vec<i32> = rows.iter().map(|r| r.2).collect();
         let texts: Vec<String> = rows.iter().map(|r| r.3.clone()).collect();
+        let ctxs: Vec<String> = (0..rows.len())
+            .map(|i| contexts.get(i).cloned().unwrap_or_default())
+            .collect();
+        let docs: Vec<String> = ctxs
+            .iter()
+            .zip(rows.iter())
+            .map(|(c, r)| bm25_doc(c, &r.3))
+            .collect();
         let vectors = FixedSizeListArray::from_iter_primitive::<Float32Type, _, _>(
             embeddings
                 .iter()
@@ -1575,6 +1707,8 @@ impl Db {
                 Arc::new(Int32Array::from(ords)),
                 Arc::new(StringArray::from(texts)),
                 Arc::new(vectors),
+                Arc::new(StringArray::from(ctxs)),
+                Arc::new(StringArray::from(docs)),
             ],
         )?;
         self.add_batch(T_CHUNKS, schema, batch).await?;
@@ -1681,11 +1815,15 @@ impl Db {
         let mut attempt = 0u32;
         loop {
             let tbl = self.conn.open_table(T_CHUNKS).execute().await?;
-            let has_fts = tbl
-                .list_indices()
-                .await?
-                .iter()
-                .any(|i| i.columns == ["text"]);
+            let indices = tbl.list_indices().await?;
+            // The BM25 document column (context + text) carries the index
+            // once it exists; a table from before it keeps indexing text.
+            let fts_col = if self.has_chunk_context().await? {
+                CHUNK_BM25_COL
+            } else {
+                "text"
+            };
+            let has_fts = indices.iter().any(|i| i.columns == [fts_col]);
             // lance-index 7.0's inverted builder PANICS (not errors) with an
             // index-out-of-bounds (builder.rs:856) when deletes + compaction
             // remap leave the token set inconsistent (TokenSet::next_id >
@@ -1705,7 +1843,7 @@ impl Db {
                     .await
                     .map(|_| ())
                 } else {
-                    t.create_index(&["text"], Index::FTS(FtsIndexBuilder::default()))
+                    t.create_index(&[fts_col], Index::FTS(FtsIndexBuilder::default()))
                         .replace(true)
                         .execute()
                         .await
@@ -1979,10 +2117,20 @@ impl Db {
         let fts_hits = if query_text.trim().is_empty() {
             vec![]
         } else {
+            // The BM25 document is context + text where the column exists
+            // (docs/RFC-outline-index.md Phase 1.5); older tables index text.
+            let fts_col = if self.has_chunk_context().await? {
+                CHUNK_BM25_COL
+            } else {
+                "text"
+            };
+            let text_query = FullTextSearchQuery::new(query_text.to_string())
+                .with_column(fts_col.to_string())
+                .map_err(|e| anyhow!("fts query: {e}"))?;
             match tbl
                 .query()
                 .only_if(filter)
-                .full_text_search(FullTextSearchQuery::new(query_text.to_string()))
+                .full_text_search(text_query)
                 .limit(pool)
                 .execute()
                 .await
@@ -2001,7 +2149,7 @@ impl Db {
             }
         };
 
-        // Reciprocal rank fusion: score = Σ w/(k + rank) over both lists.
+        // Reciprocal rank fusion: score = Σ w/(k + rank) over the lists.
         // Exact score ties are common (e.g. a vector-only and an FTS-only
         // hit at the same rank), and HashMap iteration order is randomized,
         // so break ties by chunk id to keep results stable across runs.
@@ -2672,13 +2820,17 @@ impl Db {
         // RFC-retrieval-maturity Phase 2).
         let (titles, _) = self.corpus_meta().await?;
         let tbl = self.conn.open_table(T_CHUNKS).execute().await?;
-        let batches = match tbl
-            .query()
-            .full_text_search(FullTextSearchQuery::new(query_text.to_string()))
-            .limit(k)
-            .execute()
-            .await
-        {
+        let fts_col = if self.has_chunk_context().await? {
+            CHUNK_BM25_COL
+        } else {
+            "text"
+        };
+        let Ok(query) =
+            FullTextSearchQuery::new(query_text.to_string()).with_column(fts_col.to_string())
+        else {
+            return Ok(vec![]);
+        };
+        let batches = match tbl.query().full_text_search(query).limit(k).execute().await {
             Ok(stream) => stream.try_collect::<Vec<_>>().await.unwrap_or_default(),
             Err(_) => return Ok(vec![]),
         };
@@ -3112,11 +3264,12 @@ impl Db {
         notebook_id: &str,
         source_id: &str,
         chunks: &[(String, i32, String)],
+        contexts: &[String],
         embeddings: &[Vec<f32>],
     ) -> Result<()> {
         self.delete_where(T_CHUNKS, &format!("source_id = '{}'", esc(source_id)))
             .await?;
-        self.add_chunks(notebook_id, source_id, chunks, embeddings)
+        self.add_chunks_ctx(notebook_id, source_id, chunks, contexts, embeddings)
             .await
     }
 
@@ -3927,6 +4080,9 @@ fn citations_from_batches(
         let sid = str_col(b, "source_id")?;
         let ord = i32_col(b, "ordinal")?;
         let text = str_col(b, "text")?;
+        let ctx = b
+            .column_by_name(CHUNK_CONTEXT_COL)
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>());
         let dist = b.column_by_name("_distance").and_then(|c| {
             c.as_any()
                 .downcast_ref::<arrow_array::Float32Array>()
@@ -3948,6 +4104,7 @@ fn citations_from_batches(
                 ordinal: ord.value(i),
                 snippet: text.value(i).to_string(),
                 distance: dist.as_ref().map(|d| d.value(i)).unwrap_or(0.0),
+                section: ctx.map(|c| c.value(i).to_string()).unwrap_or_default(),
             });
         }
     }
@@ -4148,7 +4305,34 @@ fn chunks_schema(dim: i32) -> SchemaRef {
             DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
             true,
         ),
+        // "title › chapter › section" — the chunk's place in its document
+        // (docs/RFC-outline-index.md Phase 1.5), read back as the citation's
+        // `section`. Nullable and after `vector`, so a table from before it
+        // exists gains it by `add_columns` and older builds' appends
+        // conform ("").
+        Field::new(CHUNK_CONTEXT_COL, DataType::Utf8, true),
+        // What BM25 indexes: the context and the text as ONE document, so a
+        // chunk matching the question in both scores above one matching a
+        // heading word alone. A separate context leg gave a context-only
+        // match a full rank-one vote and cost exact-identifier queries
+        // their top rank (hard-exact MRR 1.00 → 0.78); one document per
+        // chunk is the field-weighting BM25 was built for.
+        Field::new(CHUNK_BM25_COL, DataType::Utf8, true),
     ]))
+}
+
+/// The chunks table's context column (see `chunks_schema`).
+pub const CHUNK_CONTEXT_COL: &str = "context";
+/// The chunks table's BM25 document column: "{context}\n{text}".
+pub const CHUNK_BM25_COL: &str = "bm25";
+
+/// The BM25 document for one chunk.
+fn bm25_doc(context: &str, text: &str) -> String {
+    if context.is_empty() {
+        text.to_string()
+    } else {
+        format!("{context}\n{text}")
+    }
 }
 
 fn routes_schema(dim: i32) -> SchemaRef {
@@ -5099,6 +5283,7 @@ mod tests {
             ordinal: 0,
             snippet: String::new(),
             distance: 0.0,
+            section: String::new(),
         };
         // Gist rows reach the comparator with source_id already resolved,
         // so they inherit the source's timestamp through the same key.
@@ -5157,6 +5342,7 @@ mod tests {
             ordinal,
             snippet: snippet.into(),
             distance: 0.0,
+            section: String::new(),
         };
         // Both middle and last chunks are cited: the middle one may claim
         // only the uncited ordinal 0; the last one has no free neighbors

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -68,6 +68,48 @@ pub const NOTE_CHUNK_PREFIX: &str = "note:";
 /// not a position.
 pub const GIST_CHUNK_PREFIX: &str = "gist:";
 
+/// `source_id = "section:<source_id>"` marks a section-summary row
+/// (docs/RFC-outline-index.md Phase 2): one short summary per top-level
+/// section of a long structured source, embedded and BM25-indexed like a
+/// gist. Its chunk id is `section:<source_id>:<start>-<end>`, the ordinal
+/// span of the passages it stands for; a hit on the row is swapped for
+/// those passages before results leave `search_chunks_trace`.
+pub const SECTION_CHUNK_PREFIX: &str = "section:";
+
+/// One section summary to store (see `add_section_rows`).
+#[derive(Clone, Debug)]
+pub struct SectionGist {
+    /// First and last chunk ordinal of the section, inclusive.
+    pub start: i32,
+    pub end: i32,
+    /// "title › heading" — the chain, stored as the row's context.
+    pub chain: String,
+    pub summary: String,
+}
+
+/// The passage span a section row stands for, from its chunk id.
+pub fn section_range(chunk_id: &str) -> Option<(i32, i32)> {
+    let rest = chunk_id.strip_prefix(SECTION_CHUNK_PREFIX)?;
+    let (_, span) = rest.rsplit_once(':')?;
+    let (a, b) = span.split_once('-')?;
+    Some((a.parse().ok()?, b.parse().ok()?))
+}
+
+/// How many passages replace one section hit. The summary says "the answer
+/// is in this section"; a mini hybrid search over that span says where.
+/// Two, not the whole section: dumping a section in document order pushed
+/// the wanted passage down and let wrong-section hits crowd the top ten
+/// (topic MRR 0.50 → 0.44 measured that way).
+const SECTION_EXPAND_MAX: usize = 2;
+
+/// `SECTION_EXPAND_MAX`, overridable for eval sweeps.
+fn section_expand_max() -> usize {
+    std::env::var("ALCHEMY_SECTION_EXPAND")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(SECTION_EXPAND_MAX)
+}
+
 /// `source_id = "snote:<source_id>"` marks the user's own annotation on a
 /// source (docs/RFC-source-tags.md): one editable note per source, indexed
 /// in the chunks table so "why did I save this" is retrievable. Unlike
@@ -1410,8 +1452,14 @@ impl Db {
     /// (`snote:`) and gist (`gist:`) rows carry prefixed owner ids, so the
     /// plain-id predicate leaves them alone.
     pub async fn delete_source_chunks(&self, source_id: &str) -> Result<()> {
-        self.delete_where(T_CHUNKS, &format!("source_id = '{}'", esc(source_id)))
-            .await
+        // Section rows name passage spans by ordinal; a re-chunk invalidates
+        // them, so they go with the chunks (the gist row, keyed by content
+        // hash, survives and re-diffs on its own).
+        let pred = format!(
+            "source_id = '{0}' OR source_id = '{SECTION_CHUNK_PREFIX}{0}'",
+            esc(source_id)
+        );
+        self.delete_where(T_CHUNKS, &pred).await
     }
 
     /// Swap a source's ROW without touching its chunks — the async reingest
@@ -1530,6 +1578,62 @@ impl Db {
                 .store(true, std::sync::atomic::Ordering::Relaxed);
         }
         Ok(has)
+    }
+
+    /// Tests only: rebuild the chunks FTS index from scratch, so a seeding
+    /// that appended rows after an earlier build measures against one
+    /// index of everything rather than an incrementally optimized one.
+    #[cfg(test)]
+    pub async fn rebuild_fts_from_scratch(&self) -> Result<()> {
+        let _guard = self.fts_lock.lock().await;
+        if !self.table_exists(T_CHUNKS).await? {
+            return Ok(());
+        }
+        let tbl = self.conn.open_table(T_CHUNKS).execute().await?;
+        let col = if self.has_chunk_context().await? {
+            CHUNK_BM25_COL
+        } else {
+            "text"
+        };
+        tbl.create_index(&[col], Index::FTS(FtsIndexBuilder::default()))
+            .replace(true)
+            .execute()
+            .await?;
+        self.fts_dirty
+            .store(false, std::sync::atomic::Ordering::SeqCst);
+        Ok(())
+    }
+
+    /// Tests only: one source's section rows as (chain, summary), in
+    /// section order.
+    #[cfg(test)]
+    pub async fn section_rows(&self, source_id: &str) -> Result<Vec<(String, String)>> {
+        if !self.table_exists(T_CHUNKS).await? {
+            return Ok(vec![]);
+        }
+        let filter = format!("source_id = '{SECTION_CHUNK_PREFIX}{}'", esc(source_id));
+        let batches = self
+            .collect_cols(
+                T_CHUNKS,
+                Some(&filter),
+                &["ordinal", "text", CHUNK_CONTEXT_COL],
+            )
+            .await?;
+        let mut rows: Vec<(i32, String, String)> = Vec::new();
+        for b in &batches {
+            let ord = i32_col(b, "ordinal")?;
+            let text = str_col(b, "text")?;
+            let ctx = str_col(b, CHUNK_CONTEXT_COL)?;
+            for i in 0..b.num_rows() {
+                rows.push((
+                    ord.value(i),
+                    ctx.value(i).to_string(),
+                    text.value(i).to_string(),
+                ));
+            }
+        }
+        rows.sort_by_key(|r| r.0);
+        Ok(rows.into_iter().map(|(_, c, t)| (c, t)).collect())
     }
 
     /// Probe for tests: (chunk rows, rows whose context is non-empty).
@@ -1932,6 +2036,7 @@ impl Db {
         // is cleaner).
         let pred = format!(
             "source_id = '{0}' OR source_id = '{GIST_CHUNK_PREFIX}{0}' \
+             OR source_id = '{SECTION_CHUNK_PREFIX}{0}' \
              OR source_id = '{SNOTE_CHUNK_PREFIX}{0}'",
             esc(source_id)
         );
@@ -1963,9 +2068,10 @@ impl Db {
                 .join(", ")
         };
         let pred = format!(
-            "source_id IN ({}) OR source_id IN ({}) OR source_id IN ({})",
+            "source_id IN ({}) OR source_id IN ({}) OR source_id IN ({}) OR source_id IN ({})",
             quoted(""),
             quoted(GIST_CHUNK_PREFIX),
+            quoted(SECTION_CHUNK_PREFIX),
             quoted(SNOTE_CHUNK_PREFIX)
         );
         self.delete_where(T_CHUNKS, &pred).await?;
@@ -2094,6 +2200,7 @@ impl Db {
         // something to work with.
         let pool = k.max(1) * 3;
 
+        let query_vec_for_sections = query_vec.clone();
         let vec_batches = tbl
             .query()
             .only_if(filter.clone())
@@ -2172,6 +2279,15 @@ impl Db {
             )
         });
         let fused_hits: Vec<Citation> = merged.into_iter().map(|(c, _)| c).collect();
+        let fused_hits = self
+            .expand_section_hits(
+                fused_hits,
+                &query_vec_for_sections,
+                query_text,
+                &titles,
+                &paths,
+            )
+            .await?;
         let final_hits = fused_hits.iter().take(k).cloned().collect();
         Ok(SearchTrace {
             vector_hits: vec_hits,
@@ -3219,6 +3335,189 @@ impl Db {
         Ok(out)
     }
 
+    /// Replace one source's section-summary rows (RFC-outline-index Phase
+    /// 2). `embeddings[i]` embeds `sections[i]`; the summary is the row's
+    /// text (its snippet), the chain its context, so BM25 sees both.
+    pub async fn replace_section_rows(
+        &self,
+        notebook_id: &str,
+        source_id: &str,
+        sections: &[SectionGist],
+        embeddings: &[Vec<f32>],
+    ) -> Result<()> {
+        self.delete_section_rows(source_id).await?;
+        if sections.is_empty() {
+            return Ok(());
+        }
+        let owner = format!("{SECTION_CHUNK_PREFIX}{source_id}");
+        let rows: Vec<(String, i32, String)> = sections
+            .iter()
+            .enumerate()
+            .map(|(i, s)| {
+                (
+                    format!("{owner}:{}-{}", s.start, s.end),
+                    i as i32,
+                    s.summary.clone(),
+                )
+            })
+            .collect();
+        let contexts: Vec<String> = sections.iter().map(|s| s.chain.clone()).collect();
+        self.add_chunks_ctx(notebook_id, &owner, &rows, &contexts, embeddings)
+            .await
+    }
+
+    /// Drop one source's section-summary rows (no-op if it has none).
+    pub async fn delete_section_rows(&self, source_id: &str) -> Result<()> {
+        let pred = format!("source_id = '{SECTION_CHUNK_PREFIX}{}'", esc(source_id));
+        self.delete_where(T_CHUNKS, &pred).await
+    }
+
+    /// The passages of one section ranked against the question: the same
+    /// two legs as the main search, filtered to the section's span, fused
+    /// by RRF. Cheap — a span is a handful of rows — and it turns "the
+    /// answer is in this section" into "this passage".
+    async fn rank_within_section(
+        &self,
+        query_vec: &[f32],
+        query_text: &str,
+        span: (&str, i32, i32),
+        labels: (&HashMap<String, String>, &HashMap<String, String>),
+    ) -> Result<Vec<Citation>> {
+        let (source_id, start, end) = span;
+        let (titles, paths) = labels;
+        if !self.table_exists(T_CHUNKS).await? {
+            return Ok(vec![]);
+        }
+        let filter = format!(
+            "source_id = '{}' AND ordinal >= {start} AND ordinal <= {end}",
+            esc(source_id)
+        );
+        let tbl = self.conn.open_table(T_CHUNKS).execute().await?;
+        let span = (end - start + 1).max(1) as usize;
+        let vec_batches = tbl
+            .query()
+            .only_if(filter.clone())
+            .nearest_to(query_vec.to_vec())?
+            .limit(span)
+            .execute()
+            .await?
+            .try_collect::<Vec<_>>()
+            .await?;
+        let vec_hits = citations_from_batches(&vec_batches, titles, paths)?;
+        #[cfg(test)]
+        if std::env::var("ALCHEMY_TRACE_SECTIONS").is_ok() {
+            eprintln!(
+                "    span vector leg: {:?}",
+                vec_hits.iter().map(|p| p.ordinal).collect::<Vec<_>>()
+            );
+        }
+        let fts_hits = if query_text.trim().is_empty() {
+            vec![]
+        } else {
+            let col = if self.has_chunk_context().await? {
+                CHUNK_BM25_COL
+            } else {
+                "text"
+            };
+            match FullTextSearchQuery::new(query_text.to_string()).with_column(col.to_string()) {
+                Ok(q) => match tbl
+                    .query()
+                    .only_if(filter)
+                    .full_text_search(q)
+                    .limit(span)
+                    .execute()
+                    .await
+                {
+                    Ok(stream) => citations_from_batches(
+                        &stream.try_collect::<Vec<_>>().await.unwrap_or_default(),
+                        titles,
+                        paths,
+                    )?,
+                    Err(_) => vec![],
+                },
+                Err(_) => vec![],
+            }
+        };
+        let (w_vec, rrf_k) = self.fusion();
+        let mut fused: HashMap<String, (Citation, f32)> = HashMap::new();
+        for (hits, w) in [(&vec_hits, w_vec), (&fts_hits, 1.0)] {
+            for (rank, c) in hits.iter().enumerate() {
+                fused
+                    .entry(c.chunk_id.clone())
+                    .or_insert((c.clone(), 0.0))
+                    .1 += w / (rrf_k + rank as f32);
+            }
+        }
+        let mut merged: Vec<(Citation, f32)> = fused.into_values().collect();
+        merged.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.0.ordinal.cmp(&b.0.ordinal))
+        });
+        Ok(merged.into_iter().map(|(c, _)| c).collect())
+    }
+
+    /// Swap each section-summary hit for the passages it stands for, in
+    /// place, best-matching first (RFC-outline-index Phase 2). The summary
+    /// found the section; the reader and the prompt want the verbatim
+    /// text, which is also what click-to-highlight and the retrieval evals
+    /// match. A passage the section vouches for takes the section's rank
+    /// even if the flat search had it further down — that promotion is the
+    /// whole point (leaving it "at its own rank" kept the wanted passage at
+    /// 25 behind a summary at 1). A passage already placed higher stays.
+    async fn expand_section_hits(
+        &self,
+        hits: Vec<Citation>,
+        query_vec: &[f32],
+        query_text: &str,
+        titles: &HashMap<String, String>,
+        paths: &HashMap<String, String>,
+    ) -> Result<Vec<Citation>> {
+        if !hits.iter().any(|c| section_range(&c.chunk_id).is_some()) {
+            return Ok(hits);
+        }
+        // Ids already emitted (in either capacity); a later flat hit for a
+        // promoted passage is skipped, not duplicated.
+        let mut emitted: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut out: Vec<Citation> = Vec::with_capacity(hits.len());
+        // Every section hit expands, wherever it sits: gating on the row's
+        // rank (top 2, 3, 5, 10) measured no better than none.
+        for hit in hits {
+            let Some((start, end)) = section_range(&hit.chunk_id) else {
+                if emitted.insert(hit.chunk_id.clone()) {
+                    out.push(hit);
+                }
+                continue;
+            };
+            let passages = self
+                .rank_within_section(
+                    query_vec,
+                    query_text,
+                    (&hit.source_id, start, end),
+                    (titles, paths),
+                )
+                .await?;
+            #[cfg(test)]
+            if std::env::var("ALCHEMY_TRACE_SECTIONS").is_ok() {
+                eprintln!(
+                    "  section {}..={} of {} → {:?}",
+                    start,
+                    end,
+                    hit.section,
+                    passages.iter().map(|p| p.ordinal).collect::<Vec<_>>()
+                );
+            }
+            for mut p in passages.into_iter().take(section_expand_max()) {
+                if emitted.insert(p.chunk_id.clone()) {
+                    // The summary's rank is the passage's rank.
+                    p.distance = hit.distance;
+                    out.push(p);
+                }
+            }
+        }
+        Ok(out)
+    }
+
     /// Drop one source's gist row (no-op if it has none).
     pub async fn delete_gist_row(&self, source_id: &str) -> Result<()> {
         let pred = format!("source_id = '{GIST_CHUNK_PREFIX}{}'", esc(source_id));
@@ -4064,6 +4363,11 @@ fn split_owner(stored: &str) -> (String, String, bool, bool) {
         return (String::new(), note_id.to_string(), false, false);
     }
     if let Some(source_id) = stored.strip_prefix(GIST_CHUNK_PREFIX) {
+        return (source_id.to_string(), String::new(), true, false);
+    }
+    // Section rows are gists of a part: same caps, same "distillate, not
+    // passage" treatment everywhere a gist gets it.
+    if let Some(source_id) = stored.strip_prefix(SECTION_CHUNK_PREFIX) {
         return (source_id.to_string(), String::new(), true, false);
     }
     (stored.to_string(), String::new(), false, false)

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -87,6 +87,17 @@ pub struct SectionGist {
     pub summary: String,
 }
 
+/// One line of a notebook's outline (see `notebook_outline`).
+#[derive(Clone, Debug)]
+pub struct OutlineEntry {
+    pub source_id: String,
+    /// "title › heading" — the context column of the section row.
+    pub chain: String,
+    pub summary: String,
+    pub start: i32,
+    pub end: i32,
+}
+
 /// The passage span a section row stands for, from its chunk id.
 pub fn section_range(chunk_id: &str) -> Option<(i32, i32)> {
     let rest = chunk_id.strip_prefix(SECTION_CHUNK_PREFIX)?;
@@ -3364,6 +3375,79 @@ impl Db {
         let contexts: Vec<String> = sections.iter().map(|s| s.chain.clone()).collect();
         self.add_chunks_ctx(notebook_id, &owner, &rows, &contexts, embeddings)
             .await
+    }
+
+    /// Every section summary in a notebook — the outline the escalation
+    /// reads (RFC-outline-index Phase 3): (source_id, chain, summary, start,
+    /// end), in source then section order.
+    pub async fn notebook_outline(&self, notebook_id: &str) -> Result<Vec<OutlineEntry>> {
+        if !self.table_exists(T_CHUNKS).await? {
+            return Ok(vec![]);
+        }
+        let filter = format!(
+            "notebook_id = '{}' AND source_id LIKE '{SECTION_CHUNK_PREFIX}%'",
+            esc(notebook_id)
+        );
+        let batches = self
+            .collect_cols(
+                T_CHUNKS,
+                Some(&filter),
+                &["id", "source_id", "ordinal", "text", CHUNK_CONTEXT_COL],
+            )
+            .await?;
+        let mut out: Vec<(String, i32, OutlineEntry)> = Vec::new();
+        for b in &batches {
+            let id = str_col(b, "id")?;
+            let sid = str_col(b, "source_id")?;
+            let ord = i32_col(b, "ordinal")?;
+            let text = str_col(b, "text")?;
+            let ctx = str_col(b, CHUNK_CONTEXT_COL)?;
+            for i in 0..b.num_rows() {
+                let Some(source_id) = sid.value(i).strip_prefix(SECTION_CHUNK_PREFIX) else {
+                    continue;
+                };
+                let Some((start, end)) = section_range(id.value(i)) else {
+                    continue;
+                };
+                out.push((
+                    source_id.to_string(),
+                    ord.value(i),
+                    OutlineEntry {
+                        source_id: source_id.to_string(),
+                        chain: ctx.value(i).to_string(),
+                        summary: text.value(i).to_string(),
+                        start,
+                        end,
+                    },
+                ));
+            }
+        }
+        out.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+        Ok(out.into_iter().map(|(_, _, e)| e).collect())
+    }
+
+    /// The best passages of one section for a question — the escalation's
+    /// read after the model picks a section (RFC-outline-index Phase 3).
+    pub async fn section_passages(
+        &self,
+        notebook_id: &str,
+        query_vec: &[f32],
+        query_text: &str,
+        span: (&str, i32, i32),
+        n: usize,
+    ) -> Result<Vec<Citation>> {
+        let mut titles: HashMap<String, String> = HashMap::new();
+        let mut paths: HashMap<String, String> = HashMap::new();
+        for s in self.list_sources(notebook_id).await? {
+            if s.url.starts_with('/') {
+                paths.insert(s.id.clone(), s.url.clone());
+            }
+            titles.insert(s.id, s.title);
+        }
+        let ranked = self
+            .rank_within_section(query_vec, query_text, span, (&titles, &paths))
+            .await?;
+        Ok(ranked.into_iter().take(n).collect())
     }
 
     /// Drop one source's section-summary rows (no-op if it has none).

--- a/src-tauri/src/evals.rs
+++ b/src-tauri/src/evals.rs
@@ -320,6 +320,7 @@ pub(crate) async fn seed_docs(
             .enumerate()
             .map(|(j, c)| (format!("{id_prefix}c{i}-{j}"), j as i32, c.text.clone()))
             .collect();
+        let contexts: Vec<String> = chunks.iter().map(|c| c.context.clone()).collect();
         let source = crate::models::Source {
             image_url: String::new(),
             author: String::new(),
@@ -341,7 +342,7 @@ pub(crate) async fn seed_docs(
             fetched_at: 0,
             fetch_failures: 0,
         };
-        db.insert_source(&source, &tuples, &embeddings)
+        db.insert_source_ctx(&source, &tuples, &contexts, &embeddings)
             .await
             .expect("store fixture");
     }
@@ -524,6 +525,7 @@ async fn eval_rerank_surfaces_buried_hit() {
                 "Entry {i}: tomatoes prefer full sun and weekly deep watering in raised beds."
             ),
             distance: 0.1 + i as f32 * 0.01,
+            section: String::new(),
         })
         .collect();
     // The only passage that answers the question, buried at rank 10.
@@ -542,6 +544,7 @@ async fn eval_rerank_surfaces_buried_hit() {
                       for wind and hail damage."
                 .into(),
             distance: 0.3,
+            section: String::new(),
         },
     );
 
@@ -650,6 +653,7 @@ async fn eval_chat_grounding_across_models() {
             ordinal: i as i32,
             snippet: body.to_string(),
             distance: 0.1,
+            section: String::new(),
         })
         .collect();
     let sources: Vec<(String, String, String)> = corpus

--- a/src-tauri/src/examples.rs
+++ b/src-tauri/src/examples.rs
@@ -1018,6 +1018,8 @@ struct Prepared {
     url: String,
     text: String,
     chunks: Vec<(String, i32, String)>,
+    /// "title › chain" per chunk, stored beside it for the context leg.
+    contexts: Vec<String>,
     embeddings: Vec<Vec<f32>>,
     /// "text" for pasted bodies; "url" for the curated web sources, whose
     /// Gallery card then leads with `image_url`.
@@ -1041,11 +1043,13 @@ async fn prepare_source(
         .enumerate()
         .map(|(i, c)| (new_id(), i as i32, c.text.clone()))
         .collect();
+    let contexts: Vec<String> = chunks.iter().map(|c| c.context.clone()).collect();
     Ok(Prepared {
         title: extracted.title,
         url: url.to_string(),
         text: extracted.text,
         chunks: tuples,
+        contexts,
         embeddings,
         source_type: "text",
         image_url: String::new(),
@@ -1085,7 +1089,8 @@ async fn insert_prepared(db: &Db, notebook_id: &str, ts: i64, p: Prepared) -> an
         fetched_at: ts,
         fetch_failures: 0,
     };
-    db.insert_source(&source, &p.chunks, &p.embeddings).await
+    db.insert_source_ctx(&source, &p.chunks, &p.contexts, &p.embeddings)
+        .await
 }
 
 async fn seed_notebook(

--- a/src-tauri/src/fidelity.rs
+++ b/src-tauri/src/fidelity.rs
@@ -812,6 +812,7 @@ async fn ingest_into(ai: &Ai, db: &Db, notebook_id: &str, path: &Path) -> Source
         .enumerate()
         .map(|(i, c)| (format!("{notebook_id}-c{i}"), i as i32, c.text.clone()))
         .collect();
+    let contexts: Vec<String> = chunks.iter().map(|c| c.context.clone()).collect();
     let source = Source {
         id: format!("{notebook_id}-src"),
         notebook_id: notebook_id.to_string(),
@@ -833,7 +834,7 @@ async fn ingest_into(ai: &Ai, db: &Db, notebook_id: &str, path: &Path) -> Source
         fetched_at: 0,
         fetch_failures: 0,
     };
-    db.insert_source(&source, &tuples, &embeddings)
+    db.insert_source_ctx(&source, &tuples, &contexts, &embeddings)
         .await
         .expect("store fixture");
     source

--- a/src-tauri/src/fixtures.rs
+++ b/src-tauri/src/fixtures.rs
@@ -159,6 +159,7 @@ async fn seed(ai: &Ai, db: &Db, notebook_id: &str, sources: usize) -> usize {
 
     let mut rows: Vec<(String, String, i32, String)> = Vec::new();
     let mut inputs: Vec<String> = Vec::new();
+    let mut ctxs: Vec<String> = Vec::new();
     let mut written = 0usize;
     for i in 0..sources {
         let (title, body) = document(i);
@@ -173,6 +174,7 @@ async fn seed(ai: &Ai, db: &Db, notebook_id: &str, sources: usize) -> usize {
                 c.text.clone(),
             ));
             inputs.push(c.embed_text.clone());
+            ctxs.push(c.context.clone());
         }
         // Source rows go in one at a time: db.rs keeps its bulk `add_batch`
         // private and only chunks have a public bulk path. One commit per
@@ -206,11 +208,11 @@ async fn seed(ai: &Ai, db: &Db, notebook_id: &str, sources: usize) -> usize {
         .expect("store fixture source");
 
         if rows.len() >= SEED_BATCH {
-            written += flush_rows(ai, db, notebook_id, &mut rows, &mut inputs).await;
+            written += flush_rows(ai, db, notebook_id, &mut rows, &mut inputs, &mut ctxs).await;
             eprintln!("fixtures: seeded {}/{sources} sources", i + 1);
         }
     }
-    written += flush_rows(ai, db, notebook_id, &mut rows, &mut inputs).await;
+    written += flush_rows(ai, db, notebook_id, &mut rows, &mut inputs, &mut ctxs).await;
 
     db.defer_fts(false);
     db.flush_fts().await.expect("flush fixture fts");
@@ -227,17 +229,19 @@ async fn flush_rows(
     notebook_id: &str,
     rows: &mut Vec<(String, String, i32, String)>,
     inputs: &mut Vec<String>,
+    ctxs: &mut Vec<String>,
 ) -> usize {
     if rows.is_empty() {
         return 0;
     }
     let embeddings = ai.embed(inputs).await.expect("embed fixture batch");
-    db.add_chunk_rows(notebook_id, rows, &embeddings)
+    db.add_chunk_rows(notebook_id, rows, ctxs, &embeddings)
         .await
         .expect("store fixture chunks");
     let n = rows.len();
     rows.clear();
     inputs.clear();
+    ctxs.clear();
     n
 }
 

--- a/src-tauri/src/gist.rs
+++ b/src-tauri/src/gist.rs
@@ -525,8 +525,15 @@ async fn enrich_source(
     }
 
     let embeddings = ai.embed(&inputs).await?;
-    db.reembed_source_chunks(&source.notebook_id, &source.id, &rows, &embeddings)
-        .await?;
+    let contexts: Vec<String> = chunks.iter().map(|c| c.context.clone()).collect();
+    db.reembed_source_chunks(
+        &source.notebook_id,
+        &source.id,
+        &rows,
+        &contexts,
+        &embeddings,
+    )
+    .await?;
     Ok(EnrichOutcome::Enriched)
 }
 

--- a/src-tauri/src/gist.rs
+++ b/src-tauri/src/gist.rs
@@ -35,7 +35,7 @@ use std::sync::Mutex;
 use anyhow::Result;
 
 use crate::ai::Ai;
-use crate::db::{Db, GistRow, GIST_CHUNK_PREFIX};
+use crate::db::{Db, GistRow, SectionGist, GIST_CHUNK_PREFIX};
 use crate::inference::{ChatTurn, Role};
 use crate::models::Source;
 
@@ -316,6 +316,222 @@ pub async fn ensure_gists(db: &Db, ai: &Ai) -> Result<(usize, usize)> {
         written += 1;
     }
     Ok((written, deleted))
+}
+
+// ---- Section summaries (docs/RFC-outline-index.md Phase 2) ---------------
+
+/// A source needs at least this many top-level sections to earn section
+/// summaries — below it, the source gist already says what each part is.
+const SECTION_MIN_SECTIONS: usize = 3;
+/// And at most this many are summarized: a 300-page manual with 14
+/// chapters is 14 calls; an outline with hundreds of h1s is a table of
+/// contents, and the source gist has to do.
+const SECTION_MAX_SECTIONS: usize = 40;
+/// How much of a section the summarizer reads.
+const SECTION_HEAD_CHARS: usize = 3000;
+/// Summaries written per sweep pass, matching the gist budget's restraint.
+const SECTION_SWEEP_BUDGET: usize = 6;
+const SECTION_MIN_CHARS: usize = 40;
+const SECTION_MAX_CHARS: usize = 700;
+/// Where the per-source stamp lives: source id → hash of its section
+/// spans and headings, so a re-chunk (or a new h1) reopens the source and
+/// an unchanged one costs nothing.
+const SECTION_STATE_FILE: &str = "section-gists.json";
+
+/// One top-level section of a stored source, from its chunk rows: a `# `
+/// heading chunk opens a section that runs to the next one.
+pub struct Section {
+    pub heading: String,
+    pub start: i32,
+    pub end: i32,
+    pub text: String,
+}
+
+/// The top-level sections of a source's stored chunks (ordinal order).
+/// Heading chunks keep their heading line verbatim, so the outline is a
+/// scan, no stored tree needed.
+pub fn sections_of(rows: &[(String, i32, String)]) -> Vec<Section> {
+    let mut rows: Vec<&(String, i32, String)> = rows.iter().collect();
+    rows.sort_by_key(|r| r.1);
+    let mut out: Vec<Section> = Vec::new();
+    for (_, ord, text) in rows {
+        let first = text.lines().next().unwrap_or("");
+        if let Some(h) = first.strip_prefix("# ") {
+            out.push(Section {
+                heading: h.trim().to_string(),
+                start: *ord,
+                end: *ord,
+                text: text.clone(),
+            });
+        } else if let Some(cur) = out.last_mut() {
+            cur.end = *ord;
+            if cur.text.len() < SECTION_HEAD_CHARS {
+                cur.text.push_str("\n\n");
+                cur.text.push_str(text);
+            }
+        }
+    }
+    out
+}
+
+fn section_stamp(sections: &[Section]) -> i32 {
+    let key: String = sections
+        .iter()
+        .map(|s| format!("{}:{}-{}", s.heading, s.start, s.end))
+        .collect::<Vec<_>>()
+        .join("\n");
+    content_hash(&key)
+}
+
+fn build_section_messages(title: &str, heading: &str, text: &str) -> Vec<ChatTurn> {
+    let head: String = text.chars().take(SECTION_HEAD_CHARS).collect();
+    vec![
+        ChatTurn::system(
+            "You write the index entry for one section of a document, for a reader who \
+             will search for it by whatever words they know. Reply with exactly two \
+             lines. Line 1: one or two plain sentences — what thing the section is about, \
+             then what it covers about it (the specific figures, procedures, and parts it \
+             gives). Line 2: \"Also called:\" followed by up to five other names a reader \
+             might type for that thing — everyday words, abbreviations, the common name \
+             for a technical one, the technical name for a common one, and for a city \
+             its country. Use only what the section says or what the name plainly means. \
+             Nothing else.",
+        ),
+        ChatTurn::user(format!(
+            "Document: {title}\nSection: {heading}\n\n---\n{head}"
+        )),
+    ]
+}
+
+/// Accept a section summary: bounded, and not the model narrating itself.
+fn section_gate(candidate: &str) -> Option<String> {
+    let trimmed = candidate.trim().trim_matches('"').trim();
+    let n = trimmed.chars().count();
+    if !(SECTION_MIN_CHARS..=SECTION_MAX_CHARS).contains(&n) {
+        return None;
+    }
+    let lower = trimmed.to_lowercase();
+    if lower.starts_with("i ") || lower.starts_with("as an ai") || lower.contains("cannot") {
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+fn section_state_path(dir: &Path) -> std::path::PathBuf {
+    dir.join(SECTION_STATE_FILE)
+}
+
+fn load_section_state(dir: &Path) -> HashMap<String, i32> {
+    std::fs::read_to_string(section_state_path(dir))
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+fn save_section_state(dir: &Path, state: &HashMap<String, i32>) {
+    let write = || -> std::io::Result<()> {
+        std::fs::create_dir_all(dir)?;
+        std::fs::write(
+            section_state_path(dir),
+            serde_json::to_vec(state).unwrap_or_default(),
+        )
+    };
+    if let Err(err) = write() {
+        crate::note!("sections: marker write failed: {err}");
+    }
+}
+
+/// Write section summaries for long structured sources that lack them
+/// (docs/RFC-outline-index.md Phase 2). One Small call per top-level
+/// section, `SECTION_SWEEP_BUDGET` sources per pass; a source is stamped
+/// once its rows land and reopened only when its sections change.
+/// Returns how many sources were summarized this pass.
+pub async fn ensure_section_gists(db: &Db, ai: &Ai) -> Result<usize> {
+    let dir = ai.data_dir().to_path_buf();
+    let mut state = load_section_state(&dir);
+    let mut dirty = false;
+    let mut written = 0usize;
+    'outer: for nb in db.list_notebooks().await? {
+        for s in db.list_sources(&nb.id).await? {
+            if written >= SECTION_SWEEP_BUDGET {
+                break 'outer;
+            }
+            if s.source_type == "code" || s.chunk_count < SECTION_MIN_SECTIONS as i64 {
+                continue;
+            }
+            let rows = db.source_chunk_rows(&s.id).await?;
+            let sections = sections_of(&rows);
+            if sections.len() < SECTION_MIN_SECTIONS || sections.len() > SECTION_MAX_SECTIONS {
+                continue;
+            }
+            let stamp = section_stamp(&sections);
+            if state.get(&s.id) == Some(&stamp) {
+                continue;
+            }
+            let mut gists: Vec<SectionGist> = Vec::with_capacity(sections.len());
+            for sec in &sections {
+                let messages = build_section_messages(&s.title, &sec.heading, &sec.text);
+                let reply = match ai.chat_role(Role::Small, &messages).await {
+                    Ok(out) => {
+                        crate::freshness::record_outcome(&out);
+                        out.text
+                    }
+                    Err(err) => {
+                        crate::note!("sections: Small role failed for \"{}\": {err:#}", s.title);
+                        #[cfg(test)]
+                        eprintln!("  sections: Small role failed: {err:#}");
+                        break 'outer;
+                    }
+                };
+                #[cfg(test)]
+                if std::env::var("ALCHEMY_TRACE_SECTIONS").is_ok() {
+                    eprintln!(
+                        "  [{}] gate {}: {}",
+                        sec.heading,
+                        if section_gate(&reply).is_some() {
+                            "ok"
+                        } else {
+                            "REFUSED"
+                        },
+                        reply
+                            .trim()
+                            .replace('\n', " / ")
+                            .chars()
+                            .take(220)
+                            .collect::<String>()
+                    );
+                }
+                if let Some(summary) = section_gate(&reply) {
+                    gists.push(SectionGist {
+                        start: sec.start,
+                        end: sec.end,
+                        chain: format!("{} › {}", s.title, sec.heading),
+                        summary,
+                    });
+                }
+            }
+            // Stamp even when the gate refused everything: the sections were
+            // read, and only a change to them earns another pass.
+            state.insert(s.id.clone(), stamp);
+            dirty = true;
+            if gists.is_empty() {
+                continue;
+            }
+            let inputs: Vec<String> = gists
+                .iter()
+                .map(|g| format!("[{} — section]\n{}", g.chain, g.summary))
+                .collect();
+            let embeddings = ai.embed(&inputs).await?;
+            db.replace_section_rows(&nb.id, &s.id, &gists, &embeddings)
+                .await?;
+            written += 1;
+            crate::note!("sections: {} summaries for \"{}\"", gists.len(), s.title);
+        }
+    }
+    if dirty {
+        save_section_state(&dir, &state);
+    }
+    Ok(written)
 }
 
 // ---- Phase 2: distilled embeddings for low-density page captures ----------
@@ -650,34 +866,58 @@ pub fn spawn_sweep(db: std::sync::Arc<Db>, ai: Ai) {
                 // what's left on chunk enrichment. Tags come first: they are
                 // one cheap call per source and they show up in the UI, where
                 // enrichment only ever shows up in retrieval quality.
-                Ok((0, 0)) => match ensure_tags(&db, &ai).await {
+                Ok((0, 0)) => match ensure_section_gists(&db, &ai).await {
+                    // Section summaries ride right behind gists: same
+                    // budget shape, and the outline they index is what
+                    // long documents are retrieved by.
                     Ok(n) if n > 0 => {
                         tokio::time::sleep(std::time::Duration::from_millis(250)).await;
                     }
-                    // Tags converged. Offer registry cards once per notebook
-                    // per run (commands::registry::suggest_cards) — it reads
-                    // the gists this sweep just settled, so it comes after
-                    // them and before enrichment, same reasoning as tags:
-                    // one cheap call, and it shows up in the UI.
-                    Ok(_) => match crate::commands::suggest_cards(&db, &ai).await {
+                    Err(err) => {
+                        crate::diagnostics::error(
+                            "sweep",
+                            format!("section sweep failed: {err:#}"),
+                        );
+                        break;
+                    }
+                    Ok(_) => match ensure_tags(&db, &ai).await {
                         Ok(n) if n > 0 => {
                             tokio::time::sleep(std::time::Duration::from_millis(250)).await;
                         }
-                        // Chunk enrichment is the one stage that never
-                        // converges quickly — one small-model call per
-                        // chunk across the corpus — so it runs in quiet
-                        // hours only. The day's sweeps stop here, converged
-                        // on everything a person can see.
-                        Ok(_) if !crate::freshness::is_quiet_hours(crate::commands::now()) => break,
-                        Ok(_) => match ensure_enrichment(&db, &ai).await {
-                            Ok(0) => break,
-                            Ok(_) => {
+                        // Tags converged. Offer registry cards once per notebook
+                        // per run (commands::registry::suggest_cards) — it reads
+                        // the gists this sweep just settled, so it comes after
+                        // them and before enrichment, same reasoning as tags:
+                        // one cheap call, and it shows up in the UI.
+                        Ok(_) => match crate::commands::suggest_cards(&db, &ai).await {
+                            Ok(n) if n > 0 => {
                                 tokio::time::sleep(std::time::Duration::from_millis(250)).await;
                             }
+                            // Chunk enrichment is the one stage that never
+                            // converges quickly — one small-model call per
+                            // chunk across the corpus — so it runs in quiet
+                            // hours only. The day's sweeps stop here, converged
+                            // on everything a person can see.
+                            Ok(_) if !crate::freshness::is_quiet_hours(crate::commands::now()) => {
+                                break
+                            }
+                            Ok(_) => match ensure_enrichment(&db, &ai).await {
+                                Ok(0) => break,
+                                Ok(_) => {
+                                    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                                }
+                                Err(err) => {
+                                    crate::diagnostics::error(
+                                        "sweep",
+                                        format!("enrichment sweep failed: {err:#}"),
+                                    );
+                                    break;
+                                }
+                            },
                             Err(err) => {
                                 crate::diagnostics::error(
                                     "sweep",
-                                    format!("enrichment sweep failed: {err:#}"),
+                                    format!("card suggestion failed: {err:#}"),
                                 );
                                 break;
                             }
@@ -685,15 +925,11 @@ pub fn spawn_sweep(db: std::sync::Arc<Db>, ai: Ai) {
                         Err(err) => {
                             crate::diagnostics::error(
                                 "sweep",
-                                format!("card suggestion failed: {err:#}"),
+                                format!("tag sweep failed: {err:#}"),
                             );
                             break;
                         }
                     },
-                    Err(err) => {
-                        crate::diagnostics::error("sweep", format!("tag sweep failed: {err:#}"));
-                        break;
-                    }
                 },
                 Ok(_) => {
                     // Yield between batches so imports and chat stay snappy.
@@ -824,6 +1060,72 @@ fn gate_tags(reply: &str, haystack: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    /// Sections are the `# ` headings in ordinal order; each runs to the
+    /// next one, and the section text is its chunks joined (capped).
+    #[test]
+    fn sections_follow_top_level_headings() {
+        let rows = vec![
+            (
+                "c0".to_string(),
+                0,
+                "Preamble before any heading.".to_string(),
+            ),
+            (
+                "c1".to_string(),
+                1,
+                "# Chapter 1: Hydraulics\n\nabout".to_string(),
+            ),
+            (
+                "c2".to_string(),
+                2,
+                "## Torque Values\n\ntorque".to_string(),
+            ),
+            (
+                "c3".to_string(),
+                3,
+                "# Chapter 2: Landing Gear\n\nabout".to_string(),
+            ),
+            ("c4".to_string(), 4, "## Parts\n\nFM-1210".to_string()),
+        ];
+        let secs = super::sections_of(&rows);
+        let shape: Vec<(&str, i32, i32)> = secs
+            .iter()
+            .map(|s| (s.heading.as_str(), s.start, s.end))
+            .collect();
+        assert_eq!(
+            shape,
+            [
+                ("Chapter 1: Hydraulics", 1, 2),
+                ("Chapter 2: Landing Gear", 3, 4)
+            ]
+        );
+        assert!(
+            secs[1].text.contains("FM-1210"),
+            "section text joins its chunks"
+        );
+        // Reordered rows land the same outline.
+        let mut shuffled = rows.clone();
+        shuffled.reverse();
+        assert_eq!(super::sections_of(&shuffled).len(), 2);
+        // Stamp follows headings and spans only.
+        assert_eq!(
+            super::section_stamp(&secs),
+            super::section_stamp(&super::sections_of(&shuffled))
+        );
+    }
+
+    /// The gate keeps a bounded plain summary and drops the model talking
+    /// about itself.
+    #[test]
+    fn section_gate_bounds_and_refuses_narration() {
+        let ok = "Landing gear: the undercarriage that carries the aircraft on the ground. Also called: undercarriage, wheels.";
+        assert_eq!(super::section_gate(ok).as_deref(), Some(ok));
+        assert!(super::section_gate("Too short.").is_none());
+        assert!(super::section_gate("I cannot summarize this section for you.").is_none());
+        let long = "x".repeat(super::SECTION_MAX_CHARS + 1);
+        assert!(super::section_gate(&long).is_none());
+    }
+
     use super::*;
 
     /// The gate is the whole safety story: a tag the document cannot vouch

--- a/src-tauri/src/inference/mod.rs
+++ b/src-tauri/src/inference/mod.rs
@@ -215,6 +215,13 @@ pub struct OllamaConfig {
     /// for 12,000+ tokens — ~600s — with every other request queued behind
     /// it. A cap turns that failure mode into a ~20s worst case.
     pub num_predict: Option<u32>,
+    /// Thinking switch sent as Ollama's `think` when set; it wins over
+    /// `effort`. The Small engine sends `Some(false)`: its calls are short by
+    /// contract, and a thinking model (gemma4) spent the whole `num_predict`
+    /// cap on hidden reasoning and returned empty text — ~35s per section
+    /// summary, nothing to show — where the same prompt with thinking off
+    /// answered in under a second. Models without a thinking mode ignore it.
+    pub think: Option<bool>,
 }
 
 /// Reasoning-effort levels for the two engines that take it as a request

--- a/src-tauri/src/inference/ollama.rs
+++ b/src-tauri/src/inference/ollama.rs
@@ -208,6 +208,9 @@ impl Ollama {
     /// Both absent unless set — the server defaults are what every other
     /// request expects.
     fn apply_keep_alive(&self, body: &mut serde_json::Value) {
+        if let Some(t) = self.config.think {
+            body["think"] = json!(t);
+        }
         if let Some(ka) = &self.config.keep_alive {
             body["keep_alive"] = json!(ka);
         }
@@ -408,5 +411,29 @@ impl Ollama {
             .context("ollama ps request failed")?;
         let parsed: PsResponse = resp.json().await.context("invalid ps response")?;
         Ok(parsed.models.into_iter().map(|m| m.name).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The Small engine's `think: false` reaches the request body and wins
+    /// over a reasoning effort; an engine with no opinion sends nothing.
+    #[test]
+    fn think_switch_reaches_the_body() {
+        let small = Ollama::new(OllamaConfig {
+            think: Some(false),
+            effort: "low".into(),
+            ..Default::default()
+        });
+        let mut body = json!({});
+        small.apply_keep_alive(&mut body);
+        assert_eq!(body["think"], json!(false));
+
+        let plain = Ollama::new(OllamaConfig::default());
+        let mut body = json!({});
+        plain.apply_keep_alive(&mut body);
+        assert!(body.get("think").is_none());
     }
 }

--- a/src-tauri/src/ingest.rs
+++ b/src-tauri/src/ingest.rs
@@ -1246,6 +1246,10 @@ pub struct Chunk {
     /// sections; until then only the tests and the embed prefix do.
     #[cfg_attr(not(test), allow(dead_code))]
     pub section: String,
+    /// The embed prefix without its brackets — "title › chain" — stored
+    /// beside the chunk so the BM25 leg can see it (docs/RFC-outline-index.md
+    /// Phase 1.5). Display `text` stays verbatim.
+    pub context: String,
 }
 
 fn word_count(s: &str) -> usize {
@@ -1292,6 +1296,7 @@ pub fn chunk_text(title: &str, text: &str) -> Vec<Chunk> {
             text: body,
             embed_text,
             section,
+            context: ctx,
         }
     };
 
@@ -1585,6 +1590,7 @@ pub fn chunk_code(context: &str, text: &str) -> Vec<Chunk> {
             text: body,
             embed_text,
             section: String::new(),
+            context: ctx.to_string(),
         }
     };
 
@@ -2330,6 +2336,7 @@ mod tests {
             text: body.to_string(),
             embed_text: format!("[{title}]\n{body}"),
             section: String::new(),
+            context: title.to_string(),
         }
     }
 
@@ -2355,6 +2362,7 @@ mod tests {
             text: "Overview".into(),
             embed_text: "[Acme Blog › Docs]\nOverview".into(),
             section: "Docs".into(),
+            context: "Acme Blog › Docs".into(),
         }));
         // Long real passage never trips the gate.
         assert!(!is_boilerplate_chunk(&page_chunk(

--- a/src-tauri/src/ingest.rs
+++ b/src-tauri/src/ingest.rs
@@ -1240,6 +1240,12 @@ pub fn extract_pasted(title: &str, text: &str) -> Result<Extracted> {
 pub struct Chunk {
     pub text: String,
     pub embed_text: String,
+    /// The heading chain this chunk sits under, outermost first, joined
+    /// with " › " — empty above the first heading. Phase 2 of the outline
+    /// index (docs/RFC-outline-index.md) reads it to group chunks into
+    /// sections; until then only the tests and the embed prefix do.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub section: String,
 }
 
 fn word_count(s: &str) -> usize {
@@ -1250,15 +1256,29 @@ fn word_count(s: &str) -> usize {
 /// packed up to ~chunk_words(), markdown-style headings start a new chunk and
 /// become section context, and oversized paragraphs fall back to sentence
 /// (then word-window) splitting.
+///
+/// Section context is the heading *chain*, not the last heading seen
+/// (docs/RFC-outline-index.md): a chunk under `## Torque Values` inside
+/// `# Chapter 2: Landing Gear` embeds as `[Manual › Chapter 2: Landing Gear
+/// › Torque Values]`. In a manual whose every chapter repeats the same
+/// subsections, the chapter name is the only token that tells look-alike
+/// chunks apart, and the old one-level context dropped it the moment the
+/// subsection heading arrived. A deeper heading pushes; a shallower or
+/// equal one pops back to its level first.
 pub fn chunk_text(title: &str, text: &str) -> Vec<Chunk> {
-    let make = |heading: &str, body: &str| -> Chunk {
+    let make = |path: &[(usize, String)], body: &str| -> Chunk {
         let mut ctx = title.trim().to_string();
-        if !heading.is_empty() {
+        for (_, heading) in path {
             if !ctx.is_empty() {
                 ctx.push_str(" › ");
             }
             ctx.push_str(heading);
         }
+        let section = path
+            .iter()
+            .map(|(_, h)| h.as_str())
+            .collect::<Vec<_>>()
+            .join(" › ");
         let body = body.trim().to_string();
         // Embed text de-brackets [[wikilinks]] so retrieval reads prose;
         // display text keeps them for the reader to render as links.
@@ -1271,14 +1291,16 @@ pub fn chunk_text(title: &str, text: &str) -> Vec<Chunk> {
         Chunk {
             text: body,
             embed_text,
+            section,
         }
     };
 
     let mut chunks: Vec<Chunk> = Vec::new();
-    let mut heading = String::new(); // current section heading
+    // The open heading chain, outermost first: (level, heading).
+    let mut path: Vec<(usize, String)> = Vec::new();
     let mut cur = String::new(); // paragraphs packed into the pending chunk
     let mut cur_words = 0usize;
-    let mut cur_heading = String::new(); // section the pending chunk started in
+    let mut cur_path: Vec<(usize, String)> = Vec::new(); // chain the pending chunk started in
 
     for para in text.split("\n\n") {
         let p = para.trim();
@@ -1291,11 +1313,17 @@ pub fn chunk_text(title: &str, text: &str) -> Vec<Chunk> {
         // markers our extractors emit): new section, new chunk.
         if p.lines().count() == 1 && p.starts_with('#') {
             if !cur.is_empty() {
-                chunks.push(make(&cur_heading, &cur));
+                chunks.push(make(&cur_path, &cur));
                 cur.clear();
             }
-            heading = p.trim_start_matches('#').trim().to_string();
-            cur_heading = heading.clone();
+            let level = p.chars().take_while(|c| *c == '#').count();
+            let heading = p.trim_start_matches('#').trim().to_string();
+            // A heading closes every open section at its level or deeper.
+            while path.last().is_some_and(|(l, _)| *l >= level) {
+                path.pop();
+            }
+            path.push((level, heading));
+            cur_path = path.clone();
             cur.push_str(p); // the heading line stays in the chunk verbatim
             cur_words = words;
             continue;
@@ -1305,24 +1333,24 @@ pub fn chunk_text(title: &str, text: &str) -> Vec<Chunk> {
         // and split it by sentences (word windows as a last resort).
         if words > chunk_words() {
             if !cur.is_empty() {
-                chunks.push(make(&cur_heading, &cur));
+                chunks.push(make(&cur_path, &cur));
                 cur.clear();
                 cur_words = 0;
             }
             for piece in split_oversized(p) {
-                chunks.push(make(&heading, &piece));
+                chunks.push(make(&path, &piece));
             }
-            cur_heading = heading.clone();
+            cur_path = path.clone();
             continue;
         }
 
         if cur_words + words > chunk_words() && !cur.is_empty() {
-            chunks.push(make(&cur_heading, &cur));
+            chunks.push(make(&cur_path, &cur));
             cur.clear();
             cur_words = 0;
         }
         if cur.is_empty() {
-            cur_heading = heading.clone();
+            cur_path = path.clone();
         } else {
             cur.push_str("\n\n");
         }
@@ -1330,7 +1358,7 @@ pub fn chunk_text(title: &str, text: &str) -> Vec<Chunk> {
         cur_words += words;
     }
     if !cur.trim().is_empty() {
-        chunks.push(make(&cur_heading, &cur));
+        chunks.push(make(&cur_path, &cur));
     }
     chunks
 }
@@ -1556,6 +1584,7 @@ pub fn chunk_code(context: &str, text: &str) -> Vec<Chunk> {
         Chunk {
             text: body,
             embed_text,
+            section: String::new(),
         }
     };
 
@@ -2300,6 +2329,7 @@ mod tests {
         Chunk {
             text: body.to_string(),
             embed_text: format!("[{title}]\n{body}"),
+            section: String::new(),
         }
     }
 
@@ -2324,6 +2354,7 @@ mod tests {
         assert!(!is_boilerplate_chunk(&Chunk {
             text: "Overview".into(),
             embed_text: "[Acme Blog › Docs]\nOverview".into(),
+            section: "Docs".into(),
         }));
         // Long real passage never trips the gate.
         assert!(!is_boilerplate_chunk(&page_chunk(
@@ -2483,6 +2514,40 @@ mod tests {
         assert_eq!(chunks.len(), 2);
         assert!(chunks[1].text.starts_with("# Setup"));
         assert!(chunks[1].embed_text.starts_with("[Guide › Setup]\n"));
+        assert_eq!(chunks[0].section, "");
+        assert_eq!(chunks[1].section, "Setup");
+
+        // The context is the heading CHAIN: a subsection keeps its chapter,
+        // a sibling chapter pops back, a deeper level pushes.
+        let manual = "# Chapter 1: Hydraulics\n\nabout hydraulics.\n\n\
+             ## Torque Values\n\ntorque the bolts.\n\n\
+             ### Notes\n\nlubricate first.\n\n\
+             ## Parts\n\norder FM-1102.\n\n\
+             # Chapter 2: Landing Gear\n\nabout the gear.\n\n\
+             ## Torque Values\n\ntorque the hinge bolts.";
+        let sections: Vec<&str> = chunk_text("Manual", manual)
+            .iter()
+            .map(|c| c.section.as_str())
+            .map(|s| Box::leak(s.to_string().into_boxed_str()) as &str)
+            .collect();
+        assert_eq!(
+            sections,
+            [
+                "Chapter 1: Hydraulics",
+                "Chapter 1: Hydraulics › Torque Values",
+                "Chapter 1: Hydraulics › Torque Values › Notes",
+                "Chapter 1: Hydraulics › Parts",
+                "Chapter 2: Landing Gear",
+                "Chapter 2: Landing Gear › Torque Values",
+            ]
+        );
+        let last = chunk_text("Manual", manual).pop().unwrap();
+        assert!(
+            last.embed_text
+                .starts_with("[Manual › Chapter 2: Landing Gear › Torque Values]\n"),
+            "{}",
+            last.embed_text
+        );
 
         // An oversized paragraph splits at sentence boundaries.
         let long: String = (0..600).map(|i| format!("word{i}. ")).collect();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,6 +33,7 @@ mod menu;
 mod models;
 mod notion;
 mod outline;
+mod outline_index;
 mod pdf;
 mod pptx;
 mod rag;

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -428,6 +428,11 @@ pub struct Citation {
     /// the content hash the gist was distilled from, not a position.
     #[serde(default)]
     pub gist: bool,
+    /// Where the passage sits: "title › chapter › section" from the
+    /// chunk's stored context (docs/RFC-outline-index.md). Empty for rows
+    /// indexed before contexts were stored, and for notes.
+    #[serde(default)]
+    pub section: String,
     /// True when this row is the user's own annotation on a source
     /// (docs/RFC-source-tags.md) — stored under `snote:<source_id>`.
     /// `source_id` still names the annotated source. Prompts label these

--- a/src-tauri/src/outline_index.rs
+++ b/src-tauri/src/outline_index.rs
@@ -1,0 +1,320 @@
+//! Outline-guided retrieval as silent escalation (docs/RFC-outline-index.md
+//! Phase 3). Hybrid search stays the fast default. When its result is thin,
+//! or lands on look-alike sections of a long structured source, the Small
+//! role reads the notebook's outline — one line per section, the summary
+//! Phase 2 wrote — picks up to two sections, and their best passages join
+//! the pool ahead of the rerank. One extra small-model call, invisible to
+//! the user, traced as `outlinePick` on the retrieval line.
+
+use anyhow::Result;
+
+use crate::ai::{Ai, ChatTurn};
+use crate::db::{Db, OutlineEntry};
+use crate::inference::Role;
+use crate::models::Citation;
+
+/// Outline lines the model reads at most — a notebook with more sections
+/// than this keeps the closest by source title order; long enough for a
+/// couple of manuals, short enough to answer in one breath.
+const MAX_OUTLINE_LINES: usize = 80;
+/// Sections the model may pick.
+const MAX_PICKS: usize = 2;
+/// Passages pulled per picked section.
+const PASSAGES_PER_PICK: usize = 2;
+/// The flat search is "thin" below this — the same bar `rag::build_chat_messages`
+/// uses to ask a clarifying question instead of guessing.
+const THIN_CITATIONS: usize = 3;
+const THIN_CHARS: usize = 700;
+
+/// Does this pool call for the outline? Thin, or the top hits are the same
+/// subsection of different chapters (their chains end alike) — the exact
+/// shape of a look-alike miss in a structured document. Never when the
+/// question quotes an identifier and the flat leader carries it verbatim:
+/// a literal match is stronger evidence than a summary can give, and an
+/// outline guess against it measured exact-kind MRR 1.00 → 0.33.
+pub fn should_escalate(question: &str, pool: &[Citation]) -> bool {
+    if let Some(top) = pool.first() {
+        if literal_hit(question, &top.snippet) {
+            return false;
+        }
+    }
+    let chars: usize = pool.iter().map(|c| c.snippet.chars().count()).sum();
+    if pool.len() < THIN_CITATIONS || chars < THIN_CHARS {
+        return true;
+    }
+    let mut tails: std::collections::HashMap<(&str, &str), usize> =
+        std::collections::HashMap::new();
+    for c in pool.iter().take(5) {
+        if c.section.is_empty() || !c.note_id.is_empty() {
+            continue;
+        }
+        let Some((_, tail)) = c.section.rsplit_once(" › ") else {
+            continue;
+        };
+        *tails.entry((c.source_id.as_str(), tail)).or_default() += 1;
+    }
+    tails.values().any(|n| *n >= 2)
+}
+
+/// Does the question quote an identifier — a token with a digit in it,
+/// `FM-2041`, `SK-1305`, `v2.3`, `10.0.0.1` — that the snippet contains
+/// verbatim?
+fn literal_hit(question: &str, snippet: &str) -> bool {
+    let hay = snippet.to_lowercase();
+    question
+        .split(|c: char| {
+            c.is_whitespace() || matches!(c, ',' | ';' | '?' | '!' | '(' | ')' | '"' | '\'')
+        })
+        .map(|t| t.trim_matches(|c: char| !c.is_alphanumeric()))
+        .filter(|t| t.len() >= 3 && t.chars().any(|c| c.is_ascii_digit()))
+        .any(|t| hay.contains(&t.to_lowercase()))
+}
+
+fn build_messages(question: &str, outline: &[OutlineEntry]) -> Vec<ChatTurn> {
+    let mut lines = String::new();
+    for (i, e) in outline.iter().enumerate() {
+        let summary: String = e
+            .summary
+            .lines()
+            .next()
+            .unwrap_or("")
+            .chars()
+            .take(220)
+            .collect();
+        lines.push_str(&format!("{}. {} — {}\n", i + 1, e.chain, summary));
+    }
+    vec![
+        ChatTurn::system(
+            "You are choosing where to read in a document collection. Given a question \
+             and a numbered outline (one line per section, with a one-line summary), reply \
+             with the numbers of the sections most likely to contain the answer — at most \
+             two, most likely first, comma-separated — or the word NONE if no section \
+             fits. Numbers only, nothing else.",
+        ),
+        ChatTurn::user(format!("Question: {question}\n\nOutline:\n{lines}")),
+    ]
+}
+
+/// A reply naming more sections than this has no opinion — bonsai answers
+/// "1,2,3,…,14" when the summaries cannot say — and reads as NONE.
+const SHOTGUN: usize = 4;
+
+/// Parse "2, 7" / "7" / "NONE" into outline indexes (0-based), in order,
+/// at most `MAX_PICKS`; a shotgun reply yields nothing.
+pub fn parse_picks(reply: &str, len: usize) -> Vec<usize> {
+    let mut out = Vec::new();
+    for tok in reply.split(|c: char| !c.is_ascii_digit()) {
+        if tok.is_empty() {
+            continue;
+        }
+        if let Ok(n) = tok.parse::<usize>() {
+            if n >= 1 && n <= len && !out.contains(&(n - 1)) {
+                out.push(n - 1);
+            }
+        }
+    }
+    if out.len() > SHOTGUN {
+        return Vec::new();
+    }
+    out.truncate(MAX_PICKS);
+    out
+}
+
+/// The escalation. Returns what was picked ("Manual › Chapter 2 …; …") for
+/// the trace, or None when nothing fired or nothing changed. `pool` is
+/// edited in place: picked passages move to the front, duplicates behind
+/// them drop, and the length is preserved so callers' caps still hold.
+pub async fn escalate(
+    db: &Db,
+    ai: &Ai,
+    notebook_id: &str,
+    question: &str,
+    query_vec: &[f32],
+    pool: &mut Vec<Citation>,
+) -> Result<Option<String>> {
+    if !should_escalate(question, pool) {
+        return Ok(None);
+    }
+    let mut outline = db.notebook_outline(notebook_id).await?;
+    if outline.is_empty() {
+        return Ok(None);
+    }
+    outline.truncate(MAX_OUTLINE_LINES);
+    let reply = ai
+        .chat_role(Role::Small, &build_messages(question, &outline))
+        .await?;
+    crate::freshness::record_outcome(&reply);
+    let picks = parse_picks(&reply.text, outline.len());
+    if picks.is_empty() {
+        return Ok(None);
+    }
+    let mut promoted: Vec<Citation> = Vec::new();
+    let mut names: Vec<String> = Vec::new();
+    for i in picks {
+        let e = &outline[i];
+        let passages = db
+            .section_passages(
+                notebook_id,
+                query_vec,
+                question,
+                (&e.source_id, e.start, e.end),
+                PASSAGES_PER_PICK,
+            )
+            .await?;
+        if !passages.is_empty() {
+            names.push(e.chain.clone());
+        }
+        for p in passages {
+            if !promoted.iter().any(|q| q.chunk_id == p.chunk_id) {
+                promoted.push(p);
+            }
+        }
+    }
+    if promoted.is_empty() {
+        return Ok(None);
+    }
+    #[cfg(test)]
+    if std::env::var("ALCHEMY_TRACE_OUTLINE").is_ok() {
+        eprintln!(
+            "    outline: {question:?} → {:?} → {} → {:?}",
+            reply.text.trim(),
+            names.join("; "),
+            promoted
+                .iter()
+                .map(|c| c.chunk_id.as_str())
+                .collect::<Vec<_>>()
+        );
+    }
+    merge(pool, promoted);
+    Ok(Some(names.join("; ")))
+}
+
+/// Reciprocal-rank fusion of the flat pool with the outline's passages.
+/// A passage both the flat search and the outline vouch for outranks
+/// either alone; a vouched passage the flat search never surfaced lands
+/// behind the flat leader, not ahead of it. Measured against prepending
+/// the picks (bonsai): topic MRR 0.88 vs 0.82, exact 0.33 vs 0.20; gemma
+/// lands the same either way. The pool keeps its length so callers' caps
+/// still hold.
+fn merge(pool: &mut Vec<Citation>, promoted: Vec<Citation>) {
+    const K: f64 = 60.0;
+    let cap = pool.len().max(promoted.len());
+    // (score, flat rank, outline rank, citation); ranks are 1-based, usize::MAX when absent.
+    let mut scored: Vec<(f64, usize, usize, Citation)> = Vec::with_capacity(cap + 4);
+    for (i, c) in pool.drain(..).enumerate() {
+        scored.push((1.0 / (K + (i + 1) as f64), i + 1, usize::MAX, c));
+    }
+    for (j, p) in promoted.into_iter().enumerate() {
+        let bonus = 1.0 / (K + (j + 1) as f64);
+        if let Some(row) = scored.iter_mut().find(|r| r.3.chunk_id == p.chunk_id) {
+            row.0 += bonus;
+            row.2 = j + 1;
+        } else {
+            scored.push((bonus, usize::MAX, j + 1, p));
+        }
+    }
+    scored.sort_by(|a, b| {
+        b.0.partial_cmp(&a.0)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(a.1.cmp(&b.1))
+            .then(a.2.cmp(&b.2))
+    });
+    scored.truncate(cap);
+    *pool = scored.into_iter().map(|r| r.3).collect();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cite(id: &str, source: &str, section: &str, snippet: &str) -> Citation {
+        Citation {
+            chunk_id: id.into(),
+            source_id: source.into(),
+            source_title: "Doc".into(),
+            source_path: String::new(),
+            note_id: String::new(),
+            gist: false,
+            snote: false,
+            ordinal: 0,
+            snippet: snippet.into(),
+            distance: 0.0,
+            section: section.into(),
+        }
+    }
+
+    /// Thin pools escalate; so do look-alike subsections of one source;
+    /// a healthy varied pool does not.
+    #[test]
+    fn escalation_trigger() {
+        let long = "x".repeat(400);
+        let q = "hinge bolt torque";
+        assert!(
+            should_escalate(q, &[cite("a", "s", "", &long)]),
+            "thin: too few"
+        );
+        let varied: Vec<Citation> = (0..5)
+            .map(|i| {
+                cite(
+                    &format!("c{i}"),
+                    "s",
+                    &format!("Doc › Ch {i} › Part {i}"),
+                    &long,
+                )
+            })
+            .collect();
+        assert!(!should_escalate(q, &varied), "varied sections stay flat");
+        let alike: Vec<Citation> = (0..5)
+            .map(|i| {
+                cite(
+                    &format!("c{i}"),
+                    "s",
+                    &format!("Doc › Ch {i} › Torque Values"),
+                    &long,
+                )
+            })
+            .collect();
+        assert!(
+            should_escalate(q, &alike),
+            "same subsection of many chapters"
+        );
+        let mut literal = alike.clone();
+        literal[0].snippet = format!("Part FM-2041 is the hinge bolt. {long}");
+        assert!(
+            !should_escalate("what is part FM-2041?", &literal),
+            "the leader carries the quoted identifier"
+        );
+        assert!(
+            should_escalate("what is part FM-2041?", &alike),
+            "identifier quoted but not in the leader"
+        );
+    }
+
+    /// Fusion: a passage both sides vouch for leads; an outline-only
+    /// passage lands behind the flat leader; the pool keeps its length.
+    #[test]
+    fn merge_fuses_rather_than_prepends() {
+        let mut pool: Vec<Citation> = (0..5)
+            .map(|i| cite(&format!("f{i}"), "s", "", "x"))
+            .collect();
+        merge(
+            &mut pool,
+            vec![cite("o1", "s", "", "x"), cite("f3", "s", "", "x")],
+        );
+        let ids: Vec<&str> = pool.iter().map(|c| c.chunk_id.as_str()).collect();
+        assert_eq!(ids, vec!["f3", "f0", "o1", "f1", "f2"]);
+    }
+
+    #[test]
+    fn picks_parse_in_order_and_bounded() {
+        assert_eq!(parse_picks("7, 2", 10), vec![6, 1]);
+        assert_eq!(parse_picks("Sections 3 and 3 and 12", 10), vec![2]);
+        assert_eq!(parse_picks("NONE", 10), Vec::<usize>::new());
+        assert_eq!(parse_picks("1,2,3", 10), vec![0, 1]);
+        assert_eq!(
+            parse_picks("1,2,3,4,5,6,7,8,9,10,11,12,13,14", 14),
+            Vec::<usize>::new(),
+            "shotgun reads as no opinion"
+        );
+    }
+}

--- a/src-tauri/src/rag.rs
+++ b/src-tauri/src/rag.rs
@@ -1181,6 +1181,7 @@ mod tests {
             ordinal: 0,
             snippet: snippet.into(),
             distance: 0.0,
+            section: String::new(),
         }
     }
 

--- a/src-tauri/src/retrieval_eval.rs
+++ b/src-tauri/src/retrieval_eval.rs
@@ -2196,6 +2196,7 @@ async fn run_scale(ai: &crate::ai::Ai, target_chars: usize) -> (f64, f64, usize)
                 crate::ingest::Chunk {
                     text: c.text.clone(),
                     embed_text: c.embed_text.clone(),
+                    section: String::new(),
                 },
             ));
         }

--- a/src-tauri/src/retrieval_eval.rs
+++ b/src-tauri/src/retrieval_eval.rs
@@ -168,6 +168,11 @@ struct DatasetReport {
     variants: BTreeMap<String, VariantReport>,
 }
 
+/// The kinds a gate dataset reports rather than asserts: `outline` for the
+/// heading chain (RFC-outline-index phases 1–1.5), `topic` for paraphrased
+/// chapters (phases 2–3). Everything else in such a dataset is a control.
+const MEASURED_KINDS: [&str; 2] = ["outline", "topic"];
+
 /// Long structured documents for the outline gate (Reminders: "Outline
 /// eval cases before outline work"). The failure mode is a 300-page manual
 /// where every chapter repeats the same subsections — inspection interval,
@@ -758,7 +763,7 @@ async fn eval_retrieval_datasets() {
             // Its control kinds must be perfect, or the corpus didn't seed
             // the way the dataset assumes and the gate measures nothing.
             for (kind, m) in &hybrid.by_kind {
-                if kind != "outline" {
+                if !MEASURED_KINDS.contains(&kind.as_str()) {
                     assert!(
                         (m.recall_at_10 - 1.0).abs() < f64::EPSILON,
                         "{}: control kind {kind} recall@10 {:.2} — the gate corpus is not seeded as assumed",

--- a/src-tauri/src/retrieval_eval.rs
+++ b/src-tauri/src/retrieval_eval.rs
@@ -440,6 +440,97 @@ fn outline_corpus() -> Vec<(String, String)> {
     ]
 }
 
+/// Handwritten section summaries for the outline corpus (RFC-outline-index
+/// Phase 2) — what the Small role is asked to write per top-level section:
+/// what the section covers in plain words, plus the other names a reader
+/// might use for it. Handwritten so the retrieval mechanics (rows, hits,
+/// expansion) measure deterministically; the model-written variant has its
+/// own Ollama-gated eval. (document title, h1 heading, summary)
+const OUTLINE_SECTION_GISTS: &[(&str, &str, &str)] = &[
+    ("Fleet Maintenance Manual", "Chapter 1: Hydraulics", "Hydraulic system: fluid pressure for the flight-control actuators and the gear retraction circuit — pump and line fasteners, how often to inspect, part numbers. Also called: hydraulic pump, hydraulic lines."),
+    ("Fleet Maintenance Manual", "Chapter 2: Landing Gear", "Landing gear: the undercarriage that carries the aircraft on the ground and absorbs landing loads — door hinge bolts and axle nuts, inspection cadence, part numbers. Also called: undercarriage, gear legs, wheels."),
+    ("Fleet Maintenance Manual", "Chapter 3: Avionics", "Avionics: navigation, communication and flight-management computers — fastener torques, inspection cadence, parts. Also called: instruments, flight computers, radios."),
+    ("Fleet Maintenance Manual", "Chapter 4: Fuel System", "Fuel system: storing and metering fuel from the wing tanks to the engines — fasteners, inspection cadence, parts. Also called: fuel pumps, fuel lines, tanks."),
+    ("Fleet Maintenance Manual", "Chapter 5: Cabin Pressurization", "Cabin pressurization: regulating cabin altitude through the outflow valves — fasteners, inspection cadence, parts. Also called: pressurisation, outflow valve, cabin altitude."),
+    ("Fleet Maintenance Manual", "Chapter 6: Flight Controls", "Flight controls: linking the cockpit inceptors to the control surfaces — fasteners, inspection cadence, parts. Also called: ailerons, elevator, rudder, control surfaces."),
+    ("Fleet Maintenance Manual", "Chapter 7: Electrical", "Electrical system: generator and battery power across the buses — fasteners, inspection cadence, parts. Also called: generators, batteries, wiring, electrical buses."),
+    ("Fleet Maintenance Manual", "Chapter 8: Auxiliary Power Unit", "Auxiliary power unit: ground power and bleed air with the engines shut down — fasteners, inspection cadence, parts. Also called: APU, ground power unit."),
+    ("Fleet Maintenance Manual", "Chapter 9: Environmental Control", "Environmental control: conditioning and circulating cabin air — fasteners, inspection cadence, parts. Also called: air conditioning, cabin air, ventilation, ECS, packs."),
+    ("Fleet Maintenance Manual", "Chapter 10: Oxygen System", "Oxygen system: emergency oxygen for the flight deck and cabin — fasteners, inspection cadence, parts. Also called: O2, oxygen masks, emergency oxygen."),
+    ("Fleet Maintenance Manual", "Chapter 11: Brakes", "Brakes: stopping the aircraft on landing and holding it during engine run-up — fasteners, inspection cadence, parts. Also called: wheel brakes, braking."),
+    ("Fleet Maintenance Manual", "Chapter 12: Nose Wheel Steering", "Nose wheel steering: steering the nose gear from the tiller and the rudder pedals — fasteners, inspection cadence, parts. Also called: tiller, nosewheel, steering system."),
+    ("Fleet Maintenance Manual", "Chapter 13: Engine Cowling", "Engine cowling: the cover that encloses the engine and directs cooling air — fasteners, inspection cadence, parts. Also called: engine cover, cowl, nacelle."),
+    ("Fleet Maintenance Manual", "Chapter 14: Wing Anti-Ice", "Wing anti-ice: heating the wing leading edges with engine bleed air — fasteners, inspection cadence, parts. Also called: de-icing, anti-icing, ice protection, leading-edge heat."),
+    ("Regional Employee Policy Manual", "Lisbon Office", "Lisbon office (Portugal): paid public holidays, the nightly hotel cap for expenses, and how many weeks' notice on leaving."),
+    ("Regional Employee Policy Manual", "Austin Office", "Austin office (Texas, United States): paid public holidays, the nightly hotel cap for expenses, and how many weeks' notice on leaving."),
+    ("Regional Employee Policy Manual", "Toronto Office", "Toronto office (Canada): paid public holidays, the nightly hotel cap for expenses, and how many weeks' notice on leaving."),
+    ("Regional Employee Policy Manual", "Singapore Office", "Singapore office: paid public holidays, the nightly hotel cap for expenses, and how many weeks' notice on leaving."),
+    ("Regional Employee Policy Manual", "Dublin Office", "Dublin office (Ireland): paid public holidays, the nightly hotel cap for expenses, and how many weeks' notice on leaving."),
+    ("Regional Employee Policy Manual", "Melbourne Office", "Melbourne office (Australia): paid public holidays, the nightly hotel cap for expenses, and how many weeks' notice on leaving."),
+    ("Regional Employee Policy Manual", "Berlin Office", "Berlin office (Germany): paid public holidays, the nightly hotel cap for expenses, and how many weeks' notice on leaving."),
+    ("Regional Employee Policy Manual", "Sao Paulo Office", "Sao Paulo office (Brazil): paid public holidays, the nightly hotel cap for expenses, and how many weeks' notice on leaving."),
+    ("Regional Employee Policy Manual", "Tokyo Office", "Tokyo office (Japan): paid public holidays, the nightly hotel cap for expenses, and how many weeks' notice on leaving."),
+    ("Regional Employee Policy Manual", "Bangalore Office", "Bangalore office (India): paid public holidays, the nightly hotel cap for expenses, and how many weeks' notice on leaving."),
+    ("Regional Employee Policy Manual", "Mexico City Office", "Mexico City office (Mexico): paid public holidays, the nightly hotel cap for expenses, and how many weeks' notice on leaving."),
+    ("Regional Employee Policy Manual", "Warsaw Office", "Warsaw office (Poland): paid public holidays, the nightly hotel cap for expenses, and how many weeks' notice on leaving."),
+];
+
+/// Store the handwritten section summaries for the seeded outline corpus:
+/// each `# heading` chunk opens a section that runs to the next `#`.
+/// Returns how many rows landed.
+async fn seed_outline_sections(ai: &crate::ai::Ai, db: &Db, notebook_id: &str) -> usize {
+    let sources = db.list_sources(notebook_id).await.expect("list sources");
+    let mut written = 0usize;
+    for src in sources {
+        let rows = db.source_chunk_rows(&src.id).await.expect("chunk rows");
+        // (ordinal, heading) for every top-level heading chunk.
+        let mut heads: Vec<(i32, String)> = rows
+            .iter()
+            .filter_map(|(_, ord, text)| {
+                let first = text.lines().next().unwrap_or("");
+                first
+                    .strip_prefix("# ")
+                    .map(|h| (*ord, h.trim().to_string()))
+            })
+            .collect();
+        heads.sort_by_key(|(o, _)| *o);
+        let last = rows.iter().map(|r| r.1).max().unwrap_or(0);
+        let mut sections: Vec<crate::db::SectionGist> = Vec::new();
+        for (i, (start, heading)) in heads.iter().enumerate() {
+            let end = heads.get(i + 1).map(|(o, _)| o - 1).unwrap_or(last);
+            let Some((_, _, summary)) = OUTLINE_SECTION_GISTS
+                .iter()
+                .find(|(doc, h, _)| *doc == src.title && h == heading)
+            else {
+                continue;
+            };
+            sections.push(crate::db::SectionGist {
+                start: *start,
+                end,
+                chain: format!("{} › {heading}", src.title),
+                summary: summary.to_string(),
+            });
+        }
+        if sections.is_empty() {
+            continue;
+        }
+        let inputs: Vec<String> = sections
+            .iter()
+            .map(|s| format!("[{} — section]\n{}", s.chain, s.summary))
+            .collect();
+        let embeddings = ai.embed(&inputs).await.expect("embed sections");
+        db.replace_section_rows(notebook_id, &src.id, &sections, &embeddings)
+            .await
+            .expect("store sections");
+        written += sections.len();
+    }
+    // One index over docs and sections both: an incremental optimize after
+    // the append measured flaky (one BM25-dependent query flipping between
+    // runs), a from-scratch build does not.
+    db.rebuild_fts_from_scratch().await.expect("rebuild fts");
+    written
+}
+
 fn load_datasets() -> Vec<Dataset> {
     let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("evals")
@@ -568,6 +659,12 @@ async fn eval_retrieval_datasets() {
         let docs = outline_corpus();
         let refs: Vec<(&str, &str)> = docs.iter().map(|(t, b)| (t.as_str(), b.as_str())).collect();
         seed_docs(&ai, &db, outline_nb, &refs, "o-").await;
+        // Phase 2 rows ride the same seeding unless a sweep asks to see
+        // the corpus without them (ALCHEMY_EVAL_NO_SECTIONS=1).
+        if std::env::var("ALCHEMY_EVAL_NO_SECTIONS").is_err() {
+            let n = seed_outline_sections(&ai, &db, outline_nb).await;
+            eprintln!("outline corpus: {n} section summaries seeded");
+        }
     }
     async fn titles_of(db: &Db, nb: &str) -> HashMap<String, String> {
         db.list_sources(nb)
@@ -2908,7 +3005,14 @@ async fn eval_context_leg_probe() {
     seed_docs(&ai, &db, nb, &refs, "p-").await;
     let (rows, filled) = db.context_fill().await.expect("context fill");
     eprintln!("chunk rows {rows}, with context {filled}");
-    let q = "what torque for the landing gear hinge bolts?";
+    if std::env::var("ALCHEMY_PROBE_SECTIONS").is_ok() {
+        let n = seed_outline_sections(&ai, &db, nb).await;
+        eprintln!("{n} section summaries seeded");
+    }
+    let probe_q = std::env::var("ALCHEMY_PROBE_QUERY").ok();
+    let q = probe_q
+        .as_deref()
+        .unwrap_or("what torque for the landing gear hinge bolts?");
     let qvec = ai.embed_one(q).await.expect("embed");
     let trace = db
         .search_chunks_trace(nb, qvec, q, 10, None)
@@ -2917,10 +3021,15 @@ async fn eval_context_leg_probe() {
     assert!(trace.warnings.is_empty(), "{:?}", trace.warnings);
     let show = |name: &str, hits: &[Citation]| {
         eprintln!("{name}: {} hits", hits.len());
-        for c in hits.iter().take(4) {
+        for c in hits.iter().take(if probe_q.is_some() { 10 } else { 4 }) {
             eprintln!(
-                "  [{}] {} | {}",
+                "  [{}]{} {} | {}",
                 c.ordinal,
+                if c.chunk_id.starts_with("section:") {
+                    " (section row)"
+                } else {
+                    ""
+                },
                 c.section,
                 c.snippet
                     .lines()
@@ -2935,12 +3044,166 @@ async fn eval_context_leg_probe() {
     show("vector", &trace.vector_hits);
     show("fts(bm25 = context + text)", &trace.fts_hits);
     show("fused", &trace.final_hits);
+    if probe_q.is_none() {
+        assert!(
+            trace
+                .fts_hits
+                .first()
+                .is_some_and(|c| c.section.contains("Landing Gear")),
+            "BM25 with the chain should put the landing-gear section first"
+        );
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Hybrid metrics for one kind of one dataset over an already-seeded
+/// notebook — the datasets eval's inner loop, for evals that re-seed part
+/// of the store between measurements.
+async fn score_kind(db: &Db, ai: &crate::ai::Ai, nb: &str, ds: &Dataset, kind: &str) -> Metrics {
+    let titles: HashMap<String, String> = db
+        .list_sources(nb)
+        .await
+        .expect("list sources")
+        .into_iter()
+        .map(|s| (s.id, s.title))
+        .collect();
+    let qs: Vec<&EvalQuery> = ds.queries.iter().filter(|q| q.kind == kind).collect();
+    let texts: Vec<String> = qs.iter().map(|q| q.query.clone()).collect();
+    let qvecs = ai.embed(&texts).await.expect("embed queries");
+    let mut rows: Vec<(String, Metrics)> = Vec::new();
+    for (q, qvec) in qs.iter().zip(qvecs) {
+        let trace = db
+            .search_chunks_trace(nb, qvec, &q.query, K, None)
+            .await
+            .expect("search");
+        let (ranks, _) = matched_ranks(&trace.final_hits, &titles, &q.relevant);
+        rows.push((kind.to_string(), query_metrics(&ranks, q.relevant.len())));
+    }
+    mean(&rows, None)
+}
+
+/// Phase 2's generator against its fixtures (RFC-outline-index): the Small
+/// model writes the section summaries for the outline corpus, and the
+/// `topic` kind is scored three ways on one store — no section rows, the
+/// handwritten fixtures, the model's. Prints the model's summaries so a
+/// weak run can be read, not just counted. Needs live Ollama;
+/// ALCHEMY_EVAL_SECTION_MODEL picks the model (default bonsai-8b).
+///
+///   ALCHEMY_OLLAMA_TESTS=1 cargo test --lib eval_section_gists_model -- --ignored --nocapture
+#[tokio::test]
+#[ignore = "needs live Ollama; run explicitly — it measures a generator, it does not guard correctness"]
+async fn eval_section_gists_model() {
+    let Some(ai) = builtin_ai().await else {
+        panic!("built-in embedder unavailable");
+    };
+    let model = std::env::var("ALCHEMY_EVAL_SECTION_MODEL")
+        .unwrap_or_else(|_| "digitsflow/bonsai-8b:latest".into());
+    let dir = std::env::temp_dir().join(format!("nbl-section-model-{}", uuid::Uuid::new_v4()));
+    let db = Db::open(&dir).await.expect("open db");
+    let nb = "outline";
+    // The sweep walks notebooks, so the seeded sources need one to live in.
+    db.create_notebook(&crate::models::Notebook {
+        id: nb.to_string(),
+        title: "Outline corpus".into(),
+        created_at: 0,
+        updated_at: 0,
+        color: String::new(),
+        icon: String::new(),
+        status: String::new(),
+        growth_web: false,
+        source_count: 0,
+        note_count: 0,
+        report_count: 0,
+    })
+    .await
+    .expect("create notebook");
+    let docs = outline_corpus();
+    let refs: Vec<(&str, &str)> = docs.iter().map(|(t, b)| (t.as_str(), b.as_str())).collect();
+    seed_docs(&ai, &db, nb, &refs, "o-").await;
+    db.rebuild_fts_from_scratch().await.expect("fts");
+    let ds = load_datasets()
+        .into_iter()
+        .find(|d| d.name == "fixture-outline")
+        .expect("outline dataset");
+
+    let none = score_kind(&db, &ai, nb, &ds, "topic").await;
+    let n = seed_outline_sections(&ai, &db, nb).await;
+    assert!(n > 0);
+    let hand = score_kind(&db, &ai, nb, &ds, "topic").await;
+
+    // The model's turn: same embedder (so the store's vectors agree), the
+    // Small role on Ollama, its own data dir for the stamp file.
+    let model_ai = crate::ai::Ai::new(
+        crate::ai::AiConfig {
+            embedder: "builtin".into(),
+            chat_model: model.clone(),
+            small_model: model.clone(),
+            ..Default::default()
+        },
+        crate::ai::AiRuntime {
+            data_dir: dir.join("ai"),
+            ..Default::default()
+        },
+    );
+    for src in db.list_sources(nb).await.expect("sources") {
+        db.delete_section_rows(&src.id).await.expect("clear");
+        let rows = db.source_chunk_rows(&src.id).await.expect("rows");
+        eprintln!(
+            "  {}: {} chunks (chunk_count {}), {} sections",
+            src.title,
+            rows.len(),
+            src.chunk_count,
+            crate::gist::sections_of(&rows).len()
+        );
+    }
+    // A smoke call first, so an unreachable model reads as itself.
+    let smoke = model_ai
+        .chat_role(
+            crate::inference::Role::Small,
+            &[crate::ai::ChatTurn::user(String::from(
+                "Reply with the single word: ready",
+            ))],
+        )
+        .await
+        .expect("small model answers");
+    eprintln!("  smoke: {}", smoke.text.trim());
+    let mut summarized = 0usize;
+    loop {
+        let n = crate::gist::ensure_section_gists(&db, &model_ai)
+            .await
+            .expect("section gists");
+        if n == 0 {
+            break;
+        }
+        summarized += n;
+    }
+    assert!(summarized > 0, "the model wrote no section summaries");
+    for src in db.list_sources(nb).await.expect("sources") {
+        for (chain, summary) in db.section_rows(&src.id).await.expect("rows") {
+            eprintln!("  {chain}\n    {}", summary.replace('\n', " / "));
+        }
+    }
+    db.rebuild_fts_from_scratch().await.expect("fts");
+    let modelled = score_kind(&db, &ai, nb, &ds, "topic").await;
+    crate::evals::release_models(&[&model]).await;
+
+    let line = |label: &str, m: &Metrics| {
+        eprintln!(
+            "  {label:<22} R@5 {:.2}  R@10 {:.2}  MRR {:.2}  nDCG {:.2}",
+            m.recall_at_5, m.recall_at_10, m.mrr_at_10, m.ndcg_at_10
+        );
+    };
+    eprintln!("\ntopic kind, hybrid, section summaries by ({model}):");
+    line("none", &none);
+    line("handwritten", &hand);
+    line("model", &modelled);
+    // The bar: the model's summaries must beat no summaries. Handwritten is
+    // the ceiling to report against, not a floor to fail on.
     assert!(
-        trace
-            .fts_hits
-            .first()
-            .is_some_and(|c| c.section.contains("Landing Gear")),
-        "BM25 with the chain should put the landing-gear section first"
+        modelled.mrr_at_10 > none.mrr_at_10,
+        "model summaries did not improve topic MRR ({:.2} vs {:.2})",
+        modelled.mrr_at_10,
+        none.mrr_at_10
     );
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/src-tauri/src/retrieval_eval.rs
+++ b/src-tauri/src/retrieval_eval.rs
@@ -3060,6 +3060,19 @@ async fn eval_context_leg_probe() {
 /// notebook — the datasets eval's inner loop, for evals that re-seed part
 /// of the store between measurements.
 async fn score_kind(db: &Db, ai: &crate::ai::Ai, nb: &str, ds: &Dataset, kind: &str) -> Metrics {
+    score_kind_with(db, ai, None, nb, ds, kind).await
+}
+
+/// `score_kind`, optionally with the outline escalation (RFC-outline-index
+/// Phase 3) run over each flat result by `escalator` before scoring.
+async fn score_kind_with(
+    db: &Db,
+    ai: &crate::ai::Ai,
+    escalator: Option<&crate::ai::Ai>,
+    nb: &str,
+    ds: &Dataset,
+    kind: &str,
+) -> Metrics {
     let titles: HashMap<String, String> = db
         .list_sources(nb)
         .await
@@ -3073,13 +3086,99 @@ async fn score_kind(db: &Db, ai: &crate::ai::Ai, nb: &str, ds: &Dataset, kind: &
     let mut rows: Vec<(String, Metrics)> = Vec::new();
     for (q, qvec) in qs.iter().zip(qvecs) {
         let trace = db
-            .search_chunks_trace(nb, qvec, &q.query, K, None)
+            .search_chunks_trace(nb, qvec.clone(), &q.query, K, None)
             .await
             .expect("search");
-        let (ranks, _) = matched_ranks(&trace.final_hits, &titles, &q.relevant);
+        let mut hits = trace.final_hits;
+        if let Some(model) = escalator {
+            crate::outline_index::escalate(db, model, nb, &q.query, &qvec, &mut hits)
+                .await
+                .expect("escalate");
+        }
+        let (ranks, _) = matched_ranks(&hits, &titles, &q.relevant);
         rows.push((kind.to_string(), query_metrics(&ranks, q.relevant.len())));
     }
     mean(&rows, None)
+}
+
+/// Phase 3's escalation, on versus off, per kind, over the outline corpus
+/// with the handwritten section summaries as the outline (so the
+/// escalation's own contribution is measured, not the generator's). Needs
+/// live Ollama; ALCHEMY_EVAL_SECTION_MODEL picks the Small model.
+///
+///   ALCHEMY_OLLAMA_TESTS=1 cargo test --lib eval_outline_escalation -- --ignored --nocapture
+#[tokio::test]
+#[ignore = "needs live Ollama; run explicitly — it measures an escalation, it does not guard correctness"]
+async fn eval_outline_escalation() {
+    let Some(ai) = builtin_ai().await else {
+        panic!("built-in embedder unavailable");
+    };
+    let model = std::env::var("ALCHEMY_EVAL_SECTION_MODEL")
+        .unwrap_or_else(|_| "digitsflow/bonsai-8b:latest".into());
+    let dir = std::env::temp_dir().join(format!("nbl-outline-esc-{}", uuid::Uuid::new_v4()));
+    let db = Db::open(&dir).await.expect("open db");
+    let nb = "outline";
+    db.create_notebook(&crate::models::Notebook {
+        id: nb.to_string(),
+        title: "Outline corpus".into(),
+        created_at: 0,
+        updated_at: 0,
+        color: String::new(),
+        icon: String::new(),
+        status: String::new(),
+        growth_web: false,
+        source_count: 0,
+        note_count: 0,
+        report_count: 0,
+    })
+    .await
+    .expect("create notebook");
+    let docs = outline_corpus();
+    let refs: Vec<(&str, &str)> = docs.iter().map(|(t, b)| (t.as_str(), b.as_str())).collect();
+    seed_docs(&ai, &db, nb, &refs, "o-").await;
+    seed_outline_sections(&ai, &db, nb).await;
+    let ds = load_datasets()
+        .into_iter()
+        .find(|d| d.name == "fixture-outline")
+        .expect("outline dataset");
+    let model_ai = crate::ai::Ai::new(
+        crate::ai::AiConfig {
+            embedder: "builtin".into(),
+            chat_model: model.clone(),
+            small_model: model.clone(),
+            ..Default::default()
+        },
+        crate::ai::AiRuntime {
+            data_dir: dir.join("ai"),
+            ..Default::default()
+        },
+    );
+    eprintln!("\noutline escalation by ({model}), hybrid @{K}:");
+    let mut topic: Option<(Metrics, Metrics)> = None;
+    for kind in ["topic", "outline", "chapter", "exact"] {
+        let off = score_kind(&db, &ai, nb, &ds, kind).await;
+        let on = score_kind_with(&db, &ai, Some(&model_ai), nb, &ds, kind).await;
+        eprintln!(
+            "  {kind:<8} off  R@5 {:.2}  R@10 {:.2}  MRR {:.2}  nDCG {:.2}",
+            off.recall_at_5, off.recall_at_10, off.mrr_at_10, off.ndcg_at_10
+        );
+        eprintln!(
+            "  {kind:<8} on   R@5 {:.2}  R@10 {:.2}  MRR {:.2}  nDCG {:.2}",
+            on.recall_at_5, on.recall_at_10, on.mrr_at_10, on.ndcg_at_10
+        );
+        if kind == "topic" {
+            topic = Some((off, on));
+        }
+    }
+    crate::evals::release_models(&[&model]).await;
+    let (off, on) = topic.expect("topic scored");
+    assert!(
+        on.mrr_at_10 >= off.mrr_at_10 - 0.02,
+        "escalation regressed topic MRR ({:.2} vs {:.2})",
+        on.mrr_at_10,
+        off.mrr_at_10
+    );
+    let _ = std::fs::remove_dir_all(&dir);
 }
 
 /// Phase 2's generator against its fixtures (RFC-outline-index): the Small

--- a/src-tauri/src/retrieval_eval.rs
+++ b/src-tauri/src/retrieval_eval.rs
@@ -1612,7 +1612,7 @@ async fn eval_enrichment_reembed() {
         })
         .collect();
     let new_embeddings = ai.embed(&new_inputs).await.expect("re-embed");
-    db.reembed_source_chunks(nb, &src_id, &rows, &new_embeddings)
+    db.reembed_source_chunks(nb, &src_id, &rows, &[], &new_embeddings)
         .await
         .expect("reembed");
 
@@ -2197,6 +2197,7 @@ async fn run_scale(ai: &crate::ai::Ai, target_chars: usize) -> (f64, f64, usize)
                     text: c.text.clone(),
                     embed_text: c.embed_text.clone(),
                     section: String::new(),
+                    context: String::new(),
                 },
             ));
         }
@@ -2218,6 +2219,7 @@ async fn run_scale(ai: &crate::ai::Ai, target_chars: usize) -> (f64, f64, usize)
             .enumerate()
             .map(|(ci, c)| (format!("d{di}-c{ci}"), ci as i32, c.text.clone()))
             .collect();
+        let contexts: Vec<String> = chunked[di].iter().map(|c| c.context.clone()).collect();
         let vecs = vectors[cursor..cursor + n].to_vec();
         cursor += n;
         let source = crate::models::Source {
@@ -2242,7 +2244,7 @@ async fn run_scale(ai: &crate::ai::Ai, target_chars: usize) -> (f64, f64, usize)
             fetch_failures: 0,
         };
         total_chars += source.char_count;
-        db.insert_source(&source, &tuples, &vecs)
+        db.insert_source_ctx(&source, &tuples, &contexts, &vecs)
             .await
             .expect("insert scale doc");
     }
@@ -2885,4 +2887,55 @@ async fn eval_agent_rerank_paths() {
         xe_n as f64 / n as f64
     );
     crate::evals::release_models(&[&chat_model, &small_model]).await;
+}
+
+/// Probe for Phase 1.5 (RFC-outline-index): with the heading chain in the
+/// BM25 document, the text leg alone should put the right chapter's
+/// section first for a look-alike query over the outline corpus.
+#[tokio::test]
+async fn eval_context_leg_probe() {
+    let Some(ai) = eval_ai().await else { return };
+    let dir = std::env::temp_dir().join(format!("nbl-ctx-probe-{}", uuid::Uuid::new_v4()));
+    let db = Db::open(&dir).await.expect("open db");
+    let nb = "probe";
+    let docs = outline_corpus();
+    let refs: Vec<(&str, &str)> = docs.iter().map(|(t, b)| (t.as_str(), b.as_str())).collect();
+    seed_docs(&ai, &db, nb, &refs, "p-").await;
+    let (rows, filled) = db.context_fill().await.expect("context fill");
+    eprintln!("chunk rows {rows}, with context {filled}");
+    let q = "what torque for the landing gear hinge bolts?";
+    let qvec = ai.embed_one(q).await.expect("embed");
+    let trace = db
+        .search_chunks_trace(nb, qvec, q, 10, None)
+        .await
+        .expect("search");
+    assert!(trace.warnings.is_empty(), "{:?}", trace.warnings);
+    let show = |name: &str, hits: &[Citation]| {
+        eprintln!("{name}: {} hits", hits.len());
+        for c in hits.iter().take(4) {
+            eprintln!(
+                "  [{}] {} | {}",
+                c.ordinal,
+                c.section,
+                c.snippet
+                    .lines()
+                    .next()
+                    .unwrap_or("")
+                    .chars()
+                    .take(60)
+                    .collect::<String>()
+            );
+        }
+    };
+    show("vector", &trace.vector_hits);
+    show("fts(bm25 = context + text)", &trace.fts_hits);
+    show("fused", &trace.final_hits);
+    assert!(
+        trace
+            .fts_hits
+            .first()
+            .is_some_and(|c| c.section.contains("Landing Gear")),
+        "BM25 with the chain should put the landing-gear section first"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
 }

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -31,6 +31,7 @@ async fn rag_round_trip() {
         // and a runaway cap, so a rambling reply can't wedge the suite.
         keep_alive: Some("1m".into()),
         num_predict: Some(2_048),
+        think: None,
     });
     if !crate::evals::ollama_tests_enabled() {
         eprintln!("SKIP: set ALCHEMY_OLLAMA_TESTS=1 to run the Ollama round trip");

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -175,6 +175,8 @@ export interface Citation {
    * context §1). Optional: citations persisted before gists existed lack it.
    */
   gist?: boolean;
+  /** "title › chapter › section" for the passage; absent on older rows. */
+  section?: string;
   /**
    * True for the user's own per-source annotation (RFC-source-tags);
    * sourceId names the annotated source. Optional: older citations lack it.


### PR DESCRIPTION
First Reminders item of the outline quartet, behind the gate that shipped in v0.53.0, done in two measured steps.

**Phase 1 — chunk context is the heading chain.** `chunk_text` tracks the open heading chain by level. A chunk under `## Torque Values` inside `# Chapter 2: Landing Gear` embeds as `[Manual › Chapter 2: Landing Gear › Torque Values]`; `Chunk.section` and `Chunk.context` keep it. Display text is untouched.

**Phase 1.5 — the chain in the BM25 document.** Two nullable columns on `chunks`: `context` (read back as `Citation.section`) and `bm25` (`"{context}\n{text}"`, the one document the FTS index covers). Older tables gain both via `add_columns`, `bm25` seeded from `text`; older builds' appends conform with blanks. A separate context leg was measured and rejected: it cost hard-exact queries their top rank.

**Gate** (`fixture-outline`, hybrid, outline kind @10):

| | R@5 | R@10 | MRR | nDCG |
| --- | --- | --- | --- | --- |
| baseline v0.53.0 | 0.55 | 0.68 | 0.23 | 0.34 |
| phase 1 | 0.91 | 1.00 | 0.62 | 0.71 |
| phase 1.5 | 1.00 | 1.00 | 0.92 | 0.94 |

Controls stay at 1.00; the golden datasets (core, hard) are exactly where Phase 1 left them. Full eval suite green (`ALCHEMY_EVALS=1`), 438 unit tests, clippy and fmt clean.

**RFC.** `docs/RFC-outline-index.md` records both shapes measured for 1.5 and lays out how phases 2 (section summaries) and 3 (outline-guided escalation) get their own cases.

Existing stores: the columns are added on first write; existing rows keep chain-less context until a source is refreshed, but stay in BM25 through the seeded `bm25` column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Phase 3 — outline-guided escalation (landed)

`outline_index::escalate` runs beside the gap query in chat retrieval. Trigger: thin pool, or top-5 hits are the same subsection of different chapters. The Small role reads the notebook outline (`db::notebook_outline`), picks ≤2 sections, their best in-span passages (`db::section_passages`) RRF-fuse into the pool. Traced as `outlinePick`.

On/off, `ALCHEMY_OLLAMA_TESTS=1 cargo test --lib eval_outline_escalation -- --ignored --nocapture`, handwritten summaries:

| kind | off MRR | bonsai on | gemma4 on |
| --- | --- | --- | --- |
| topic | 0.79 | 0.88 | 0.88 |
| outline | 0.89 | 0.91 | 0.93 |
| chapter / exact | 1.00 | 1.00 | 1.00 |

Measured wrong first: prepending picks (exact → 0.20), escalating over a literal identifier match (exact → 0.33), trusting a shotgun reply. All three are in the RFC.
