### PR TITLE
Chat latency: helpers bounded, gap query gated, models warmed on typing

### DIFF
--- a/docs/RFC-inference-providers.md
+++ b/docs/RFC-inference-providers.md
@@ -84,9 +84,12 @@ wants the model the user picked to *write* for them. On the chat model,
 routing inherits that model's worst case: an agent-CLI provider took
 more than 30s to classify "open the ferrari notebook", so an imperative
 message cost more than the answer it was standing in for, and a wedged
-provider made the router itself the hang. `chat_role` already falls
-through to the chat engine when Small is absent or errors, so the move
-is strictly faster and never less capable.
+provider made the router itself the hang. `chat_role` routes Small to
+the chat engine when no Small engine is configured, so the move is
+strictly faster and never less capable. (It no longer falls through on
+*error*: a failing Small engine used to hand its work to whatever
+answers chat — a paid agent CLI, silently, after the small engine's full
+timeout — so since PR #45 the call fails and the caller decides.)
 
 ## 3. The boundary
 
@@ -250,9 +253,13 @@ OpenAI-shaped lives here. No per-vendor SDKs.
   reordered by the user's preference list, overridable per role in
   advanced settings. Zero-config result on a bare Mac: builtin embedder +
   builtin MLX chat — everything works, nothing was configured.
-- **Failure fallthrough**: a provider error at call time drops to the
-  next rung with one toast ("Ollama unreachable — answered with Claude
-  Code"). No modal, no dead chat.
+- **Failure is visible, not routed around**: a provider error at call
+  time lands in the chat error row with the fix as a button — Retry,
+  `ollama serve` / `ollama stop <model>` in Terminal, Settings → Models,
+  or a one-click rerun on another live engine (RFC-self-resolve). The
+  earlier plan, a silent drop to the next rung with a toast, measured
+  badly: a wedged Ollama held a helper call for its full ten-minute
+  timeout and then quietly billed the question to Codex.
 - **Telemetry**: per-provider tok/s already exists (`ModelStat`); the
   router records it per rung so "why is this slow" has an answer and the
   ladder can be tuned with evidence.

--- a/src-tauri/src/ai/mod.rs
+++ b/src-tauri/src/ai/mod.rs
@@ -578,6 +578,10 @@ pub struct Ai {
     /// that kept running while the local small model was down would spend
     /// it silently, a dozen calls a minute (it did, 2026-09-01).
     strict_small: bool,
+    /// Ceiling on one Small-role call — set by `helpers()` for the calls a
+    /// person is waiting behind (gap query, outline pick). None = the
+    /// engine's own transport timeout.
+    small_timeout: Option<std::time::Duration>,
     /// Ollama retained directly for the capabilities that haven't joined the
     /// router yet (OCR fallback, model listing).
     ollama: Ollama,
@@ -747,6 +751,7 @@ impl Ai {
         );
         Self {
             strict_small: false,
+            small_timeout: None,
             config,
             router,
             ollama,
@@ -1034,10 +1039,20 @@ impl Ai {
                 _ => true,
             };
             if usable {
-                match engine.chat(messages).await {
+                let outcome = match self.small_timeout {
+                    Some(limit) => match tokio::time::timeout(limit, engine.chat(messages)).await {
+                        Ok(res) => res,
+                        Err(_) => Err(anyhow::anyhow!(
+                            "small model answered nothing in {}s",
+                            limit.as_secs()
+                        )),
+                    },
+                    None => engine.chat(messages).await,
+                };
+                match outcome {
                     Ok(out) => return Ok(out),
                     Err(err) if self.strict_small => {
-                        return Err(err.context("small model unavailable; background work holds"));
+                        return Err(err.context("small model unavailable; helper skipped"));
                     }
                     Err(err) => {
                         crate::note!("small-role engine failed, falling through: {err:#}");
@@ -1046,6 +1061,43 @@ impl Ai {
             }
         }
         self.router.chat_engine(Role::Chat).chat(messages).await
+    }
+
+    /// Longest a chat-path helper may hold the answer. Measured: retrieval's
+    /// model stage lands in 2–9 s on local models when Ollama is healthy;
+    /// when it is wedged, its requests die at its own 10-minute mark, and a
+    /// gap query that waited the whole way put the first token 600 s out.
+    pub const HELPER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+    /// This handle for the helpers that run *before* an answer a person is
+    /// waiting on — the gap query, the outline pick. The Small role gets
+    /// `HELPER_TIMEOUT` and never borrows the chat provider: falling through
+    /// costs a whole extra round trip on the provider that is about to
+    /// answer anyway, and a wedged local server cost ten minutes. A helper
+    /// that cannot answer quickly is skipped; the answer proceeds on the
+    /// flat search.
+    pub fn helpers(mut self) -> Self {
+        self.strict_small = true;
+        self.small_timeout = Some(Self::HELPER_TIMEOUT);
+        self
+    }
+
+    /// Ask Ollama to load the chat and Small models now, so the cold load
+    /// (measured: 111 s for lfm2.5, 115 s for a 27B MLX model, against 10 s
+    /// and 26 s warm) overlaps the user's typing instead of following Send.
+    /// Event-driven — the composer calls it on the first keystroke of a
+    /// draft — never from a tick. Providers other than Ollama have nothing
+    /// to warm. Best-effort and sequential: the chat model is the long
+    /// wait, the Small model backs the helpers behind it.
+    pub async fn warm_models(&self) {
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for role in [Role::Chat, Role::Small] {
+            if let ChatEngine::Ollama(o) = self.router.chat_engine(role) {
+                if seen.insert(o.chat_model_name().to_string()) {
+                    o.warm().await;
+                }
+            }
+        }
     }
 
     /// This handle for background work: sweeps, the nightly weave, card

--- a/src-tauri/src/ai/mod.rs
+++ b/src-tauri/src/ai/mod.rs
@@ -577,7 +577,6 @@ pub struct Ai {
     /// engine. A gateway or agent CLI is the user's *chat* spend; a sweep
     /// that kept running while the local small model was down would spend
     /// it silently, a dozen calls a minute (it did, 2026-09-01).
-    strict_small: bool,
     /// Ceiling on one Small-role call — set by `helpers()` for the calls a
     /// person is waiting behind (gap query, outline pick). None = the
     /// engine's own transport timeout.
@@ -750,7 +749,6 @@ impl Ai {
             crate::inference::rerank::XencModel::Small,
         );
         Self {
-            strict_small: false,
             small_timeout: None,
             config,
             router,
@@ -989,12 +987,10 @@ impl Ai {
         self.router.chat_engine(Role::Chat).chat(messages).await
     }
 
-    /// Role-routed chat with failure fallthrough (RFC-inference-providers
-    /// §7): if the role's engine is unavailable or errors, the configured
-    /// chat engine answers instead — one log line, never a dead call.
-    /// Is there a distinct Small-role engine, or would `chat_role(Small)`
-    /// fall through to the chat engine? Evals comparing the two roles need
-    /// to know the difference is real before reporting a comparison.
+    /// Is there a distinct Small-role engine, or does `chat_role(Small)`
+    /// route to the chat engine by configuration? Evals comparing the two
+    /// roles need to know the difference is real before reporting a
+    /// comparison.
     #[cfg(test)]
     pub fn has_small_role(&self) -> bool {
         self.router.has_small()
@@ -1049,15 +1045,12 @@ impl Ai {
                     },
                     None => engine.chat(messages).await,
                 };
-                match outcome {
-                    Ok(out) => return Ok(out),
-                    Err(err) if self.strict_small => {
-                        return Err(err.context("small model unavailable; helper skipped"));
-                    }
-                    Err(err) => {
-                        crate::note!("small-role engine failed, falling through: {err:#}");
-                    }
-                }
+                // Never the chat provider instead. Falling through used to
+                // send Small-role work to whatever answers chat — a paid
+                // agent CLI, silently, and only after the small engine's
+                // full timeout had elapsed. The caller decides what a missing
+                // helper means; a person sees the chat error row.
+                return outcome.map_err(|err| err.context("small model unavailable"));
             }
         }
         self.router.chat_engine(Role::Chat).chat(messages).await
@@ -1071,13 +1064,9 @@ impl Ai {
 
     /// This handle for the helpers that run *before* an answer a person is
     /// waiting on — the gap query, the outline pick. The Small role gets
-    /// `HELPER_TIMEOUT` and never borrows the chat provider: falling through
-    /// costs a whole extra round trip on the provider that is about to
-    /// answer anyway, and a wedged local server cost ten minutes. A helper
-    /// that cannot answer quickly is skipped; the answer proceeds on the
-    /// flat search.
+    /// `HELPER_TIMEOUT`; a helper that cannot answer quickly is skipped and
+    /// the answer proceeds on the flat search.
     pub fn helpers(mut self) -> Self {
-        self.strict_small = true;
         self.small_timeout = Some(Self::HELPER_TIMEOUT);
         self
     }
@@ -1098,15 +1087,6 @@ impl Ai {
                 }
             }
         }
-    }
-
-    /// This handle for background work: sweeps, the nightly weave, card
-    /// enrichment. The Small role stays on the small engine or fails — it
-    /// never borrows the chat provider. Foreground callers keep the
-    /// fall-through, because a person is waiting on them.
-    pub fn background(mut self) -> Self {
-        self.strict_small = true;
-        self
     }
 
     pub async fn chat_stream<F>(&self, messages: &[ChatTurn], on_token: F) -> Result<ChatOutcome>

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2266,6 +2266,82 @@ pub async fn grep_sources(
         .collect())
 }
 
+/// Should the gap query run at all? The model call it gates is a full
+/// Small-role round trip on every question — 2–9 s of the retrieval stage
+/// on local models — while most questions have one subject the flat search
+/// already answered. Two cheap signals say a second search could matter:
+/// the question links things (compare, versus, change from … to …), or it
+/// names terms the pool never mentions. Measured on the fixture datasets
+/// (`eval_gap_gate`): every multi-hop query asks; the single-subject kinds
+/// mostly skip. Returns why the gate opened, or None to skip.
+pub(crate) fn gap_gate(question: &str, pool: &[Citation]) -> Option<&'static str> {
+    if pool.is_empty() {
+        return Some("empty");
+    }
+    let q = format!(" {} ", question.to_lowercase());
+    const LINKED: &[&str] = &[
+        " compare",
+        " comparison",
+        " versus ",
+        " vs ",
+        " vs. ",
+        " differ",
+        " both ",
+        " either ",
+        " between ",
+        " than ",
+        " evolve",
+        " change",
+        " over time",
+        " through ",
+        " respectively",
+        " relate",
+        " relationship",
+        " depend",
+        " as well as ",
+        " and also ",
+        " each ",
+    ];
+    if LINKED.iter().any(|w| q.contains(w)) {
+        return Some("linked");
+    }
+    if q.contains(" from ") && q.contains(" to ") {
+        return Some("range");
+    }
+    // Terms the pool never mentions. Five-character stems forgive
+    // inflection (employees / employee, patched / patching); one stray
+    // synonym is normal, two say the search missed a subject.
+    const STOP: &[&str] = &[
+        "what", "which", "when", "where", "does", "did", "the", "this", "that", "these", "those",
+        "there", "their", "they", "them", "with", "from", "into", "about", "have", "has", "had",
+        "should", "would", "could", "will", "your", "you", "our", "get", "got", "need", "needs",
+        "use", "used", "uses", "much", "many", "long", "often", "more", "less", "some", "any",
+        "all", "how", "who", "why", "was", "were", "are", "is", "be", "been", "for", "and", "but",
+        "not", "can", "may", "might", "must", "over", "under", "after", "before", "still", "also",
+        "just", "only", "like", "want", "wants", "tell", "know", "find", "give", "make", "explain",
+        "explains", "written", "write", "wrote", "down", "document", "covers", "cover", "mention",
+        "mentions", "says", "say", "said",
+    ];
+    let hay = pool
+        .iter()
+        .map(|c| format!("{} {} {}", c.source_title, c.section, c.snippet))
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase();
+    let uncovered = q
+        .split(|c: char| !c.is_alphanumeric() && c != '-')
+        .filter(|w| w.len() >= 4 && !STOP.contains(w))
+        .filter(|w| {
+            let stem: String = w.chars().take(5).collect();
+            !hay.contains(&stem)
+        })
+        .count();
+    if uncovered >= 2 {
+        return Some("uncovered");
+    }
+    None
+}
+
 /// Iterative retrieval's gap loop (RFC-judged-evals §4.3): show the small
 /// tier the first-pass excerpts, ask what ONE search would find the
 /// missing evidence, run it, and merge. Self-gating — NONE means the
@@ -8621,17 +8697,25 @@ pub async fn send_message(
     // gold-evidence citation 48%→60% with zero single-hop regression.
     let mut pool = search.final_hits;
     let t_stage = std::time::Instant::now();
-    let gap_query = gap_retrieve(
-        &ai,
-        &state.db,
-        &notebook_id,
-        &content,
-        &mut pool,
-        k,
-        fetch_k,
-        source_ids.as_deref(),
-    )
-    .await;
+    // The helpers ahead of the answer run on the Small role with a short
+    // ceiling and never borrow the chat provider (`Ai::helpers`).
+    let helpers = ai.clone().helpers();
+    let gap_gate = gap_gate(&content, &pool);
+    let gap_query = if gap_gate.is_some() {
+        gap_retrieve(
+            &helpers,
+            &state.db,
+            &notebook_id,
+            &content,
+            &mut pool,
+            k,
+            fetch_k,
+            source_ids.as_deref(),
+        )
+        .await
+    } else {
+        None
+    };
     let gap_ms = t_stage.elapsed().as_millis() as u64;
     // Outline-guided escalation (RFC-outline-index Phase 3): when the pool
     // is thin or sits on look-alike sections of a structured source, the
@@ -8640,7 +8724,7 @@ pub async fn send_message(
     // pool as it was.
     let outline_pick = match crate::outline_index::escalate(
         &state.db,
-        &ai,
+        &helpers,
         &notebook_id,
         &content,
         &query_vec_for_outline,
@@ -8665,6 +8749,7 @@ pub async fn send_message(
             "ftsHits": search.fts_hits.len(),
             "fusedHits": search.fused_hits.len(),
             "grepHits": grep_hits.len(),
+            "gapGate": gap_gate,
             "gapQuery": gap_query,
             "outlinePick": outline_pick,
             "warnings": search.warnings,
@@ -8727,6 +8812,9 @@ pub async fn send_message(
         &persona,
         &profile,
     );
+    // Prompt size rides the timing line: prefill is the part of first-token
+    // time retrieval numbers cannot explain.
+    let prompt_chars: usize = messages.iter().map(|m| m.content.chars().count()).sum();
     // One-shot provider override (RFC-self-resolve phase 4): the error row's
     // "Answer with Ollama / Apple Intelligence" rerun answers THIS question
     // on the named engine — config untouched, one send only.
@@ -8856,6 +8944,7 @@ pub async fn send_message(
                 "grepMs": grep_ms,
                 "gapMs": gap_ms,
                 "rerankMs": rerank_ms,
+                "promptChars": prompt_chars,
             })),
         );
     }
@@ -10205,6 +10294,27 @@ pub async fn enqueue_generation(
         "",
     )
     .await)
+}
+
+/// Preload the chat and Small models while the user is still typing
+/// (`Ai::warm_models`). Fire-and-forget; at most once per ten minutes so a
+/// composer that re-renders cannot turn into a poll.
+#[tauri::command]
+pub async fn warm_chat_models(state: State<'_, AppState>) -> Result<(), String> {
+    static LAST_WARM: std::sync::Mutex<Option<std::time::Instant>> = std::sync::Mutex::new(None);
+    {
+        let mut last = LAST_WARM.lock().unwrap();
+        if last
+            .map(|t| t.elapsed() < std::time::Duration::from_secs(600))
+            .unwrap_or(false)
+        {
+            return Ok(());
+        }
+        *last = Some(std::time::Instant::now());
+    }
+    let ai = state.ai.read().await.clone();
+    tokio::spawn(async move { ai.warm_models().await });
+    Ok(())
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -878,6 +878,30 @@ pub(crate) fn classify_model_error(raw: &str) -> Option<String> {
         );
     }
 
