### PR TITLE
Background Small-role calls yield to foreground requests

### DIFF
--- a/src-tauri/src/ai/mod.rs
+++ b/src-tauri/src/ai/mod.rs
@@ -577,6 +577,9 @@ pub struct Ai {
     /// engine. A gateway or agent CLI is the user's *chat* spend; a sweep
     /// that kept running while the local small model was down would spend
     /// it silently, a dozen calls a minute (it did, 2026-09-01).
+    /// A background handle: every Small-role call first waits for the
+    /// foreground queue to clear (`crate::foreground`).
+    yields: bool,
     /// Ceiling on one Small-role call — set by `helpers()` for the calls a
     /// person is waiting behind (gap query, outline pick). None = the
     /// engine's own transport timeout.
@@ -749,6 +752,7 @@ impl Ai {
             crate::inference::rerank::XencModel::Small,
         );
         Self {
+            yields: false,
             small_timeout: None,
             config,
             router,
@@ -1035,6 +1039,9 @@ impl Ai {
                 _ => true,
             };
             if usable {
+                if self.yields {
+                    crate::foreground::wait_idle().await;
+                }
                 let outcome = match self.small_timeout {
                     Some(limit) => match tokio::time::timeout(limit, engine.chat(messages)).await {
                         Ok(res) => res,
@@ -1061,6 +1068,17 @@ impl Ai {
     /// when it is wedged, its requests die at its own 10-minute mark, and a
     /// gap query that waited the whole way put the first token 600 s out.
     pub const HELPER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+    /// This handle for background work — sweeps, the nightly weave, card
+    /// triage and enrichment. Its Small-role calls go last: each one waits
+    /// for every foreground request (`crate::foreground::Guard`) to finish
+    /// before it takes the local model's single slot. Measured need: a
+    /// sweep's back-to-back 3–4 s calls pushed a chat helper past its
+    /// ten-second ceiling on a healthy server.
+    pub fn background(mut self) -> Self {
+        self.yields = true;
+        self
+    }
 
     /// This handle for the helpers that run *before* an answer a person is
     /// waiting on — the gap query, the outline pick. The Small role gets

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2367,6 +2367,58 @@ pub(crate) fn gap_gate(question: &str, pool: &[Citation]) -> Option<&'static str
     None
 }
 
+/// The gap query a Small-role reply carries, or None when the reply says
+/// NONE, restates the question, or parrots the prompt. Three guards, each
+/// found live: small models restate the question instead of answering
+/// NONE (Jaccard ≈0.7 catches that while a targeted query, which reuses
+/// only part of the question's words, passes at ≈0.4); they answer
+/// "…reply NONE instead" with NONE buried mid-sentence; and bonsai once
+/// echoed the instruction itself — "ONLY the search query text for the
+/// missing evidence…" — which then ran as a search.
+pub(crate) fn gap_query_from_reply(question: &str, reply: &str) -> Option<String> {
+    let gq = reply
+        .lines()
+        .next()
+        .unwrap_or("")
+        .trim()
+        .trim_matches(|c: char| c == '"' || c == '.' || c.is_whitespace())
+        .to_string();
+    if gq.is_empty() || gq.len() > 200 {
+        return None;
+    }
+    let lower = gq.to_ascii_lowercase();
+    if lower
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .any(|w| w == "none")
+    {
+        return None;
+    }
+    const PARROT: &[&str] = &[
+        "search query",
+        "missing evidence",
+        "restates the question",
+        "excerpts",
+        "second entity",
+    ];
+    if PARROT.iter().any(|p| lower.contains(p)) {
+        return None;
+    }
+    let words = |s: &str| -> std::collections::HashSet<String> {
+        s.to_lowercase()
+            .split(|c: char| !c.is_alphanumeric())
+            .filter(|w| w.len() > 2)
+            .map(str::to_string)
+            .collect()
+    };
+    let (qw, gw) = (words(question), words(&gq));
+    let overlap = qw.intersection(&gw).count();
+    let union = qw.union(&gw).count();
+    if union > 0 && overlap * 10 >= union * 6 {
+        return None;
+    }
+    Some(gq)
+}
+
 /// Iterative retrieval's gap loop (RFC-judged-evals §4.3): show the small
 /// tier the first-pass excerpts, ask what ONE search would find the
 /// missing evidence, run it, and merge. Self-gating — NONE means the
@@ -2413,37 +2465,7 @@ pub(crate) async fn gap_retrieve(
         )
         .await
         .ok()?;
-    let gq = reply
-        .text
-        .lines()
-        .next()
-        .unwrap_or("")
-        .trim()
-        .trim_matches('"')
-        .trim_end_matches('.')
-        .to_string();
-    if gq.is_empty() || gq.len() > 200 || gq.to_ascii_lowercase().starts_with("none") {
-        return None;
-    }
-    // Rephrase guard (found live, not in the harness): small models
-    // sometimes restate the question instead of answering NONE — a second
-    // search for the same thing buys nothing. Jaccard word similarity
-    // catches the restatement (≈0.7) while sparing a targeted gap query,
-    // which reuses only PART of the question's words (≈0.4 on the live
-    // comparison case) — plain question-overlap would kill both.
-    let words = |s: &str| -> std::collections::HashSet<String> {
-        s.to_lowercase()
-            .split(|c: char| !c.is_alphanumeric())
-            .filter(|w| w.len() > 2)
-            .map(str::to_string)
-            .collect()
-    };
-    let (qw, gw) = (words(question), words(&gq));
-    let overlap = qw.intersection(&gw).count();
-    let union = qw.union(&gw).count();
-    if union > 0 && overlap * 10 >= union * 6 {
-        return None;
-    }
+    let gq = gap_query_from_reply(question, &reply.text)?;
     let qvec = ai.embed_one(&gq).await.ok()?;
     let extra = db
         .search_chunks_trace(notebook_id, qvec, &gq, fetch_k, source_ids)
@@ -8644,6 +8666,9 @@ pub async fn send_message(
     source_ids: Option<Vec<String>>,
     provider_override: Option<String>,
 ) -> Result<Message, String> {
+    // A person is waiting: background Small-role calls stand aside
+    // until this returns (`crate::foreground`).
+    let _foreground = crate::foreground::begin();
     let content = content.trim().to_string();
     if content.is_empty() {
         return Err("Message is empty".into());
@@ -9021,6 +9046,9 @@ pub async fn send_message_agentic(
     config: Option<ChatConfig>,
     source_ids: Option<Vec<String>>,
 ) -> Result<Message, String> {
+    // A person is waiting: background Small-role calls stand aside
+    // until this returns (`crate::foreground`).
+    let _foreground = crate::foreground::begin();
     let content = content.trim().to_string();
     if content.is_empty() {
         return Err("Message is empty".into());
@@ -10380,6 +10408,9 @@ pub async fn generate_artifact(
     prompt: Option<String>,
     source_ids: Option<Vec<String>>,
 ) -> Result<Note, String> {
+    // A person is waiting: background Small-role calls stand aside
+    // until this returns (`crate::foreground`).
+    let _foreground = crate::foreground::begin();
     let prompt = prompt.unwrap_or_default();
     let cancel = state.begin_generation(&format!("artifact:{}", window.label()));
     let produced = tokio::select! {
@@ -13320,6 +13351,9 @@ pub async fn ask_everything(
     // thread back); absent means those simply have nothing to act on.
     thread_id: Option<String>,
 ) -> Result<MetaAnswer, String> {
+    // A person is waiting: background Small-role calls stand aside
+    // until this returns (`crate::foreground`).
+    let _foreground = crate::foreground::begin();
     touch_activity();
     let question = question.trim().to_string();
     if question.is_empty() {

--- a/src-tauri/src/commands/registry.rs
+++ b/src-tauri/src/commands/registry.rs
@@ -1235,6 +1235,7 @@ pub(crate) async fn suggest_now(
     // strip re-sorts itself on the registry bump.
     let db = db.clone();
     tauri::async_runtime::spawn(async move {
+        let ai = ai.background();
         if let Err(err) = triage_suggested_cards(&db, &ai).await {
             crate::note!("registry triage failed: {err:#}");
         }

--- a/src-tauri/src/commands/weave.rs
+++ b/src-tauri/src/commands/weave.rs
@@ -80,6 +80,7 @@ const MAX_NIGHTLY_SOURCES: usize = 8;
 /// Budget-checked per source rather than once up front, because the cost is
 /// per judgment and a night can run out halfway through the list.
 pub(crate) fn spawn_nightly(db: Arc<Db>, ai: Ai, since: i64, budget: String) {
+    let ai = ai.background();
     // One nightly pass at a time, and never blocked by arrival judgments:
     // the pass is serial internally, so it is not the pile-up the arrival
     // cap guards against.

--- a/src-tauri/src/foreground.rs
+++ b/src-tauri/src/foreground.rs
@@ -1,0 +1,90 @@
+//! Foreground first on the local model queue.
+//!
+//! Ollama serves one request per model at a time. The gist, section, and
+//! tag sweeps issue Small-role calls back to back (3–4 s each), so a helper
+//! in front of an answer — the gap query, the outline pick, ten-second
+//! ceiling — queued behind them and timed out on a perfectly healthy
+//! server (measured: `gapMs 10001` with a sweep in flight).
+//!
+//! The rule: a person's request holds a [`Guard`] for its whole duration
+//! (chat, deep research, ask-everything, studio generation), and a
+//! background handle (`Ai::background`) waits for the count to reach zero
+//! before each Small-role call. The sweep finishes the call it is on — at
+//! most a few seconds — then stands aside until the foreground is quiet.
+//! Nothing is cancelled, nothing is lost; the sweep just goes last.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static ACTIVE: AtomicUsize = AtomicUsize::new(0);
+
+/// A foreground request in flight. Dropping it releases the queue.
+pub struct Guard(());
+
+/// Mark a person's request as in flight until the guard drops.
+pub fn begin() -> Guard {
+    ACTIVE.fetch_add(1, Ordering::SeqCst);
+    Guard(())
+}
+
+impl Drop for Guard {
+    fn drop(&mut self) {
+        ACTIVE.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+/// Foreground requests currently in flight.
+pub fn active() -> usize {
+    ACTIVE.load(Ordering::SeqCst)
+}
+
+/// Poll spacing while a background call waits its turn.
+const TICK: std::time::Duration = std::time::Duration::from_millis(250);
+
+/// Wait until no foreground request is in flight. Returns at once when
+/// the queue is quiet; otherwise polls, noting every ten seconds so a
+/// stalled sweep reads as waiting rather than dead.
+pub async fn wait_idle() {
+    let mut waited = std::time::Duration::ZERO;
+    while active() > 0 {
+        tokio::time::sleep(TICK).await;
+        waited += TICK;
+        if waited.as_millis().is_multiple_of(10_000) {
+            crate::note!(
+                "background: waiting on {} foreground request(s), {}s",
+                active(),
+                waited.as_secs()
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Idle returns at once; a held guard holds `wait_idle` until it drops.
+    #[tokio::test]
+    async fn background_waits_for_the_foreground() {
+        let t = std::time::Instant::now();
+        wait_idle().await;
+        assert!(t.elapsed() < TICK, "idle queue should not wait");
+
+        let guard = begin();
+        assert_eq!(active(), 1);
+        let released = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let flag = released.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(TICK * 2).await;
+            flag.store(true, Ordering::SeqCst);
+            drop(guard);
+        });
+        let t = std::time::Instant::now();
+        wait_idle().await;
+        assert!(
+            released.load(Ordering::SeqCst),
+            "returned before the guard dropped"
+        );
+        assert!(t.elapsed() >= TICK * 2);
+        assert_eq!(active(), 0);
+    }
+}

--- a/src-tauri/src/gist.rs
+++ b/src-tauri/src/gist.rs
@@ -834,6 +834,7 @@ pub fn spawn_sweep(db: std::sync::Arc<Db>, ai: Ai) {
     if !ai.config().source_gists {
         return;
     }
+    let ai = ai.background();
     if SWEEPING
         .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
         .is_err()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ mod dragout;
 mod examples;
 mod export;
 mod filesearch;
+mod foreground;
 mod freshness;
 mod genqueue;
 mod gist;

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -1172,3 +1172,34 @@ fn stuck_ollama_reads_as_a_stop_fix() {
         "ollama stop x; rm -rf ~"
     ));
 }
+
+/// `gap_query_from_reply`: NONE anywhere, a parroted instruction, and a
+/// restated question all read as "no gap"; a targeted query passes.
+#[test]
+fn gap_reply_guards_reject_none_parrots_and_restatements() {
+    let q = "compare how guests get wifi at home versus in the office";
+    let gap = crate::commands::gap_query_from_reply;
+    assert_eq!(gap(q, "NONE"), None);
+    assert_eq!(
+        gap(q, "Everything needed is here, so reply NONE instead."),
+        None
+    );
+    assert_eq!(
+        gap(
+            q,
+            "ONLY the search query text for the missing evidence — a search that merely \
+             restates the question is useless; reply NONE instead"
+        ),
+        None,
+        "the prompt's own instruction is not a query"
+    );
+    assert_eq!(
+        gap(q, "how do guests get wifi at home versus in the office?"),
+        None,
+        "restatement"
+    );
+    assert_eq!(
+        gap(q, "\"office guest network passphrase\".").as_deref(),
+        Some("office guest network passphrase")
+    );
+}


### PR DESCRIPTION
Closes bead alchemy-release-7y3.

Ollama serves one request per model at a time, and the gist/section/tag sweeps issue Small-role calls back to back (3–4 s each). A helper in front of an answer (gap query, outline pick, 10 s ceiling) queued behind them and timed out on a healthy server — `gapMs 10001` with a sweep in flight.

**Mechanism** (`src-tauri/src/foreground.rs`): a person's request holds a guard for its duration (`send_message`, `send_message_agentic`, `generate_artifact`, `ask_everything`); a background handle (`Ai::background()`, back with a new meaning) waits for the count to reach zero before each Small-role call. The sweep finishes the call it is on, then stands aside. Nothing is cancelled. Sweeps, the nightly weave, and Registry triage take the handle.

**Measured** in the dev app, question sent while a 12-chapter import's section sweep ran:

| | gap stage |
| --- | --- |
| before (sweep in flight) | 10,002 ms (ceiling hit, helper skipped) |
| after (sweep in flight) | 3,806 ms (one in-flight call, then the helper ran) |
| no sweep | 663 ms |

Dev log: `background: waiting on 1 foreground request(s), 10s`.

**Also found**: the small model once echoed the prompt's instruction as its gap query ("ONLY the search query text for the missing evidence…"), which then ran as a search. `gap_query_from_reply` now rejects NONE anywhere in the line, parroted instruction phrases, and restatements; unit-tested.

**Not fixed here**: a second Alchemy process (the installed app next to a dev build) sweeps the same store and shares the same Ollama queue; no in-process rule can yield across processes. That is the "quit the dev app" rule, not a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