+    // Ollama accepted the request and then went quiet past the deadline a
+    // healthy server meets (`Ollama::run_stream`): the runner is stuck.
+    // `ollama stop <model>` drops that runner; the next request reloads it.
+    if lower.starts_with("ollama: ")
+        && (lower.contains(" sent nothing for ") || lower.contains(" stalled mid-answer "))
+    {
+        let model = raw["ollama: ".len()..]
+            .split(' ')
+            .next()
+            .filter(|m| is_safe_model_name(m))
+            .map(str::to_string);
+        return Some(match model {
+            Some(m) => format!(
+                "Ollama took the question but never answered — “{m}” looks stuck. \
+                 Fix: open Terminal, run `ollama stop {m}`, then retry here. Or pick \
+                 another model in Settings → Models."
+            ),
+            None => "Ollama took the question but never answered — the model looks \
+                     stuck. Restart Ollama and retry, or pick another model in \
+                     Settings → Models."
+                .into(),
+        });
+    }
+
     // A model-shaped timeout: still loading into memory, or holding the GPU
     // for another job. Scoped to provider-ish errors so a slow source fetch
     // during import never gets model advice.
@@ -954,6 +978,7 @@ pub(crate) fn terminal_command_allowed(command: &str) -> bool {
     // AppleScript string or the shell.
     command
         .strip_prefix("ollama pull ")
+        .or_else(|| command.strip_prefix("ollama stop "))
         .is_some_and(is_safe_model_name)
 }
 

--- a/src-tauri/src/commands/registry.rs
+++ b/src-tauri/src/commands/registry.rs
@@ -1235,7 +1235,6 @@ pub(crate) async fn suggest_now(
     // strip re-sorts itself on the registry bump.
     let db = db.clone();
     tauri::async_runtime::spawn(async move {
-        let ai = ai.background();
         if let Err(err) = triage_suggested_cards(&db, &ai).await {
             crate::note!("registry triage failed: {err:#}");
         }

--- a/src-tauri/src/commands/weave.rs
+++ b/src-tauri/src/commands/weave.rs
@@ -80,7 +80,6 @@ const MAX_NIGHTLY_SOURCES: usize = 8;
 /// Budget-checked per source rather than once up front, because the cost is
 /// per judgment and a night can run out halfway through the list.
 pub(crate) fn spawn_nightly(db: Arc<Db>, ai: Ai, since: i64, budget: String) {
-    let ai = ai.background();
     // One nightly pass at a time, and never blocked by arrival judgments:
     // the pass is serial internally, so it is not the pile-up the arrival
     // cap guards against.

--- a/src-tauri/src/gist.rs
+++ b/src-tauri/src/gist.rs
@@ -834,7 +834,6 @@ pub fn spawn_sweep(db: std::sync::Arc<Db>, ai: Ai) {
     if !ai.config().source_gists {
         return;
     }
-    let ai = ai.background();
     if SWEEPING
         .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
         .is_err()

--- a/src-tauri/src/inference/ollama.rs
+++ b/src-tauri/src/inference/ollama.rs
@@ -370,6 +370,41 @@ impl Ollama {
             .await;
     }
 
+    /// Load this engine's chat model without generating — a chat request
+    /// with no messages is Ollama's documented preload; it returns once the
+    /// model is resident. Residency is this engine's `keep_alive` or ten
+    /// minutes: long enough to bridge typing and Send, short enough that a
+    /// draft never sent does not pin a 20 GB model all afternoon. The
+    /// following real request re-sets residency to its own window.
+    pub async fn warm(&self) {
+        let keep = self
+            .config
+            .keep_alive
+            .clone()
+            .unwrap_or_else(|| "10m".into());
+        let started = std::time::Instant::now();
+        let res = self
+            .http
+            .post(self.url("/api/chat"))
+            .timeout(std::time::Duration::from_secs(300))
+            .json(&json!({
+                "model": self.config.chat_model,
+                "messages": [],
+                "keep_alive": keep,
+            }))
+            .send()
+            .await;
+        match res {
+            Ok(r) if r.status().is_success() => crate::note!(
+                "warm: {} resident after {} ms",
+                self.config.chat_model,
+                started.elapsed().as_millis()
+            ),
+            Ok(r) => crate::note!("warm: {} → HTTP {}", self.config.chat_model, r.status()),
+            Err(err) => crate::note!("warm: {} failed: {err:#}", self.config.chat_model),
+        }
+    }
+
     /// The chat model this engine answers with — the name a loading status
     /// should show.
     pub fn chat_model_name(&self) -> &str {

--- a/src-tauri/src/inference/ollama.rs
+++ b/src-tauri/src/inference/ollama.rs
@@ -63,13 +63,27 @@ struct ChatMessageDelta {
 
 impl Ollama {
     pub fn new(config: OllamaConfig) -> Self {
+        // No blanket request timeout: chat is bounded by what a healthy
+        // server does (`run_stream`), everything else sets its own. The old
+        // ten-minute ceiling let a wedged server hold an answer for exactly
+        // that long before anyone heard about it.
         let http = reqwest::Client::builder()
-            // Local models can take a while on the first token; be patient.
-            .timeout(std::time::Duration::from_secs(600))
+            .connect_timeout(std::time::Duration::from_secs(5))
             .build()
             .expect("failed to build reqwest client");
         Self { http, config }
     }
+
+    /// Longest a *loaded* model may take to its first token — prefill of a
+    /// long prompt on a 27B model measures in the tens of seconds; past
+    /// this the server is stuck, not slow.
+    const FIRST_TOKEN_LOADED: std::time::Duration = std::time::Duration::from_secs(90);
+    /// The same for a model that still has to page in (measured: 115 s for
+    /// a 27B MLX model cold). The composer's warm-up makes this the rare
+    /// case.
+    const FIRST_TOKEN_COLD: std::time::Duration = std::time::Duration::from_secs(180);
+    /// Longest silence between tokens once an answer is under way.
+    const STALL: std::time::Duration = std::time::Duration::from_secs(30);
 
     fn url(&self, path: &str) -> String {
         format!("{}{}", self.config.base_url.trim_end_matches('/'), path)
@@ -220,84 +234,80 @@ impl Ollama {
     }
 
     /// Non-streaming chat completion; used for one-shot artifact generation.
+    /// Rides the streaming request underneath so it shares the same
+    /// first-token and stall deadlines — a wedged server is a wedged server
+    /// whichever way the answer is read.
     pub async fn chat(&self, messages: &[ChatTurn]) -> Result<ChatOutcome> {
         let mut body = json!({
             "model": self.config.chat_model,
             "messages": messages,
-            "stream": false,
+            "stream": true,
         });
         self.apply_keep_alive(&mut body);
-        let mut attempt = 0;
-        let resp = loop {
-            let resp = self
-                .http
-                .post(self.url("/api/chat"))
-                .json(&body)
-                .send()
-                .await
-                .context("ollama chat request failed")?;
-            if resp.status().is_success() || !Self::backoff_if_retryable(&resp, attempt).await {
-                break resp;
-            }
-            attempt += 1;
-        };
-
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            return Err(anyhow!("ollama chat {}: {}", status, body));
-        }
-        let value: serde_json::Value = resp.json().await?;
-        let text = value["message"]["content"]
-            .as_str()
-            .unwrap_or_default()
-            .to_string();
-        let stats = GenStats::from_parts(
-            value.get("eval_count").and_then(|v| v.as_u64()),
-            value.get("eval_duration").and_then(|v| v.as_u64()),
-        );
-        Ok(ChatOutcome {
-            text,
-            stats,
-            cost_usd: None,
-        })
+        self.run_stream(body, |_| {}).await
     }
 
     /// Streaming chat. `on_token` is called for each content delta as it arrives.
     /// Returns the full concatenated assistant message.
-    pub async fn chat_stream<F>(
-        &self,
-        messages: &[ChatTurn],
-        mut on_token: F,
-    ) -> Result<ChatOutcome>
+    pub async fn chat_stream<F>(&self, messages: &[ChatTurn], on_token: F) -> Result<ChatOutcome>
     where
         F: FnMut(&str),
     {
-        let body = {
-            let mut body = json!({
-                "model": self.config.chat_model,
-                "messages": messages,
-                "stream": true,
-            });
-            // Only when the user asked for one: the parameter is absent by
-            // default, which is what every model expects.
-            if !self.config.effort.trim().is_empty() {
-                body["think"] = json!(self.config.effort.trim());
-            }
-            self.apply_keep_alive(&mut body);
-            body
+        let mut body = json!({
+            "model": self.config.chat_model,
+            "messages": messages,
+            "stream": true,
+        });
+        // Only when the user asked for one: the parameter is absent by
+        // default, which is what every model expects.
+        if !self.config.effort.trim().is_empty() {
+            body["think"] = json!(self.config.effort.trim());
+        }
+        self.apply_keep_alive(&mut body);
+        self.run_stream(body, on_token).await
+    }
+
+    /// One streamed `/api/chat` request under the deadlines a healthy
+    /// server meets: the first token within `FIRST_TOKEN_LOADED` (or
+    /// `FIRST_TOKEN_COLD` when `/api/ps` says the model is not resident),
+    /// then no silence longer than `STALL`. Either miss is an error naming
+    /// the model — the chat error row turns it into a Retry and an
+    /// `ollama stop <model>` fix — instead of the ten-minute wait it was.
+    async fn run_stream<F>(&self, body: serde_json::Value, mut on_token: F) -> Result<ChatOutcome>
+    where
+        F: FnMut(&str),
+    {
+        let model = self.config.chat_model.clone();
+        let norm = |s: &str| s.trim_end_matches(":latest").to_string();
+        let loaded = match self.ps().await {
+            Ok(names) => names.iter().any(|n| norm(n) == norm(&model)),
+            Err(_) => false,
         };
+        let first = if loaded {
+            Self::FIRST_TOKEN_LOADED
+        } else {
+            Self::FIRST_TOKEN_COLD
+        };
+        let stuck = |waited: std::time::Duration| {
+            anyhow!(
+                "ollama: {model} sent nothing for {}s (model {} loaded) — it looks stuck",
+                waited.as_secs(),
+                if loaded { "was" } else { "was not" }
+            )
+        };
+        let started = std::time::Instant::now();
         // Retries happen strictly before any body is consumed, so a retried
         // stream can never emit duplicate tokens.
         let mut attempt = 0;
         let resp = loop {
-            let resp = self
-                .http
-                .post(self.url("/api/chat"))
-                .json(&body)
-                .send()
-                .await
-                .context("ollama chat request failed")?;
+            let remaining = first.saturating_sub(started.elapsed());
+            let sent = tokio::time::timeout(
+                remaining,
+                self.http.post(self.url("/api/chat")).json(&body).send(),
+            )
+            .await
+            .map_err(|_| stuck(started.elapsed()))?;
+            let resp = sent.context("ollama chat request failed")?;
             if resp.status().is_success() || !Self::backoff_if_retryable(&resp, attempt).await {
                 break resp;
             }
@@ -313,8 +323,27 @@ impl Ollama {
         let mut full = String::new();
         let mut buf: Vec<u8> = Vec::new();
         let mut stream = resp.bytes_stream();
+        let mut any_token = false;
 
-        while let Some(chunk) = stream.next().await {
+        loop {
+            let limit = if any_token {
+                Self::STALL
+            } else {
+                first.saturating_sub(started.elapsed())
+            };
+            let next = tokio::time::timeout(limit, stream.next())
+                .await
+                .map_err(|_| {
+                    if any_token {
+                        anyhow!(
+                            "ollama: {model} stalled mid-answer for {}s — it looks stuck",
+                            Self::STALL.as_secs()
+                        )
+                    } else {
+                        stuck(started.elapsed())
+                    }
+                })?;
+            let Some(chunk) = next else { break };
             let bytes = chunk.context("error reading chat stream")?;
             buf.extend_from_slice(&bytes);
 
@@ -326,6 +355,7 @@ impl Ollama {
                     continue;
                 }
                 if let Ok(parsed) = serde_json::from_slice::<ChatChunk>(line) {
+                    any_token = true;
                     if let Some(delta) = parsed.message {
                         if !delta.content.is_empty() {
                             on_token(&delta.content);
@@ -416,6 +446,7 @@ impl Ollama {
         let resp = self
             .http
             .get(self.url("/api/tags"))
+            .timeout(std::time::Duration::from_secs(10))
             .send()
             .await
             .context("ollama tags request failed")?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -469,6 +469,7 @@ pub fn run() {
             commands::send_message,
             commands::send_message_agentic,
             commands::cancel_generation,
+            commands::warm_chat_models,
             commands::open_in_terminal,
             commands::start_ollama,
             commands::suggest_notebook,

--- a/src-tauri/src/retrieval_eval.rs
+++ b/src-tauri/src/retrieval_eval.rs
@@ -3101,6 +3101,59 @@ async fn score_kind_with(
     mean(&rows, None)
 }
 
+/// The gap query's lexical gate (`commands::gap_gate`) over the fixture
+/// datasets on the flat search: how often each kind would still pay for
+/// the Small-role call, and that every multi-hop query does. Deterministic.
+#[tokio::test]
+async fn eval_gap_gate() {
+    let Some(ai) = eval_ai().await else { return };
+    let dir = std::env::temp_dir().join(format!("nbl-eval-gate-{}", uuid::Uuid::new_v4()));
+    let db = Db::open(&dir).await.expect("open db");
+    let nb = "eval-nb";
+    seed_corpus(&ai, &db, nb).await;
+    seed_docs(&ai, &db, nb, EXTRA_CORPUS, "x-").await;
+    let mut asked: std::collections::BTreeMap<String, (usize, usize)> = Default::default();
+    let mut multihop_skipped: Vec<String> = Vec::new();
+    for ds in load_datasets()
+        .into_iter()
+        .filter(|d| d.corpus != "outline")
+    {
+        let texts: Vec<String> = ds.queries.iter().map(|q| q.query.clone()).collect();
+        let qvecs = ai.embed(&texts).await.expect("embed");
+        for (q, qvec) in ds.queries.iter().zip(qvecs) {
+            let trace = db
+                .search_chunks_trace(nb, qvec, &q.query, K, None)
+                .await
+                .expect("search");
+            let gate = crate::commands::gap_gate(&q.query, &trace.final_hits);
+            let e = asked.entry(q.kind.clone()).or_default();
+            e.1 += 1;
+            if gate.is_some() {
+                e.0 += 1;
+            } else if q.kind == "multihop" {
+                multihop_skipped.push(q.query.clone());
+            }
+            if std::env::var("ALCHEMY_TRACE_GATE").is_ok() {
+                eprintln!(
+                    "  {:<10} {:<10} {}",
+                    q.kind,
+                    gate.unwrap_or("skip"),
+                    q.query
+                );
+            }
+        }
+    }
+    eprintln!("\ngap gate asks (kind: asked/total):");
+    for (kind, (a, n)) in &asked {
+        eprintln!("  {kind:<10} {a}/{n}");
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+    assert!(
+        multihop_skipped.is_empty(),
+        "multi-hop queries the gate would skip: {multihop_skipped:?}"
+    );
+}
+
 /// Phase 3's escalation, on versus off, per kind, over the outline corpus
 /// with the handwritten section summaries as the outline (so the
 /// escalation's own contribution is measured, not the generator's). Needs

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -1145,3 +1145,30 @@ fn gap_gate_opens_only_for_linked_or_unmentioned_subjects() {
         "two subjects the pool never mentions"
     );
 }
+
+/// A stuck Ollama runner (`Ollama::run_stream`'s deadlines) reads as a
+/// Terminal fix the error row can offer — `ollama stop <model>` — and that
+/// command passes the Terminal allowlist while an unsafe name does not.
+#[test]
+fn stuck_ollama_reads_as_a_stop_fix() {
+    let advice = crate::commands::classify_model_error(
+        "ollama: gemma4:12b-mlx sent nothing for 90s (model was loaded) — it looks stuck",
+    )
+    .expect("classified");
+    assert!(
+        advice.contains("run `ollama stop gemma4:12b-mlx`"),
+        "{advice}"
+    );
+    assert!(advice.contains("Settings → Models"), "{advice}");
+    let stalled = crate::commands::classify_model_error(
+        "ollama: bonsai stalled mid-answer for 30s — it looks stuck",
+    )
+    .expect("classified");
+    assert!(stalled.contains("`ollama stop bonsai`"), "{stalled}");
+    assert!(crate::commands::terminal_command_allowed(
+        "ollama stop gemma4:12b-mlx"
+    ));
+    assert!(!crate::commands::terminal_command_allowed(
+        "ollama stop x; rm -rf ~"
+    ));
+}

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -1100,3 +1100,48 @@ fn a_commission_is_built_the_same_way_whoever_asks() {
         .expect("a blank name is not a refusal");
     assert_eq!(unnamed.name, "Commissioned run");
 }
+
+/// The gap query's lexical gate (`commands::gap_gate`): an empty pool, a
+/// linking question, and two unmentioned terms open it; a single-subject
+/// question the pool already answers keeps the model call out of the path.
+#[test]
+fn gap_gate_opens_only_for_linked_or_unmentioned_subjects() {
+    let cite = |snippet: &str| crate::models::Citation {
+        chunk_id: "c".into(),
+        source_id: "s".into(),
+        source_title: "Home Network Guide".into(),
+        source_path: String::new(),
+        note_id: String::new(),
+        gist: false,
+        snote: false,
+        ordinal: 0,
+        snippet: snippet.into(),
+        distance: 0.0,
+        section: String::new(),
+    };
+    let pool = vec![cite(
+        "Guests join the wifi through the captive portal; the passphrase rotates monthly.",
+    )];
+    assert_eq!(crate::commands::gap_gate("anything", &[]), Some("empty"));
+    assert_eq!(
+        crate::commands::gap_gate("how do guests get on the wifi?", &pool),
+        None,
+        "one subject the pool covers"
+    );
+    assert_eq!(
+        crate::commands::gap_gate("compare guest wifi at home versus the office", &pool),
+        Some("linked")
+    );
+    assert_eq!(
+        crate::commands::gap_gate("what was the passphrase policy from 2024 to 2025?", &pool),
+        Some("range")
+    );
+    assert_eq!(
+        crate::commands::gap_gate(
+            "what does the sourdough starter schedule say about hydration?",
+            &pool
+        ),
+        Some("uncovered"),
+        "two subjects the pool never mentions"
+    );
+}

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -945,6 +945,10 @@ export function ChatPanel() {
                   : undefined
               }
               onChange={(e) => {
+                // First keystroke of a draft: start loading the models now,
+                // so a cold local model's load overlaps the typing instead
+                // of following Send. Throttled backend-side (10 min).
+                if (!draft && e.target.value) void api.warmChatModels().catch(() => {});
                 setDraft(e.target.value);
                 // Any edit re-opens the picker (Esc/blur only dismiss the
                 // current text) and resets the highlight to the top match.

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -396,6 +396,8 @@ export const api = {
     run(cmd<void>("delete_message", { messageId })),
   cancelGeneration: (scope?: "chat" | "artifact" | "tts" | "meta") =>
     run(cmd<void>("cancel_generation", { scope })),
+  /** Preload the chat models while the user types (fire-and-forget). */
+  warmChatModels: () => run(cmd<void>("warm_chat_models")),
   suggestFollowups: (notebookId: string) =>
     run(query<string[]>("suggest_followups", { notebookId })),
   generateNotebookSummary: (notebookId: string) =>


### PR DESCRIPTION
Three findings from the chat timing traces (`traces/retrieval.jsonl`, `chat-timing` rows), each fixed at its cause.

**Helper calls could wait on a wedged local server.** On Sep 1 two gap queries sat behind Ollama requests that died at Ollama's own 10-minute mark (server log: `500 | 10m0s | POST /api/chat`), then fell through to Codex — first token at 600 s and 292 s. `Ai::helpers()` is the handle for the calls ahead of an answer (gap query, outline pick): Small role only, 10-second ceiling, skipped rather than fallen through.

**The gap query ran on every question.** Its self-gating is itself a model call, 2–9 s of every retrieval stage on local models. `commands::gap_gate` opens it only for questions that link things (compare, versus, from … to) or name two terms the pool never mentions. Measured on the fixture datasets (`eval_gap_gate`, deterministic, runs under `ALCHEMY_EVALS=1`):

| kind | asks |
| --- | --- |
| multihop | 4/4 |
| paraphrase | 2/9 |
| metadata | 1/4 |
| exact | 0/7 |
| section | 0/6 |

**Cold model loads dominated local first-token time** (111 s vs 10 s for lfm2.5, 115 s vs 26 s for qwen3.8 27B). The composer's first keystroke calls `warm_chat_models`, which asks Ollama to load the chat and Small models (Ollama's empty-messages preload), throttled to once per 10 minutes. Event-driven, never from a tick. Non-Ollama providers have nothing to warm.

Also: `promptChars` on the chat timing line, so prefill can be measured next.

Verified in the dev app: first keystroke → `warm: digitsflow/bonsai-8b:latest resident after 17 ms`; a plain question → trace `gapGate: "uncovered"`, gap stage capped at 10,001 ms while a background sweep held Ollama's queue, answer proceeded on the flat search.

Found on the way: the background sweep's Small-role calls share Ollama's single queue with foreground helpers, so a sweep in flight is what pushed that gap query past 10 s. Filed as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Second commit — Ollama deadlines, no silent fall-through

The Ollama client's blanket 10-minute request timeout is gone. Chat runs under what a healthy server meets: connect 5 s, first token within 90 s when `/api/ps` says the model is resident (180 s when it still has to load), no silence over 30 s mid-answer. Non-streaming chat rides the same request. A miss is an error naming the model, which the chat error row turns into **Retry**, an **`ollama stop <model>`** Terminal fix (allowlisted), **Settings → Models**, and the existing rerun-on-another-engine offers.

The Small role no longer falls through to the chat provider on error (it used to hand work to Codex silently, after the small engine's full timeout). The call fails and the caller decides; `Ai::background()` is gone since strict is the only mode. RFC-inference-providers updated to match.

Unit tests cover the classifier and the allowlist; the stuck-server path itself was not exercised live (it needs a wedged Ollama).
