### PR TITLE
Events: feeds, watchers, arrivals, live cards, agent stream

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -137,19 +137,30 @@ introduce a webfont; the system stack is deliberate.
   opacity, no pointer events.
 - **Inputs / Textareas**: 32px tall, `surface-2` fill, 1px `--input` border,
   radius 6px; focus swaps border to `ring/70` plus a 1px ring — no glow.
+- **Selects** (`ui.Select`): a native `<select>` with `appearance-none` and
+  a lucide chevron drawn over it, same height and fill as inputs. Never a
+  bare styled `<select>` — WKWebView ignores its padding and height, so the
+  text sits flush against the border.
 - **Cards / list rows**: `surface` fill, 1px `--border`, radius 6–10px; hover
   raises to `surface-2` and `--border-strong`. Clickable cards use
   `ui.CardAction` — an `absolute inset-0` real button rendered as a *sibling*
   of the card content (card is `relative`, secondary controls sit above it
   with `relative z-20`), so nothing interactive ever nests. Row actions
-  hidden until hover **or focus-within**, never hover-only.
+  hidden until hover **or focus-within**, never hover-only. **At most two
+  quick actions show on a row**; everything else — edit, delete, pause —
+  lives in the row's ⋯ menu (`ui.RowMenu`), which right-clicking the row
+  opens too (§9, objects are direct). List containers are `select-none`:
+  row text is chrome, never a text selection.
 - **Menus**: `menu-glass` material (see §2), hairline edge (see §6), radius 6px, 13px items;
   open focuses the first item, arrows cycle, Escape closes and restores focus,
   `role="menu"`/`menuitem`.
 - **Modals**: `elevated`, radius 10px, hairline + soft shadow, 44px header
   with 13px semibold title; scrim `black/40` with 2px backdrop blur. Escape
   closes; focus is trapped and restored. Confirmations use the app modal,
-  never `window.confirm`.
+  never `window.confirm`. **Actions live in the `footer` slot** — a fixed
+  bar under the scrolling body — never inside the form, so a long dialog
+  keeps Cancel and Save in reach (a submit button outside the form points
+  at it with `form="<id>"`).
 - **Toasts**: bottom-center, `elevated/90` with backdrop blur, status-tinted
   border, 12px text.
 - **Icons**: lucide, 16px (`h-4`) in headers/toolbars, 14px (`h-3.5`) in dense

--- a/cli/alchemy.mjs
+++ b/cli/alchemy.mjs
@@ -24,11 +24,14 @@ Usage:
   alchemy add <file-or-url>... --notebook <id-or-title> [--title <title>] [--json]
   alchemy add - --notebook <id-or-title> [--title <title>] [--json]
   alchemy search <query...> [--notebook <id-or-title>] [--limit <1-20>] [--json]
+  alchemy events [--notebook <id-or-title>] [--kinds <k,k>] [--since <ms|24h|7d>] [--follow] [--json]
 
 Commands:
   notebooks  List notebooks and their ids (--all includes archived).
   add        Add local files, web URLs, or stdin (use - or pipe with no input).
   search     Search one notebook, or all notebooks when --notebook is omitted.
+  events     Source-change events (added, updated, removed, unreachable,
+             completed, moved). --follow tails the app's live stream.
 
 Connection:
   The Alchemy app must be running with MCP enabled. The CLI discovers the
@@ -40,7 +43,60 @@ Examples:
   alchemy add report.pdf https://example.com --notebook "Project Atlas"
   pbpaste | alchemy add --notebook "Project Atlas" --title "Meeting notes"
   alchemy search "renewal risk" --notebook "Project Atlas"
-  alchemy search "where did I save the contractor agreement?" --json`;
+  alchemy search "where did I save the contractor agreement?" --json
+  alchemy events --kinds added --since 7d
+  alchemy events --follow --json | jq -c 'select(.kind == "added")'`;
+
+export const EVENT_KINDS = ["added", "updated", "removed", "unreachable", "completed", "moved"];
+
+/** "24h" / "7d" / "90m" / a raw epoch-millisecond number → epoch ms floor. */
+export function parseSince(value, now = Date.now()) {
+  const m = /^(\d+)([mhd])$/.exec(value);
+  if (m) {
+    const unit = { m: 60_000, h: 3_600_000, d: 86_400_000 }[m[2]];
+    return now - Number(m[1]) * unit;
+  }
+  if (/^\d{10,}$/.test(value)) return Number(value);
+  throw new CliError("--since takes a duration like 24h, 7d, 90m, or an epoch-millisecond timestamp");
+}
+
+/** The live stream sits beside the MCP endpoint: …/mcp → …/events. */
+export function eventsUrl(mcpUrl) {
+  const url = new URL(mcpUrl);
+  url.pathname = url.pathname.replace(/\/mcp\/?$/, "/events");
+  if (!url.pathname.endsWith("/events")) url.pathname = "/events";
+  url.search = "";
+  return url.toString();
+}
+
+/** Incremental Server-Sent Events decoder: feed it chunks, get back the
+ *  parsed `data:` payloads of every complete event, keeping the tail. */
+export function sseEvents(buffer, chunk) {
+  const text = buffer + chunk;
+  const events = [];
+  const blocks = text.split(/\r?\n\r?\n/);
+  const rest = blocks.pop();
+  for (const block of blocks) {
+    const data = block
+      .split(/\r?\n/)
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice(5).trimStart())
+      .join("\n");
+    if (!data) continue;
+    try {
+      events.push(JSON.parse(data));
+    } catch {
+      /* comments and keep-alives carry no JSON */
+    }
+  }
+  return { events, rest };
+}
+
+export function formatEvent(e) {
+  const at = new Date(e.at);
+  const stamp = `${at.getHours().toString().padStart(2, "0")}:${at.getMinutes().toString().padStart(2, "0")}`;
+  return `${stamp}  ${e.kind.padEnd(11)} ${e.sourceTitle} — ${e.detail}`;
+}
 
 export class CliError extends Error {}
 
@@ -121,6 +177,23 @@ export function parseArgs(argv) {
       }
     }
     return { command, mcpUrl, mcpToken, json, notebook, query, limit };
+  }
+
+  if (command === "events") {
+    const notebook = takeOption(args, "--notebook");
+    const rawKinds = takeOption(args, "--kinds");
+    const rawSince = takeOption(args, "--since");
+    const follow = takeFlag(args, "--follow");
+    if (args.length) throw new CliError(`unexpected argument: ${args[0]}`);
+    const kinds = rawKinds
+      ? rawKinds
+          .split(",")
+          .map((k) => k.trim())
+          .filter(Boolean)
+      : undefined;
+    const bad = kinds?.find((k) => !EVENT_KINDS.includes(k));
+    if (bad) throw new CliError(`unknown event kind: ${bad} (one of ${EVENT_KINDS.join(", ")})`);
+    return { command, mcpUrl, mcpToken, json, notebook, kinds, since: rawSince, follow };
   }
 
   throw new CliError(`unknown command: ${command}`);
@@ -432,6 +505,54 @@ export async function run(argv = process.argv.slice(2)) {
       sources.push(await client.call("add_source", { notebook_id: notebook.id, ...args }));
     }
     options.json ? console.log(JSON.stringify(sources, null, 2)) : printAdded(sources);
+    return;
+  }
+
+  if (options.command === "events") {
+    const notebook = options.notebook ? await resolveNotebook(client, options.notebook) : null;
+    const since = options.since ? parseSince(options.since) : undefined;
+    const filter = {
+      ...(notebook ? { notebook_id: notebook.id } : {}),
+      ...(options.kinds ? { kinds: options.kinds } : {}),
+    };
+    const events = await client.call("list_source_events", {
+      ...filter,
+      ...(since !== undefined ? { since } : {}),
+    });
+    const emit = (e) => console.log(options.json ? JSON.stringify(e) : formatEvent(e));
+    // Newest first from the tool; a log reads oldest first.
+    let newest = since ?? 0;
+    for (const e of [...events].reverse()) {
+      emit(e);
+      newest = Math.max(newest, e.at);
+    }
+    if (!options.follow) return;
+    // The live stream replays from the newest event already printed, so
+    // nothing lands twice and nothing between the read and the connect is
+    // lost. Filters apply client-side; the stream carries everything.
+    const url = new URL(eventsUrl(connection.url));
+    url.searchParams.set("since", String(newest));
+    const headers = { accept: "text/event-stream" };
+    if (connection.token) headers.authorization = `Bearer ${connection.token}`;
+    let response;
+    try {
+      response = await fetch(url, { headers });
+    } catch (error) {
+      throw new CliError(`could not open the event stream at ${url} (${error.message})`);
+    }
+    if (!response.ok || !response.body) {
+      throw new CliError(`event stream refused: HTTP ${response.status} (this app may predate /events)`);
+    }
+    let buffer = "";
+    for await (const chunk of response.body.pipeThrough(new TextDecoderStream())) {
+      const parsed = sseEvents(buffer, chunk);
+      buffer = parsed.rest;
+      for (const e of parsed.events) {
+        if (notebook && e.notebookId !== notebook.id) continue;
+        if (options.kinds && !options.kinds.includes(e.kind)) continue;
+        emit(e);
+      }
+    }
     return;
   }
 

--- a/cli/alchemy.test.mjs
+++ b/cli/alchemy.test.mjs
@@ -9,9 +9,13 @@ import {
   McpClient,
   discoverMcpConnection,
   discoverMcpUrl,
+  eventsUrl,
+  formatEvent,
   parseArgs,
+  parseSince,
   resolveNotebook,
   sourceArguments,
+  sseEvents,
   visibleNotebooks,
 } from "./alchemy.mjs";
 
@@ -165,4 +169,34 @@ test("MCP client ignores SSE progress and returns the matching response", async 
   const client = new McpClient("http://127.0.0.1:41414/mcp", fetchImpl);
   assert.deepEqual(await client.call("search", {}), []);
   assert.equal(initialized, true);
+});
+
+test("events: parses filters, rejects unknown kinds, and derives the stream URL", () => {
+  assert.deepEqual(parseArgs(["events", "--kinds", "added,removed", "--since", "7d", "--follow"]), {
+    command: "events",
+    mcpUrl: undefined,
+    mcpToken: undefined,
+    json: false,
+    notebook: undefined,
+    kinds: ["added", "removed"],
+    since: "7d",
+    follow: true,
+  });
+  assert.throws(() => parseArgs(["events", "--kinds", "bogus"]), /unknown event kind: bogus/);
+  assert.throws(() => parseArgs(["events", "extra"]), /unexpected argument/);
+  assert.equal(parseSince("24h", 100_000_000), 100_000_000 - 86_400_000);
+  assert.equal(parseSince("1788300000000"), 1_788_300_000_000);
+  assert.throws(() => parseSince("yesterday"), CliError);
+  assert.equal(eventsUrl("http://127.0.0.1:41415/mcp"), "http://127.0.0.1:41415/events");
+  assert.equal(eventsUrl("http://127.0.0.1:41414/mcp/"), "http://127.0.0.1:41414/events");
+});
+
+test("events: decodes SSE frames incrementally and formats a line", () => {
+  const first = sseEvents("", ": keep-alive\n\ndata: {\"kind\":\"added\",\"at\":1}\n\ndata: {\"ki");
+  assert.deepEqual(first.events, [{ kind: "added", at: 1 }]);
+  const second = sseEvents(first.rest, "nd\":\"removed\",\"at\":2}\n\n");
+  assert.deepEqual(second.events, [{ kind: "removed", at: 2 }]);
+  assert.equal(second.rest, "");
+  const line = formatEvent({ kind: "added", at: Date.UTC(2026, 8, 2, 12, 0), sourceTitle: "Tauri Blog", detail: "2 new entries" });
+  assert.match(line, /^\d\d:\d\d  added       Tauri Blog — 2 new entries$/);
 });

--- a/docs/RFC-events.md
+++ b/docs/RFC-events.md
@@ -415,18 +415,11 @@ timeline.
 - **Card parse drift.** cider output changing shape breaks the stocks card
   silently into "no card". Fallback is prose, so nothing is lost, and a
   fixture test per card pins the format.
-- **cider prints to stderr from library paths.** `watch` announces itself
-  and notes a missing store with `eprintln!`, and `watch_via`'s CLI branch
-  does the same; `eprintln!` panics on a closed stderr and has aborted this
-  app from an FFI callback before (diagnostics.rs). `macwatch.rs` therefore
-  calls `watch` only, filters the stores for presence before calling it, and
-  skips the watch when stderr is already closed. The fix belongs upstream —
-  a quiet library path, or a logging hook — and is a cider follow-up.
-
-## Decisions (2026-09-01)
-
-Three questions the draft left open, settled in review:
-
+- **cider's library paths printed to stderr** (`eprintln!`), which panics
+  on a closed stderr and has aborted this app before. Fixed upstream in
+  cider 0.6.2: the library logs through the `log` facade, and
+  `diagnostics::install_log_bridge` routes those lines into the app log.
+  Alchemy pins 0.6.2 and uses the full `watch_via(Via::Auto)` path.
 - **Feed parents hold a rolling index** of their kept entries and re-embed
   on change (§2). Reports and the wiki fold got measurably better once they
   could see indexes and prior versions of themselves; feeds start there.

--- a/docs/RFC-events.md
+++ b/docs/RFC-events.md
@@ -117,8 +117,8 @@ unchanged document is a no-op at the same cost as a Mac resync today.
 
 The parent is not empty. Its text is a **rolling index**: the feed's
 description plus one line per kept entry (date, title, first sentence),
-rewritten and re-embedded whenever an entry lands. \"What's new in the
-Tauri blog\" retrieves the parent; a specific claim retrieves the child.
+rewritten and re-embedded whenever an entry lands. "What's new in the
+Tauri blog" retrieves the parent; a specific claim retrieves the child.
 This is the same lesson the wiki fold and living reports taught: a
 synthesized index over its own history gives the next judgement enough
 context to be a judgement, and the `updated` event's diff keeps the
@@ -330,7 +330,8 @@ Each phase is its own change with its own gate, in dependency order:
 
 1. **Vocabulary + producers** — `added`/`removed`/`unreachable` from the
    existing reconcilers, trigger filters, `list_source_events` filters.
-   *Gate:* a folder add of 3 files writes 3 `added` rows and one
+   *Gate:* a folder add of 3 files writes **one** `added` event naming the
+   three files (never one row per file — cost rule 3) and one
    `sources://changed`; a filtered standing question ignores events outside
    its filter (unit tests beside `is_due`).
 2. **Feeds** — parent/child shape, poller, sniffing, tier-1 discovery into

--- a/docs/RFC-events.md
+++ b/docs/RFC-events.md
@@ -1,6 +1,8 @@
 # RFC: Events — feeds, watchers, arrivals, and live cards
 
-Status: draft, for review (2026-09-01). Tracking: `bd show alchemy-release-jcd`.
+Status: implementing on `cld/events` (2026-09-02) — phases 1–4 and 6 landed
+and live-verified; phase 5 (cider deltas) waits on the cider 0.5 release.
+Tracking: `bd show alchemy-release-jcd`.
 Origin: "explore bringing in realtime or event-based data." Companion to
 [RFC-night-shift.md](RFC-night-shift.md) (the scheduler and `source_events`),
 [RFC-living-notebook.md](RFC-living-notebook.md) (growth, consent tiers), and
@@ -354,7 +356,9 @@ Each phase is its own change with its own gate, in dependency order:
    `updated` diff of the list.
 6. **Agent stream** — `/events` SSE, CLI `events --follow`, ACP config.
    *Gate:* `curl -N` tails a live `added` event within a second of the
-   poller writing it.
+   poller writing it. (Landed: `events.rs`, `alchemy events [--follow]`,
+   `events_url` in the discovery file. The ACP `session/new` hand-off is
+   still open.)
 
 Phases 1–3 are the product; 4–6 are cost and reach. Nothing here is a
 timeline.

--- a/docs/RFC-events.md
+++ b/docs/RFC-events.md
@@ -236,8 +236,7 @@ One strip, two places, reading `source_events_since` and nothing else:
   "3 new from *Tauri blog* · 1 page changed · 2 reminders done". Expands to
   the events, each linking to the entry, the diff, or the item. Source rows
   carry a new-dot until the strip is dismissed. The seen watermark is a
-  per-notebook `seen_events_at` in `localStorage` (mind the StrictMode
-  restore gotcha), not a table — it is a UI convenience.
+  per-notebook row in the `app_state` table (see Decisions).
 - **On Home**, `AwayDigest` gains the same tallies beside reports, in the
   steward sidebar RFC-v12-steward §2 reserved.
 
@@ -407,11 +406,15 @@ Three questions the draft left open, settled in review:
 - **Feed parents hold a rolling index** of their kept entries and re-embed
   on change (§2). Reports and the wiki fold got measurably better once they
   could see indexes and prior versions of themselves; feeds start there.
-- **Arrivals watermark is per notebook**, in `localStorage`. Notebooks are
+- **Arrivals watermark is per notebook, in the database.** Notebooks are
   the isolation boundary the user reaches for, while the registry, staff
   history, activity, and global chat all draw their value from everything
-  living in one database — so the watermark is UI state, not a table, and
-  nothing about events becomes notebook-partitioned storage.
+  living in one database — so nothing about events becomes
+  notebook-partitioned storage. (Revised 2026-09-02: the draft said
+  `localStorage`; the app is single-tenant by design and already has a
+  database, so small state — this watermark, feed poll state, discovered
+  feeds, robots caches — lives in one `app_state` key-value table, never
+  in sidecar files or the webview.)
 - **arXiv follows a query, never a category.** A category feed is the
   whole field and would widen a notebook's focus into noise. The host rule
   builds an `export.arxiv.org/api/query` feed from the notebook's standing

--- a/docs/RFC-events.md
+++ b/docs/RFC-events.md
@@ -116,7 +116,7 @@ unchanged because children are just sources. The parent's `mtime` holds
 unchanged document is a no-op at the same cost as a Mac resync today.
 
 The parent is not empty. Its text is a **rolling index**: the feed's
-description plus one line per kept entry (date, title, first sentence),
+description plus one line per kept entry (`- YYYY-MM-DD — [Title](link)`),
 rewritten and re-embedded whenever an entry lands. "What's new in the
 Tauri blog" retrieves the parent; a specific claim retrieves the child.
 This is the same lesson the wiki fold and living reports taught: a

--- a/docs/RFC-events.md
+++ b/docs/RFC-events.md
@@ -148,9 +148,13 @@ doubled on each failure, reset on success. Conditional requests
    nothing extra. Found feeds land as a growth proposal of kind `feed`
    ("*Tauri blog* has a feed — follow it?"), never auto-subscribed.
 2. *Well-known paths.* `/feed`, `/rss`, `/rss.xml`, `/atom.xml`,
-   `/feed.xml`, `/index.xml`, `/feed.json`. One probe per domain, cached
-   in a `feed_hosts.json` beside `git_hosts.json`, run only from the
-   explicit **Follow updates…** menu item on a source — not from the sweep.
+   `/feed.xml`, `/index.xml`, `/feed.json`, and last `/sitemap.xml`. One
+   probe per domain, run only from the explicit **Follow updates…** menu
+   item on a source — not from the sweep. **A sitemap is a watch, not a
+   feed**: connecting one marks every page it lists as seen and ingests
+   nothing; only pages that appear later arrive, each fetched through the
+   normal page path under the same caps. Watching a site is not copying
+   it, and no starter notebook ships one — a user who wants it follows it.
 3. *Host rules.* GitHub repo → `releases.atom` and `commits.atom`;
    Wikipedia article → page-history Atom; YouTube channel → the channel's
    `videos.xml`; arXiv abs/pdf → an `export.arxiv.org/api/query` feed built

--- a/docs/RFC-events.md
+++ b/docs/RFC-events.md
@@ -1,7 +1,8 @@
 # RFC: Events — feeds, watchers, arrivals, and live cards
 
 Status: implementing on `cld/events` (2026-09-02) — phases 1–4 and 6 landed
-and live-verified; phase 5 (cider deltas) waits on the cider 0.5 release.
+and live-verified; phase 5 (Mac item events) landed against cider 0.6 and
+awaits its live check.
 Tracking: `bd show alchemy-release-jcd`.
 Origin: "explore bringing in realtime or event-based data." Companion to
 [RFC-night-shift.md](RFC-night-shift.md) (the scheduler and `source_events`),
@@ -202,15 +203,26 @@ Debounce matters more than latency: a folder sync tool writing 400 files
 must land as one rescan and one coalesced batch of events, or it recreates
 the Lance scan storms.
 
-**Mac events via cider.** cider reads the Reminders and Calendar SQLite
-stores directly and already returns stable IDs and `modified_at`. Upstream
-(`cider_lib`, fix-there-then-bump per house rule), each list call gains
-`since: Option<DateTime>`; Alchemy keeps the last high-water mark per Mac
-source and asks for the delta, producing `added`/`completed`/`moved`/
-`updated` per item instead of one whole-list diff. A later `cider watch`
-that FSEvents the store files and yields a change stream slots in behind
-the same call, so Alchemy's side does not change twice. Mail stays out as
-a source, as RFC-cider-tools decided; nothing here reopens that.
+**Mac events via cider.** cider 0.6 (linked from its git tag until it
+publishes) gives two things: `since: Option<DateTime>` on the Reminders,
+Calendar, and Notes list calls, and `watch` — FSEvents over the directories
+those apps write to, folded into one event per store. Alchemy takes the
+watch (`macwatch.rs`): one resident task over Reminders, Calendar, and
+Notes, debounced two seconds per provider, and on an event every Mac source
+of that provider re-fetches through the ordinary path — one cider read and
+a hash compare each, a reingest only where the rendering moved. The
+fifteen-minute sweep cadence stays underneath it. Item-level events do not
+use `since`: the stored rendering already carries the ids, due dates, days,
+and times a delta needs, so `mac::item_events` diffs the old and new
+renderings and writes `completed` / `moved` / `added` / `removed` per item
+— the same answer whether the change arrived through the watch, the sweep,
+or one of Alchemy's own write-backs, and no high-water mark to keep per
+source. A calendar window slides every fetch, so days that fell off the
+front and days that rolled in at the back are not events. When the items
+have nothing to say (a note, a stocks table, an edited reminder note) the
+generic `updated` diff is written as before; more than 20 item events in
+one resync collapse into one `updated` carrying the count. Mail stays out
+as a source, as RFC-cider-tools decided; nothing here reopens that.
 
 ### 5. Triggers: filters on change-triggered reports
 
@@ -357,7 +369,12 @@ Each phase is its own change with its own gate, in dependency order:
    notebook's folder is a source within 5 seconds.
 5. **cider deltas** — `since` upstream, release, bump; item-level Mac
    events. *Gate:* completing a reminder writes one `completed` row, not an
-   `updated` diff of the list.
+   `updated` diff of the list. (Landed: cider 0.6 from its git tag,
+   `macwatch.rs` over the Reminders/Calendar/Notes stores,
+   `mac::item_events` diffing the stored and fresh renderings,
+   `reingest_with(quiet)` so an item-named resync writes no generic
+   `updated`. The upstream `since` filters are available and unused — the
+   rendering diff needs no high-water mark.)
 6. **Agent stream** — `/events` SSE, CLI `events --follow`, ACP config.
    *Gate:* `curl -N` tails a live `added` event within a second of the
    poller writing it. (Landed: `events.rs`, `alchemy events [--follow]`,
@@ -399,6 +416,13 @@ timeline.
 - **Card parse drift.** cider output changing shape breaks the stocks card
   silently into "no card". Fallback is prose, so nothing is lost, and a
   fixture test per card pins the format.
+- **cider prints to stderr from library paths.** `watch` announces itself
+  and notes a missing store with `eprintln!`, and `watch_via`'s CLI branch
+  does the same; `eprintln!` panics on a closed stderr and has aborted this
+  app from an FFI callback before (diagnostics.rs). `macwatch.rs` therefore
+  calls `watch` only, filters the stores for presence before calling it, and
+  skips the watch when stderr is already closed. The fix belongs upstream —
+  a quiet library path, or a logging hook — and is a cider follow-up.
 
 ## Decisions (2026-09-01)
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -114,6 +114,7 @@ dependencies = [
  "docx-rs",
  "dom_smoothie",
  "fastembed",
+ "feed-rs",
  "futures",
  "futures-util",
  "grep-regex",
@@ -3240,6 +3241,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "feed-rs"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "369995dae0733f1fe5ab0e3f345f6503a5f384179df5d8da333702031a131cf9"
+dependencies = [
+ "chrono",
+ "mediatype",
+ "quick-xml",
+ "regex",
+ "serde",
+ "serde_json",
+ "siphasher",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "field-offset"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6008,6 +6026,15 @@ checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
  "digest 0.11.3",
+]
+
+[[package]]
+name = "mediatype"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120fa187be19d9962f0926633453784691731018a2bf936ddb4e29101b79c4a7"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -126,6 +126,7 @@ dependencies = [
  "kamadak-exif",
  "kokoro-en",
  "lancedb",
+ "log",
  "model2vec-rs",
  "notify",
  "objc2",
@@ -1363,11 +1364,13 @@ dependencies = [
 
 [[package]]
 name = "cider-cli"
-version = "0.6.0"
-source = "git+https://github.com/thrashr888/cider?tag=v0.6.0#03def0295fc62d26ba85910c594d9a5cbe64e5fa"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab1c533503e475fdd8ac32c30f3e02eeabfc4fbc520dc910406049316a3d0b74"
 dependencies = [
  "anyhow",
  "chrono",
+ "log",
  "notify",
  "plist",
  "serde",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1363,15 +1363,17 @@ dependencies = [
 
 [[package]]
 name = "cider-cli"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617218d2457fce5b07fe916332d8bc59d789d51859903e2d4a98bc7965113e22"
+version = "0.6.0"
+source = "git+https://github.com/thrashr888/cider?tag=v0.6.0#03def0295fc62d26ba85910c594d9a5cbe64e5fa"
 dependencies = [
  "anyhow",
  "chrono",
+ "notify",
+ "plist",
  "serde",
  "serde_json",
  "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -126,6 +126,7 @@ dependencies = [
  "kokoro-en",
  "lancedb",
  "model2vec-rs",
+ "notify",
  "objc2",
  "objc2-app-kit",
  "objc2-core-spotlight",
@@ -3368,6 +3369,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "fsst"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4544,6 +4554,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4902,6 +4932,26 @@ dependencies = [
  "pin-project",
  "regex",
  "tokio",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
 ]
 
 [[package]]
@@ -6074,6 +6124,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
@@ -6329,6 +6391,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.13.1",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -9836,7 +9917,7 @@ checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.2.2",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -11206,6 +11287,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -11253,6 +11343,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -11314,6 +11419,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -11332,6 +11443,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -11347,6 +11464,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -11380,6 +11503,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -11395,6 +11524,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -11416,6 +11551,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -11431,6 +11572,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -59,6 +59,8 @@ percent-encoding = "2"
 # Folder scanning for all folder sources (docs/RFC-git-sources.md): ripgrep's
 # own walker — .gitignore/.ignore-aware, symlink-safe, prunes dot-dirs.
 ignore = "0.4"
+# FSEvents for open notebooks' folder sources (fswatch.rs, RFC-events §4).
+notify = "6"
 # Query-time exact-match retrieval leg over repo-backed sources — ripgrep's
 # engine, in-process (RFC-git-sources §6).
 grep-regex = "0.1"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -58,7 +58,10 @@ csv = "1"
 # drops its Clap CLI front-end. cider is Paul's repo: fix bugs there.
 # TODO(cider): back to crates.io once 0.6 publishes (0.6.0 is tagged, not
 # yet on crates.io; the watch module and `since` deltas live there).
-cider = { package = "cider-cli", git = "https://github.com/thrashr888/cider", tag = "v0.6.0", default-features = false }
+cider = { package = "cider-cli", version = "0.6.2", default-features = false }
+# cider logs through the `log` facade (0.6.2); diagnostics.rs installs the
+# logger that routes it into the app log.
+log = "0.4"
 percent-encoding = "2"
 # Folder scanning for all folder sources (docs/RFC-git-sources.md): ripgrep's
 # own walker — .gitignore/.ignore-aware, symlink-safe, prunes dot-dirs.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,6 +44,8 @@ tauri-plugin-dialog = "2"
 tauri-plugin-notification = "2"
 futures-util = "0.3.32"
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
+# RSS / Atom / JSON Feed parsing for feed sources (docs/RFC-events.md §2).
+feed-rs = "2"
 tauri-plugin-debug-bridge = { version = "0.6", optional = true }
 model2vec-rs = "0.2.1"
 tokio-util = { version = "0.7.18", default-features = false }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -56,7 +56,9 @@ csv = "1"
 # Apple Notes/Reminders/Calendar/Stocks sources (mac.rs) — linked, not shelled
 # out to, so users need no `brew install cider`. default-features = false
 # drops its Clap CLI front-end. cider is Paul's repo: fix bugs there.
-cider = { package = "cider-cli", version = "0.4", default-features = false }
+# TODO(cider): back to crates.io once 0.6 publishes (0.6.0 is tagged, not
+# yet on crates.io; the watch module and `since` deltas live there).
+cider = { package = "cider-cli", git = "https://github.com/thrashr888/cider", tag = "v0.6.0", default-features = false }
 percent-encoding = "2"
 # Folder scanning for all folder sources (docs/RFC-git-sources.md): ripgrep's
 # own walker — .gitignore/.ignore-aware, symlink-safe, prunes dot-dirs.

--- a/src-tauri/src/capture.rs
+++ b/src-tauri/src/capture.rs
@@ -371,6 +371,11 @@ pub async fn extract_url_rescued(url: &str) -> Result<Extracted> {
         }
     }
     let fast = ingest::extract_url(url).await;
+    // A feed document is final: nothing about a render pass would improve
+    // raw XML, and its entry text could trip the blocked-page markers.
+    if fast.as_ref().is_ok_and(|ex| ex.source_type == "feed") {
+        return fast;
+    }
     if let Err(err) = &fast {
         if err.downcast_ref::<ingest::HttpErrorPage>().is_some() {
             // The server said the page is gone and the body agreed. Rendering

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -13,7 +13,7 @@ mod brief;
 mod diagnostics;
 mod ledger;
 mod registry;
-mod reports;
+pub(crate) mod reports;
 mod second_look;
 pub(crate) mod weave;
 pub(crate) use brief::ensure_default_brief;
@@ -2771,19 +2771,29 @@ pub(crate) async fn reingest(
             updated.content.clone(),
         );
     }
-    let _ = state
-        .db
-        .add_source_event(&crate::models::SourceEvent {
-            id: new_id(),
-            notebook_id: existing.notebook_id.clone(),
-            source_id: existing.id.clone(),
-            source_title: updated.title.clone(),
-            kind: "updated".into(),
-            detail,
-            diff,
-            at: now(),
-        })
-        .await;
+    // A folder-like parent's content is its map, which the scan rewrites
+    // whenever files come or go — and the scan already writes the `added` /
+    // `removed` events for exactly that (note_scan_events), so a parent
+    // `updated` here would be the same arrival twice.
+    let is_parent = matches!(
+        existing.source_type.as_str(),
+        "folder" | "obsidian" | "git" | "notion"
+    );
+    if !is_parent {
+        let _ = state
+            .db
+            .add_source_event(&crate::models::SourceEvent {
+                id: new_id(),
+                notebook_id: existing.notebook_id.clone(),
+                source_id: existing.id.clone(),
+                source_title: updated.title.clone(),
+                kind: "updated".into(),
+                detail,
+                diff,
+                at: now(),
+            })
+            .await;
+    }
     // Refreshed content means a changed hash — let the sweep re-gist it.
     crate::gist::spawn_sweep(state.db.clone(), state.ai.read().await.clone());
     Ok(Source {
@@ -4677,6 +4687,9 @@ async fn rescan_one_folder_inner(
     };
     let work: Vec<&ScanEntry> = on_disk.iter().filter(|e| needs_action(e)).collect();
     let total = work.len() as u32;
+    // Titles for this pass's `added` / `removed` events (note_scan_events).
+    let mut added_titles: Vec<String> = Vec::new();
+    let mut removed_titles: Vec<String> = Vec::new();
 
     for (done, entry) in work.iter().enumerate() {
         let path = entry.path.as_str();
@@ -4695,6 +4708,7 @@ async fn rescan_one_folder_inner(
             // New but not downloaded — list it, label it, embed nothing.
             None if entry.placeholder => {
                 store_placeholder_child(state, folder, path, mtime).await?;
+                added_titles.push(ingest::file_title(path));
                 scan.added += 1;
             }
             // New file — full ingest as a child of this folder.
@@ -4715,6 +4729,7 @@ async fn rescan_one_folder_inner(
                     if !settled {
                         spawn_retitle(state, &src).await;
                     }
+                    added_titles.push(src.title.clone());
                     scan.added += 1;
                 }
                 Err(err) => {
@@ -4793,9 +4808,11 @@ async fn rescan_one_folder_inner(
     for child in &children {
         if !disk_paths.contains(child.url.as_str()) {
             state.db.delete_source(&child.id).await?;
+            removed_titles.push(child.title.clone());
             scan.removed += 1;
         }
     }
+    note_scan_events(state, folder, &added_titles, &removed_titles).await;
 
     // The parent's content is a folder/repo map: git provenance (when the
     // root sits in a working tree), the file tree, and the skip list — so
@@ -4881,6 +4898,49 @@ async fn rescan_one_folder_inner(
         state.db.touch_notebook(&folder.notebook_id, now()).await?;
     }
     Ok(scan)
+}
+
+/// The scan's arrivals and departures as `source_events` rows
+/// (docs/RFC-events.md §1): one `added` and one `removed` per pass, never
+/// one per file — a sync tool dropping 400 files must read as "400 new
+/// files", not 400 rows. The folder parent is the event's source, so a
+/// standing question watches the folder; titles ride in `diff` as `+`/`−`
+/// lines, capped like a content diff. Best-effort: an event miss must never
+/// fail the scan that produced it.
+async fn note_scan_events(state: &AppState, folder: &Source, added: &[String], removed: &[String]) {
+    const SHOWN: usize = 20;
+    for (kind, sign, titles) in [("added", '+', added), ("removed", '\u{2212}', removed)] {
+        if titles.is_empty() {
+            continue;
+        }
+        let detail = match (kind, titles.len()) {
+            ("added", 1) => format!("new file \u{00b7} {}", titles[0]),
+            ("added", n) => format!("{n} new files"),
+            (_, 1) => format!("file gone \u{00b7} {}", titles[0]),
+            (_, n) => format!("{n} files gone"),
+        };
+        let mut lines: Vec<String> = titles
+            .iter()
+            .take(SHOWN)
+            .map(|t| format!("{sign} {t}"))
+            .collect();
+        if titles.len() > SHOWN {
+            lines.push(format!("\u{2026} and {} more", titles.len() - SHOWN));
+        }
+        let _ = state
+            .db
+            .add_source_event(&crate::models::SourceEvent {
+                id: new_id(),
+                notebook_id: folder.notebook_id.clone(),
+                source_id: folder.id.clone(),
+                source_title: folder.title.clone(),
+                kind: kind.into(),
+                detail,
+                diff: lines.join("\n"),
+                at: now(),
+            })
+            .await;
+    }
 }
 
 /// A cloud-storage sync root the user can pick a subfolder from. `provider` is
@@ -7402,6 +7462,8 @@ pub(crate) fn build_commission(
         named => named.to_string(),
     };
     Ok(ReportSchedule {
+        watch_sources: String::new(),
+        watch_kinds: String::new(),
         id: new_id(),
         notebook_id: notebook_id.to_string(),
         name,
@@ -7541,6 +7603,8 @@ async fn create_schedule_reply(
         }
     };
     let schedule = ReportSchedule {
+        watch_sources: String::new(),
+        watch_kinds: String::new(),
         id: new_id(),
         notebook_id: notebook_id.to_string(),
         name: name.trim().to_string(),
@@ -8125,6 +8189,8 @@ async fn try_tool_route(
                     &schedule.trigger,
                     schedule.interval_secs,
                     schedule.enabled,
+                    &schedule.watch_sources,
+                    &schedule.watch_kinds,
                 )
                 .await
             {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -155,6 +155,10 @@ pub struct AppState {
     /// Last successfully applied glass state per window label
     /// (enabled, dark, pinned) — evicted on window destroy in lib.rs.
     pub glass_applied: Mutex<HashMap<String, (bool, bool, bool)>>,
+    /// Window label → the notebook that window has open (`set_open_notebook`).
+    /// Drives FSEvents scoping and the closed-notebook sweep (fswatch.rs);
+    /// evicted on window destroy in lib.rs and pruned on each rearm.
+    pub open_notebooks: Mutex<HashMap<String, String>>,
     /// The generation queue (genqueue.rs): pending-note jobs the backend
     /// worker drains independently of any window.
     pub gen_queue: crate::genqueue::GenQueue,
@@ -190,6 +194,16 @@ pub(crate) fn notify_changed(scope: &str, notebook_id: Option<&str>) {
 }
 
 impl AppState {
+    /// The set of notebook ids some window currently has open.
+    pub fn open_notebook_ids(&self) -> HashSet<String> {
+        self.open_notebooks
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .values()
+            .cloned()
+            .collect()
+    }
+
     /// Start a fresh cancellation scope for a new generation, returning its
     /// token. Supersedes any previous token in the same scope.
     pub fn begin_generation(&self, scope: &str) -> tokio_util::sync::CancellationToken {
@@ -4041,7 +4055,7 @@ const SNIFF_BYTES: usize = 8 * 1024;
 
 /// Vendored/generated directories pruned even when a repo forgot to
 /// gitignore them.
-const SKIP_DIRS: &[&str] = &[
+pub(crate) const SKIP_DIRS: &[&str] = &[
     "node_modules",
     "vendor",
     "third_party",
@@ -5448,6 +5462,52 @@ pub(crate) async fn resync_sources_inner(
     state: &AppState,
     only_notebook: Option<&str>,
 ) -> Result<FolderScan, String> {
+    Ok(
+        resync_sources_filtered(app, state, only_notebook, crate::fswatch::Sweep::All)
+            .await?
+            .unwrap_or_default(),
+    )
+}
+
+/// A window reports the notebook it has open (`None` = Home). Recomputes the
+/// FSEvents watch set right away so a file saved into the newly opened
+/// notebook's folder lands within seconds (docs/RFC-events.md §4).
+#[tauri::command]
+pub async fn set_open_notebook(
+    window: tauri::Window,
+    app: AppHandle,
+    state: State<'_, AppState>,
+    notebook_id: Option<String>,
+) -> Result<(), String> {
+    {
+        let mut open = state
+            .open_notebooks
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        match notebook_id {
+            Some(id) => {
+                open.insert(window.label().to_string(), id);
+            }
+            None => {
+                open.remove(window.label());
+            }
+        }
+    }
+    crate::fswatch::rearm(&app).await;
+    Ok(())
+}
+
+/// The sweep proper. `sweep` decides which folder parents walk this pass
+/// (fswatch.rs: the scheduler tick skips closed notebooks' local folders
+/// between ten-minute windows; everyone else walks all). Returns `Ok(None)`
+/// when another scan holds the lock — distinct from "nothing changed", so
+/// the FSEvents loop can retry instead of dropping a real change.
+pub(crate) async fn resync_sources_filtered(
+    app: &AppHandle,
+    state: &AppState,
+    only_notebook: Option<&str>,
+    sweep: crate::fswatch::Sweep<'_>,
+) -> Result<Option<FolderScan>, String> {
     let app = app.clone();
     // The Spotlight index rides the same tick (internally ~10-min throttled).
     #[cfg(target_os = "macos")]
@@ -5463,7 +5523,7 @@ pub(crate) async fn resync_sources_inner(
     // A manual folder add/refresh is already scanning — skip this tick rather
     // than queue behind it and ingest the same files twice.
     let Ok(_guard) = state.folder_scan_lock.try_lock() else {
-        return Ok(FolderScan::default());
+        return Ok(None);
     };
     let mut total = FolderScan::default();
     let mut per_notebook: HashMap<String, FolderScan> = HashMap::new();
@@ -5478,6 +5538,11 @@ pub(crate) async fn resync_sources_inner(
             continue;
         }
         if only_notebook.is_some_and(|nb| nb != folder.notebook_id) {
+            continue;
+        }
+        // Closed notebooks' local folders walk on the ten-minute cadence;
+        // FSEvents covers the open ones between minute ticks (fswatch.rs).
+        if !crate::fswatch::in_sweep(&folder.source_type, &folder.notebook_id, sweep) {
             continue;
         }
         // Remote repos: one cheap ls-remote per cadence tick; a moved branch
@@ -5676,7 +5741,7 @@ pub(crate) async fn resync_sources_inner(
             let _ = app.emit("sources://changed", SourcesChanged { notebook_id, scan });
         }
     }
-    Ok(total)
+    Ok(Some(total))
 }
 
 #[derive(serde::Serialize, Clone)]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4126,15 +4126,22 @@ pub async fn complete_mac_reminder(
 }
 
 /// Post-write resync: fetch the item's current state and re-embed it.
-/// Under the scan lock: the store change this write caused wakes the Mac
-/// watch too, and two resyncs diffing the same pre-write text both wrote
-/// the item event. Serialized, the second sees the first's text and is a
-/// no-op (`resync_mac_text`).
+/// Under the scan lock, and measured against the row as stored now, not
+/// the caller's copy: that copy predates the write, and the store change
+/// the write caused wakes the Mac watch too — a Reminders write takes
+/// seconds while FSEvents fires in two, so the watch's resync often lands
+/// first. Two resyncs diffing the same pre-write text both wrote the item
+/// event; against the stored text the second is a no-op
+/// (`resync_mac_text`).
 pub(crate) async fn resync_mac_source(
     state: &AppState,
     existing: Source,
 ) -> Result<Source, String> {
     let _guard = state.folder_scan_lock.lock().await;
+    let existing = match state.db.get_source(&existing.id).await {
+        Ok(Some(current)) => current,
+        _ => existing,
+    };
     let (_, text) = e(crate::mac::fetch(&existing.url).await)?;
     resync_mac_text(state, existing, text).await
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3179,22 +3179,14 @@ pub(crate) async fn refresh_source_impl(
         });
     }
     if crate::mac::is_mac_uri(&existing.url) {
-        // Mac item — re-fetch through cider and re-embed. Like files, a
-        // failed fetch (permission prompt pending, app closed) must not wipe
-        // the working source.
-        let (_, text) = crate::mac::fetch(&existing.url).await?;
-        let mut existing = existing;
-        existing.mtime = crate::mac::content_stamp(&text);
-        let extracted = ingest::Extracted {
-            feeds: Vec::new(),
-            image_url: String::new(),
-            author: String::new(),
-            title: existing.title.clone(),
-            source_type: "mac".to_string(),
-            url: existing.url.clone(),
-            text,
-        };
-        return reingest(state, &existing, extracted, None, true).await;
+        // Mac item — the same tail every Mac refresh takes (the watch, the
+        // sweep, the write-backs): item events, no-op when unchanged, and
+        // the scan lock so a concurrent watch resync cannot double-count.
+        // Like files, a failed fetch (permission prompt pending, app
+        // closed) must not wipe the working source.
+        return resync_mac_source(state, existing)
+            .await
+            .map_err(anyhow::Error::msg);
     }
     // Git-backed singles (README/blob) refresh from their cache clone — the
     // cache dir is the definitive marker; page captures of github.com URLs
@@ -4134,10 +4126,15 @@ pub async fn complete_mac_reminder(
 }
 
 /// Post-write resync: fetch the item's current state and re-embed it.
+/// Under the scan lock: the store change this write caused wakes the Mac
+/// watch too, and two resyncs diffing the same pre-write text both wrote
+/// the item event. Serialized, the second sees the first's text and is a
+/// no-op (`resync_mac_text`).
 pub(crate) async fn resync_mac_source(
     state: &AppState,
     existing: Source,
 ) -> Result<Source, String> {
+    let _guard = state.folder_scan_lock.lock().await;
     let (_, text) = e(crate::mac::fetch(&existing.url).await)?;
     resync_mac_text(state, existing, text).await
 }
@@ -4168,6 +4165,14 @@ pub(crate) async fn resync_mac_text(
             .source_content(&existing.id)
             .await
             .unwrap_or_default();
+    }
+    // Nothing changed: no reingest, no event. A manual "Sync now" on an
+    // unchanged list used to write an empty-diff `updated` every time.
+    if existing.content == text {
+        return Ok(Source {
+            content: String::new(),
+            ..existing
+        });
     }
     let events = crate::mac::item_events(&existing.url, &existing.content, &text);
     existing.mtime = crate::mac::content_stamp(&text);

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1399,7 +1399,7 @@ pub(crate) async fn store_extracted(
     let feeds = extracted.feeds.clone();
     let src = store_new_source(state, notebook_id, extracted, "", mtime, None, true).await?;
     if !feeds.is_empty() {
-        crate::feeds::remember_discovered(state, notebook_id, &src, &feeds);
+        crate::feeds::remember_discovered(state, notebook_id, &src, &feeds).await;
     }
     Ok(src)
 }
@@ -11104,11 +11104,7 @@ pub async fn growth_proposals(
     let mut proposals = crate::growth::proposals(&sources, &queries);
     // Feeds the notebook's pages advertised (docs/RFC-events.md §2, tier 1):
     // remembered at import, proposed here, followed only on a click.
-    proposals.extend(crate::feeds::discovered_proposals(
-        &state,
-        &notebook_id,
-        &sources,
-    ));
+    proposals.extend(crate::feeds::discovered_proposals(&state, &notebook_id, &sources).await);
     Ok(GrowthOverview { queries, proposals })
 }
 
@@ -11116,6 +11112,35 @@ pub async fn growth_proposals(
 /// advertised, what its host's shape implies, and — only when those come
 /// up empty — what sits at the conventional paths on its origin (the one
 /// tier that fetches; docs/RFC-events.md §2). Nothing is followed here.
+/// The Arrivals watermark (docs/RFC-events.md §6): when this notebook's
+/// arrivals were last dismissed. One `app_state` row per notebook — the
+/// database is single-tenant by design, so UI state lives there too, not
+/// in a webview's localStorage that a second window or a reinstall forgets.
+#[tauri::command]
+pub async fn arrivals_seen_at(
+    state: State<'_, AppState>,
+    notebook_id: String,
+) -> Result<i64, String> {
+    Ok(e(state
+        .db
+        .kv_get(&format!("arrivals.seen.{notebook_id}"))
+        .await)?
+    .and_then(|raw| raw.parse::<i64>().ok())
+    .unwrap_or(0))
+}
+
+#[tauri::command]
+pub async fn mark_arrivals_seen(
+    state: State<'_, AppState>,
+    notebook_id: String,
+    at: i64,
+) -> Result<(), String> {
+    e(state
+        .db
+        .kv_set(&format!("arrivals.seen.{notebook_id}"), &at.to_string())
+        .await)
+}
+
 #[tauri::command]
 pub async fn discover_feeds(
     state: State<'_, AppState>,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1380,7 +1380,14 @@ pub(crate) async fn store_extracted(
     } else {
         0
     };
-    store_new_source(state, notebook_id, extracted, "", mtime, None, true).await
+    // Tier-1 feed discovery rode in on the page (docs/RFC-events.md §2):
+    // remember it for the Grow pane's proposals — never auto-follow.
+    let feeds = extracted.feeds.clone();
+    let src = store_new_source(state, notebook_id, extracted, "", mtime, None, true).await?;
+    if !feeds.is_empty() {
+        crate::feeds::remember_discovered(state, notebook_id, &src, &feeds);
+    }
+    Ok(src)
 }
 
 /// Classify and persist a new source row IMMEDIATELY, then hand chunking and
@@ -1389,7 +1396,7 @@ pub(crate) async fn store_extracted(
 /// `parent_id` is set for folder children (which dedup by path, not
 /// content); `mtime` for any file-backed source; `code_ctx` is the
 /// "repo › path" retrieval context for code chunks when the caller knows it.
-async fn store_new_source(
+pub(crate) async fn store_new_source(
     state: &AppState,
     notebook_id: &str,
     extracted: ingest::Extracted,
@@ -1594,6 +1601,7 @@ pub(crate) fn resume_stranded_imports(app: &AppHandle) {
         if let Ok(processing) = state.db.processing_sources().await {
             for s in processing {
                 let extracted = ingest::Extracted {
+                    feeds: Vec::new(),
                     image_url: s.image_url.clone(),
                     author: s.author.clone(),
                     title: s.title.clone(),
@@ -1707,6 +1715,7 @@ async fn extract_image(state: &AppState, path: &str) -> anyhow::Result<ingest::E
         anyhow::bail!("no text found in image {path}");
     }
     Ok(ingest::Extracted {
+        feeds: Vec::new(),
         image_url: String::new(),
         author: String::new(),
         title: ingest::file_title(path),
@@ -1740,6 +1749,7 @@ async fn extract_pdf_ocr(state: &AppState, path: &str) -> anyhow::Result<ingest:
         anyhow::bail!("OCR produced no text from {path}");
     }
     Ok(ingest::Extracted {
+        feeds: Vec::new(),
         image_url: String::new(),
         author: String::new(),
         title: ingest::file_title(path),
@@ -2017,6 +2027,14 @@ pub(crate) async fn ingest_url(
         }
     }
     match crate::capture::extract_url_rescued(url).await {
+        // The fetch came back as a feed document (docs/RFC-events.md §2):
+        // connect it as a living source — parent index plus newest entries.
+        Ok(extracted) if extracted.source_type == "feed" => {
+            match crate::feeds::connect(state, notebook_id, &extracted.url, &extracted.text).await {
+                Ok(src) => Ok(src),
+                Err(err) => store_failed_url(state, notebook_id, url.trim(), err.to_string()).await,
+            }
+        }
         Ok(extracted) => store_extracted(state, notebook_id, extracted).await,
         Err(err) => store_failed_url(state, notebook_id, url.trim(), err.to_string()).await,
     }
@@ -2224,7 +2242,7 @@ pub(crate) async fn repo_backed_files(
         .filter(|s| {
             matches!(
                 s.source_type.as_str(),
-                "folder" | "obsidian" | "git" | "notion"
+                "folder" | "obsidian" | "git" | "notion" | "feed"
             ) && s.parent_id.is_empty()
         })
         .map(|s| s.id.as_str())
@@ -2777,7 +2795,7 @@ pub(crate) async fn reingest(
     // `updated` here would be the same arrival twice.
     let is_parent = matches!(
         existing.source_type.as_str(),
-        "folder" | "obsidian" | "git" | "notion"
+        "folder" | "obsidian" | "git" | "notion" | "feed"
     );
     if !is_parent {
         let _ = state
@@ -3075,6 +3093,10 @@ pub(crate) async fn refresh_source_impl(
     if existing.url.is_empty() {
         anyhow::bail!("This source has no URL or file path to refresh from");
     }
+    // A feed parent polls now, cadence ignored (docs/RFC-events.md §2).
+    if existing.source_type == "feed" {
+        return crate::feeds::refresh(state, &existing).await;
+    }
     if matches!(
         existing.source_type.as_str(),
         "folder" | "obsidian" | "git" | "notion"
@@ -3132,6 +3154,7 @@ pub(crate) async fn refresh_source_impl(
         let mut existing = existing;
         existing.mtime = crate::mac::content_stamp(&text);
         let extracted = ingest::Extracted {
+            feeds: Vec::new(),
             image_url: String::new(),
             author: String::new(),
             title: existing.title.clone(),
@@ -3936,6 +3959,7 @@ pub(crate) async fn ingest_mac(
     // store_extracted stamps 0 for a nonexistent path, so set it after.
     let stamp = crate::mac::content_stamp(&text);
     let extracted = ingest::Extracted {
+        feeds: Vec::new(),
         image_url: String::new(),
         author: String::new(),
         title,
@@ -4009,6 +4033,7 @@ pub(crate) async fn resync_mac_source(
     let (_, text) = e(crate::mac::fetch(&existing.url).await)?;
     existing.mtime = crate::mac::content_stamp(&text);
     let extracted = ingest::Extracted {
+        feeds: Vec::new(),
         image_url: String::new(),
         author: String::new(),
         title: existing.title.clone(),
@@ -4878,6 +4903,7 @@ async fn rescan_one_folder_inner(
             .unwrap_or_default();
         if map != current {
             let extracted = ingest::Extracted {
+                feeds: Vec::new(),
                 image_url: String::new(),
                 author: String::new(),
                 title: folder.title.clone(),
@@ -5656,6 +5682,7 @@ pub(crate) async fn resync_sources_inner(
                     let mut existing = src.clone();
                     existing.mtime = stamp;
                     let extracted = ingest::Extracted {
+                        feeds: Vec::new(),
                         image_url: String::new(),
                         author: String::new(),
                         title: existing.title.clone(),
@@ -5762,6 +5789,7 @@ pub async fn reembed_all(app: AppHandle, state: State<'_, AppState>) -> Result<u
                 s.notebook_id.clone(),
                 s.id.clone(),
                 ingest::Extracted {
+                    feeds: Vec::new(),
                     image_url: String::new(),
                     author: String::new(),
                     title: s.title.clone(),
@@ -9979,6 +10007,7 @@ pub async fn convert_note_to_source(
 ) -> Result<Source, String> {
     let note = e(state.db.get_note(&note_id).await)?.ok_or_else(|| "Note not found".to_string())?;
     let extracted = ingest::Extracted {
+        feeds: Vec::new(),
         image_url: String::new(),
         author: String::new(),
         title: note.title.clone(),
@@ -10931,8 +10960,29 @@ pub async fn growth_proposals(
     // returns as fast as a text scan.
     let sources = e(state.db.sources_with_content(&notebook_id).await)?;
     let queries = crate::growth::standing_queries(&state.trace_dir, &notebook_id, now());
-    let proposals = crate::growth::proposals(&sources, &queries);
+    let mut proposals = crate::growth::proposals(&sources, &queries);
+    // Feeds the notebook's pages advertised (docs/RFC-events.md §2, tier 1):
+    // remembered at import, proposed here, followed only on a click.
+    proposals.extend(crate::feeds::discovered_proposals(
+        &state,
+        &notebook_id,
+        &sources,
+    ));
     Ok(GrowthOverview { queries, proposals })
+}
+
+/// Every feed the app can offer to follow for one source: what its page
+/// advertised, what its host's shape implies, and — only when those come
+/// up empty — what sits at the conventional paths on its origin (the one
+/// tier that fetches; docs/RFC-events.md §2). Nothing is followed here.
+#[tauri::command]
+pub async fn discover_feeds(
+    state: State<'_, AppState>,
+    source_id: String,
+) -> Result<Vec<crate::feeds::FeedCandidate>, String> {
+    let source =
+        e(state.db.get_source(&source_id).await)?.ok_or_else(|| "Source not found".to_string())?;
+    Ok(crate::feeds::discover_for_source(&state, &source).await)
 }
 
 /// The Spotlight tier alone — mdfind subprocesses make it the slow section,
@@ -12560,6 +12610,7 @@ async fn import_bundle(
             None => String::new(),
         };
         let extracted = ingest::Extracted {
+            feeds: Vec::new(),
             image_url: String::new(),
             author: String::new(),
             title,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2672,6 +2672,24 @@ pub(crate) async fn reingest(
     code_ctx: Option<&str>,
     embed: bool,
 ) -> anyhow::Result<Source> {
+    reingest_with(state, existing, extracted, code_ctx, embed, false).await
+}
+
+/// [`reingest`] with the event write under the caller's control. `quiet`
+/// means the caller has already named what changed item by item — the Mac
+/// resync's `completed` / `moved` / `added` rows (docs/RFC-events.md §1,
+/// phase 5) — and the generic `updated` diff would be the same arrival
+/// twice: the parent rule below, made explicit for the one caller that
+/// knows more than the diff does. Everything else about the refresh (the
+/// row, the chunks, the weave, the registry match) is unchanged.
+pub(crate) async fn reingest_with(
+    state: &AppState,
+    existing: &Source,
+    extracted: ingest::Extracted,
+    code_ctx: Option<&str>,
+    embed: bool,
+    quiet: bool,
+) -> anyhow::Result<Source> {
     // Classify against the stored URL: text edits arrive via extract_pasted
     // with an empty extracted.url, which would drop the Google-doc exemption.
     let (status, error) = classify(&existing.source_type, &existing.url, &extracted.text);
@@ -2811,7 +2829,7 @@ pub(crate) async fn reingest(
         existing.source_type.as_str(),
         "folder" | "obsidian" | "git" | "notion" | "feed"
     );
-    if !is_parent {
+    if !is_parent && !quiet {
         let _ = state
             .db
             .add_source_event(&crate::models::SourceEvent {
@@ -4118,9 +4136,40 @@ pub async fn complete_mac_reminder(
 /// Post-write resync: fetch the item's current state and re-embed it.
 pub(crate) async fn resync_mac_source(
     state: &AppState,
-    mut existing: Source,
+    existing: Source,
 ) -> Result<Source, String> {
     let (_, text) = e(crate::mac::fetch(&existing.url).await)?;
+    resync_mac_text(state, existing, text).await
+}
+
+/// Item events per resync before they collapse into one `updated` with a
+/// count — a list rebuilt wholesale is one arrival, not forty.
+const MAC_ITEM_EVENTS_MAX: usize = 20;
+
+/// The Mac resync's shared tail: `text` is the fresh rendering of
+/// `existing`, already fetched. Reads the stored rendering back, names what
+/// changed item by item (`mac::item_events`), re-embeds, and writes one
+/// event per item — or, when the items had nothing to say (a note, a stocks
+/// table, an edited reminder note), lets `reingest` write its generic
+/// `updated` diff as before. Every path that refreshes a Mac source ends
+/// here — the store watch (macwatch.rs), the minute sweep, and our own
+/// write-backs — so an event reads the same whichever one saw the change.
+pub(crate) async fn resync_mac_text(
+    state: &AppState,
+    mut existing: Source,
+    text: String,
+) -> Result<Source, String> {
+    // The sweep hands over a metadata-only row, the write-backs a full one;
+    // either way the stored text is what the items (and the generic diff)
+    // are measured against.
+    if existing.content.is_empty() {
+        existing.content = state
+            .db
+            .source_content(&existing.id)
+            .await
+            .unwrap_or_default();
+    }
+    let events = crate::mac::item_events(&existing.url, &existing.content, &text);
     existing.mtime = crate::mac::content_stamp(&text);
     let extracted = ingest::Extracted {
         feeds: Vec::new(),
@@ -4131,7 +4180,108 @@ pub(crate) async fn resync_mac_source(
         url: existing.url.clone(),
         text,
     };
-    e(reingest(state, &existing, extracted, None, true).await)
+    let quiet = !events.is_empty();
+    let updated = e(reingest_with(state, &existing, extracted, None, true, quiet).await)?;
+    note_mac_item_events(state, &existing, &updated.title, events).await;
+    Ok(updated)
+}
+
+/// One `source_events` row per item event, capped at [`MAC_ITEM_EVENTS_MAX`];
+/// past the cap, one `updated` row carries the count and the first lines.
+/// Best-effort, like every event write: a miss never fails the resync.
+async fn note_mac_item_events(
+    state: &AppState,
+    source: &Source,
+    title: &str,
+    events: Vec<(&'static str, String)>,
+) {
+    let row = |kind: &str, detail: String, diff: String| crate::models::SourceEvent {
+        id: new_id(),
+        notebook_id: source.notebook_id.clone(),
+        source_id: source.id.clone(),
+        source_title: title.to_string(),
+        kind: kind.into(),
+        detail,
+        diff,
+        at: now(),
+    };
+    if events.len() > MAC_ITEM_EVENTS_MAX {
+        let n = events.len();
+        let lines: Vec<String> = events
+            .into_iter()
+            .take(MAC_ITEM_EVENTS_MAX)
+            .map(|(kind, detail)| format!("{kind} \u{00b7} {detail}"))
+            .collect();
+        let _ = state
+            .db
+            .add_source_event(&row(
+                "updated",
+                format!("Mac item synced \u{00b7} {n} items changed"),
+                lines.join("\n"),
+            ))
+            .await;
+        return;
+    }
+    for (kind, detail) in events {
+        let _ = state
+            .db
+            .add_source_event(&row(kind, detail, String::new()))
+            .await;
+    }
+}
+
+/// Every Mac source of one provider, re-fetched now: the store watch
+/// (macwatch.rs) saw Reminders, Calendar, or Notes write, so the sweep's
+/// fifteen-minute cadence does not apply. Archived notebooks sit out, as in
+/// the sweep. One cider read and a hash compare per source; only a changed
+/// rendering reingests (and names its items). Emits `sources://changed` per
+/// notebook that changed, the way the sweep does. Waits for the scan lock —
+/// a manual import ahead of it is a reason to queue, not to drop a change.
+pub(crate) async fn resync_mac_provider(
+    app: &AppHandle,
+    state: &AppState,
+    provider: &str,
+) -> Result<FolderScan, String> {
+    let _guard = state.folder_scan_lock.lock().await;
+    let prefix = format!("cider://{provider}/");
+    let archived = state.db.archived_notebook_ids().await.unwrap_or_default();
+    let mut total = FolderScan::default();
+    let mut per_notebook: HashMap<String, FolderScan> = HashMap::new();
+    for src in e(state.db.all_mac_sources().await)? {
+        if !src.url.starts_with(&prefix) || archived.contains(&src.notebook_id) {
+            continue;
+        }
+        let text = match crate::mac::fetch(&src.url).await {
+            Ok((_, text)) => text,
+            Err(err) => {
+                // Transient (a permission prompt, an app mid-write): the
+                // sweep retries on its own cadence.
+                crate::note!("macwatch: failed to fetch {}: {err:#}", src.url);
+                continue;
+            }
+        };
+        if crate::mac::content_stamp(&text) == src.mtime {
+            continue;
+        }
+        let scan = per_notebook.entry(src.notebook_id.clone()).or_default();
+        match resync_mac_text(state, src.clone(), text).await {
+            Ok(_) => {
+                scan.updated += 1;
+                total.updated += 1;
+            }
+            Err(err) => {
+                crate::note!("macwatch: failed to re-embed {}: {err:#}", src.url);
+                scan.failed += 1;
+                total.failed += 1;
+            }
+        }
+    }
+    for (notebook_id, scan) in per_notebook {
+        if scan.changed() {
+            let _ = app.emit("sources://changed", SourcesChanged { notebook_id, scan });
+        }
+    }
+    Ok(total)
 }
 
 // ---- Folder sources --------------------------------------------------------
@@ -5820,19 +5970,8 @@ pub(crate) async fn resync_sources_filtered(
                     if stamp == src.mtime {
                         continue;
                     }
-                    let mut existing = src.clone();
-                    existing.mtime = stamp;
-                    let extracted = ingest::Extracted {
-                        feeds: Vec::new(),
-                        image_url: String::new(),
-                        author: String::new(),
-                        title: existing.title.clone(),
-                        source_type: "mac".to_string(),
-                        url: existing.url.clone(),
-                        text,
-                    };
                     let scan = per_notebook.entry(src.notebook_id.clone()).or_default();
-                    match reingest(state, &existing, extracted, None, true).await {
+                    match resync_mac_text(state, src.clone(), text).await {
                         Ok(_) => {
                             scan.updated += 1;
                             total.updated += 1;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -11752,12 +11752,20 @@ pub fn list_shortcuts() -> Vec<crate::menu::ShortcutRow> {
 pub async fn list_source_events(
     state: State<'_, AppState>,
     hours: Option<u32>,
+    notebook_id: Option<String>,
 ) -> Result<Vec<crate::models::SourceEvent>, String> {
     let hours = i64::from(hours.unwrap_or(24));
-    e(state
+    let mut events = e(state
         .db
         .source_events_since(now() - hours * 3_600_000)
-        .await)
+        .await)?;
+    // The Arrivals strip reads one notebook (docs/RFC-events.md §6); Home
+    // and the Staff section read everything. Filtered here, not in Lance —
+    // the window is small and already in hand.
+    if let Some(nb) = notebook_id.filter(|s| !s.is_empty()) {
+        events.retain(|ev| ev.notebook_id == nb);
+    }
+    Ok(events)
 }
 
 /// What the last snapshot did, for the Nightly settings page

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3618,7 +3618,12 @@ fn snippet_of(title: &str, content: &str, max_chars: usize) -> String {
             in_fence = !in_fence;
             continue;
         }
-        if t.is_empty() || t.starts_with("> ") || t.starts_with("![") || is_rule(t) {
+        if t.is_empty()
+            || t.starts_with("> ")
+            || t.starts_with("![")
+            || is_badge_row(t)
+            || is_rule(t)
+        {
             continue;
         }
         if out.is_empty() {
@@ -3675,6 +3680,44 @@ fn snippet_of(title: &str, content: &str, max_chars: usize) -> String {
         out.push('…');
     }
     out
+}
+
+/// A line that is nothing but images or linked images — `![a](u)` and the
+/// `[![a](u)](l)` shape README badge rows take. Alt text ("Discord",
+/// "Twitter") is not prose, so the whole row skips.
+fn is_badge_row(t: &str) -> bool {
+    let mut rest = t.trim();
+    if rest.is_empty() {
+        return false;
+    }
+    while !rest.is_empty() {
+        let linked = rest.starts_with("[![");
+        let start = if linked {
+            1
+        } else if rest.starts_with("![") {
+            0
+        } else {
+            return false;
+        };
+        let Some(close_alt) = rest[start..].find("](") else {
+            return false;
+        };
+        let Some(close_url) = rest[start + close_alt..].find(')') else {
+            return false;
+        };
+        rest = &rest[start + close_alt + close_url + 1..];
+        if linked {
+            let Some(r) = rest.strip_prefix("](") else {
+                return false;
+            };
+            let Some(end) = r.find(')') else {
+                return false;
+            };
+            rest = &r[end + 1..];
+        }
+        rest = rest.trim_start();
+    }
+    true
 }
 
 /// `---`, `***`, `___` (three or more): a thematic break, not content.
@@ -3742,7 +3785,9 @@ fn render_inline(t: &str) -> String {
             break;
         }
     }
-    s = unlink(&s);
+    s = untag(&s);
+    // Twice: a linked image `[![alt](img)](url)` unlinks inside-out.
+    s = unlink(&unlink(&s));
     s = uncode(&s);
     s = s.replace("**", "").replace("__", "");
     // Whole-line single emphasis only; a bare `_` or `*` mid-line is more
@@ -3753,6 +3798,37 @@ fn render_inline(t: &str) -> String {
         }
     }
     s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Inline HTML → its text. GitHub READMEs open with `<a href><img src>`
+/// badge rows and `<p align="center">` wrappers that GFM renders but a
+/// card must not show raw; a line that is only tags strips to nothing and
+/// the caller skips it. A bare `<` with no closing `>` on the line (a
+/// comparison, "a <b") passes through.
+fn untag(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(open) = rest.find('<') {
+        let Some(len) = rest[open..].find('>') else {
+            break;
+        };
+        // Only tag-shaped runs: `<name`, `</name`, `<!--`. "a < b > c" stays.
+        let inner = &rest[open + 1..open + len];
+        let tagish = inner
+            .trim_start_matches('/')
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_alphabetic() || c == '!');
+        if !tagish {
+            out.push_str(&rest[..open + 1]);
+            rest = &rest[open + 1..];
+            continue;
+        }
+        out.push_str(&rest[..open]);
+        rest = &rest[open + len + 1..];
+    }
+    out.push_str(rest);
+    out
 }
 
 /// `[text](url)` and `![alt](url)` → `text` / `alt`. Unbalanced brackets
@@ -14353,6 +14429,24 @@ mod tool_tests {
     /// Gallery snippets of spreadsheet-shaped sources are the table's
     /// corner, not pipe soup: header plus the first rows, first three
     /// columns, separator dropped, an ellipsis cell where columns were cut.
+    /// A README that opens with badge markup shows its first sentence, not
+    /// the anchor and image tags GFM would have rendered.
+    #[test]
+    fn snippet_strips_inline_html() {
+        let readme = "# lancedb\n\n\
+             <a href=\"https://cloud.lancedb.com\" target=\"_blank\">\n\
+             <img src=\"https://github.com/user-attachments/assets/92dad0a2.png\" alt=\"LanceDB Cloud\">\n\
+             </a>\n\
+             [![Blog](https://img.shields.io/badge/blog.svg)](https://blog.lancedb.com/) [![Discord](https://img.shields.io/discord.svg)](https://discord.gg/x)\n\
+             ![Stars](https://img.shields.io/stars.svg)\n\
+             <p align=\"center\"><b>Developer-friendly</b>, serverless vector database.</p>\n\
+             Only a < b here is math, not a tag.";
+        assert_eq!(
+            snippet_of("lancedb", readme, 280),
+            "Developer-friendly, serverless vector database.\nOnly a < b here is math, not a tag."
+        );
+    }
+
     #[test]
     fn snippet_previews_a_table_corner() {
         let sheet = "# Sheet: Q3\n\

--- a/src-tauri/src/commands/brief.rs
+++ b/src-tauri/src/commands/brief.rs
@@ -66,6 +66,8 @@ pub(crate) async fn ensure_default_brief(state: &AppState) {
         return; // transient — retry next pass, marker unwritten
     };
     let schedule = ReportSchedule {
+        watch_sources: String::new(),
+        watch_kinds: String::new(),
         id: new_id(),
         notebook_id: nb.id,
         name: DEFAULT_BRIEF_NAME.into(),

--- a/src-tauri/src/commands/reports.rs
+++ b/src-tauri/src/commands/reports.rs
@@ -16,7 +16,20 @@ fn resolve_trigger(trigger: Option<String>) -> String {
     }
 }
 
+/// The change-trigger filters (docs/RFC-events.md §5), normalized: source
+/// ids as given, kinds restricted to `EVENT_KINDS`. Empty means "any".
+pub(crate) fn resolve_watch(sources: Option<String>, kinds: Option<String>) -> (String, String) {
+    (
+        crate::models::normalize_watch_list(sources.as_deref().unwrap_or(""), None),
+        crate::models::normalize_watch_list(
+            kinds.as_deref().unwrap_or(""),
+            Some(&crate::models::EVENT_KINDS),
+        ),
+    )
+}
+
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn create_report_schedule(
     state: State<'_, AppState>,
     notebook_id: String,
@@ -25,8 +38,13 @@ pub async fn create_report_schedule(
     prompt: String,
     trigger: Option<String>,
     interval_secs: i64,
+    watch_sources: Option<String>,
+    watch_kinds: Option<String>,
 ) -> Result<ReportSchedule, String> {
+    let (watch_sources, watch_kinds) = resolve_watch(watch_sources, watch_kinds);
     let schedule = ReportSchedule {
+        watch_sources,
+        watch_kinds,
         id: new_id(),
         notebook_id,
         name: name.trim().to_string(),
@@ -54,7 +72,10 @@ pub async fn update_report_schedule(
     trigger: Option<String>,
     interval_secs: i64,
     enabled: bool,
+    watch_sources: Option<String>,
+    watch_kinds: Option<String>,
 ) -> Result<(), String> {
+    let (watch_sources, watch_kinds) = resolve_watch(watch_sources, watch_kinds);
     e(state
         .db
         .update_report_schedule(
@@ -65,6 +86,8 @@ pub async fn update_report_schedule(
             &resolve_trigger(trigger),
             interval_secs,
             enabled,
+            &watch_sources,
+            &watch_kinds,
         )
         .await)
 }

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -1324,6 +1324,13 @@ impl Db {
         Ok(out)
     }
 
+    /// Living Mac sources — `cider://` origins (mac.rs) of every status: the
+    /// store watch re-fetches these by provider, and an errored one (a
+    /// permission denied at add time) deserves the retry a change brings.
+    pub async fn all_mac_sources(&self) -> Result<Vec<Source>> {
+        self.query_sources(Some("source_type = 'mac'"), false).await
+    }
+
     /// Top-level ready sources that aren't folder-like parents (folders and
     /// git repos sweep via rescan) — the resync sweep filters these down to
     /// file- or git-backed ones and re-embeds any whose backing changed.

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -1364,6 +1364,12 @@ impl Db {
         self.query_sources(Some("source_type = 'url'"), false).await
     }
 
+    /// Feed parents (docs/RFC-events.md §2) — the poller's work list.
+    pub async fn all_feed_sources(&self) -> Result<Vec<Source>> {
+        self.query_sources(Some("source_type = 'feed'"), false)
+            .await
+    }
+
     /// Update a source's recorded file mtime without touching its chunks.
     pub async fn set_source_mtime(&self, source_id: &str, mtime: i64) -> Result<()> {
         let tbl = self.conn.open_table(T_SOURCES).execute().await?;

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -33,6 +33,12 @@ const T_REPORTS: &str = "report_schedules";
 const T_ROUTES: &str = "routes";
 const T_SOURCE_EVENTS: &str = "source_events";
 const T_RECEIPTS: &str = "run_receipts";
+/// Small app state that used to live in JSON sidecars and localStorage:
+/// feed poll state, discovered feeds, robots.txt caches, the Arrivals
+/// watermark. One row per key, JSON or a scalar in `value`. The database
+/// is single-tenant by design; a second store beside it is a second
+/// source of truth.
+const T_KV: &str = "app_state";
 const T_LEDGER: &str = "ledger";
 /// The Registry's cast (docs/RFC-registry.md). Corpus-scoped: no
 /// notebook_id column, unlike every other entity table here.
@@ -3965,6 +3971,45 @@ impl Db {
         Ok(out)
     }
 
+    // ---- App state (key → value) -------------------------------------------
+
+    /// One value by key; `None` when unset (or before the table exists).
+    pub async fn kv_get(&self, key: &str) -> Result<Option<String>> {
+        if !self.table_exists(T_KV).await? {
+            return Ok(None);
+        }
+        let batches = self
+            .collect(T_KV, Some(&format!("key = '{}'", esc(key))))
+            .await?;
+        for b in &batches {
+            if b.num_rows() > 0 {
+                let value = str_col(b, "value")?;
+                return Ok(Some(value.value(0).to_string()));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Set (replace) one value. Delete-then-append: the table is tiny and
+    /// a key is written far less often than it is read.
+    pub async fn kv_set(&self, key: &str, value: &str) -> Result<()> {
+        // Created on first write: unlike the entity tables, nothing needs
+        // this one at startup.
+        self.ensure_table(T_KV, kv_schema()).await?;
+        self.delete_where(T_KV, &format!("key = '{}'", esc(key)))
+            .await?;
+        let schema = kv_schema();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec![key.to_string()])),
+                Arc::new(StringArray::from(vec![value.to_string()])),
+                Arc::new(Int64Array::from(vec![crate::commands::now()])),
+            ],
+        )?;
+        self.add_batch(T_KV, schema, batch).await
+    }
+
     /// Record one run. Best-effort by contract: a receipt that fails to
     /// write must never fail the run it describes, so callers log and move on.
     pub async fn add_receipt(&self, receipt: &RunReceipt) -> Result<()> {
@@ -4884,6 +4929,14 @@ fn notes_schema() -> SchemaRef {
         Field::new("prompt", DataType::Utf8, false),
         Field::new("origin", DataType::Utf8, false),
         Field::new("status", DataType::Utf8, false),
+    ]))
+}
+
+fn kv_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("key", DataType::Utf8, false),
+        Field::new("value", DataType::Utf8, false),
+        Field::new("updated_at", DataType::Int64, false),
     ]))
 }
 

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -3921,7 +3921,11 @@ impl Db {
     pub async fn add_source_event(&self, event: &SourceEvent) -> Result<()> {
         let schema = source_events_schema();
         let batch = source_event_batch(&schema, event)?;
-        self.add_batch(T_SOURCE_EVENTS, schema, batch).await
+        self.add_batch(T_SOURCE_EVENTS, schema, batch).await?;
+        // The one write point doubles as the live stream's fan-out
+        // (docs/RFC-events.md §8): agents tailing /events see it now.
+        crate::events::publish(event);
+        Ok(())
     }
 
     /// Events newer than `since`, newest first. Prunes the rolling window on

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -453,7 +453,12 @@ impl Db {
         // Commissions (docs/RFC-night-shift-area.md §1). Zero means "the next
         // pass", which is the right reading for every schedule that predates
         // the column.
-        self.add_i64_column(T_REPORTS, "not_before", "0").await
+        self.add_i64_column(T_REPORTS, "not_before", "0").await?;
+        // Standing-question filters (docs/RFC-events.md §5). Empty means
+        // "any", which is exactly what every pre-filter schedule meant.
+        self.add_string_column(T_REPORTS, "watch_sources", "")
+            .await?;
+        self.add_string_column(T_REPORTS, "watch_kinds", "").await
     }
 
     /// Lateness came after receipts did; 0 reads as "not recorded", which is
@@ -3854,8 +3859,15 @@ impl Db {
             let enabled = i64_col(b, "enabled")?;
             let last = i64_col(b, "last_run_at")?;
             let created = i64_col(b, "created_at")?;
+            let watch_sources = opt_str_col(b, "watch_sources");
+            let watch_kinds = opt_str_col(b, "watch_kinds");
+            let opt = |col: Option<&StringArray>, i: usize| {
+                col.map(|c| c.value(i).to_string()).unwrap_or_default()
+            };
             for i in 0..b.num_rows() {
                 out.push(ReportSchedule {
+                    watch_sources: opt(watch_sources, i),
+                    watch_kinds: opt(watch_kinds, i),
                     id: id.value(i).to_string(),
                     notebook_id: nb.value(i).to_string(),
                     name: name.value(i).to_string(),
@@ -4281,6 +4293,8 @@ impl Db {
         trigger: &str,
         interval_secs: i64,
         enabled: bool,
+        watch_sources: &str,
+        watch_kinds: &str,
     ) -> Result<()> {
         let tbl = self.conn.open_table(T_REPORTS).execute().await?;
         tbl.update()
@@ -4291,6 +4305,8 @@ impl Db {
             .column("trigger", format!("'{}'", esc(trigger)))
             .column("interval_secs", interval_secs.to_string())
             .column("enabled", i64::from(enabled).to_string())
+            .column("watch_sources", format!("'{}'", esc(watch_sources)))
+            .column("watch_kinds", format!("'{}'", esc(watch_kinds)))
             .execute()
             .await?;
         Ok(())
@@ -5023,6 +5039,8 @@ fn reports_schema() -> SchemaRef {
         Field::new("enabled", DataType::Int64, false),
         Field::new("last_run_at", DataType::Int64, false),
         Field::new("created_at", DataType::Int64, false),
+        Field::new("watch_sources", DataType::Utf8, false),
+        Field::new("watch_kinds", DataType::Utf8, false),
     ]))
 }
 
@@ -5041,6 +5059,8 @@ fn report_batch(schema: &SchemaRef, r: &ReportSchedule) -> Result<RecordBatch> {
             Arc::new(Int64Array::from(vec![i64::from(r.enabled)])),
             Arc::new(Int64Array::from(vec![r.last_run_at])),
             Arc::new(Int64Array::from(vec![r.created_at])),
+            Arc::new(StringArray::from(vec![r.watch_sources.clone()])),
+            Arc::new(StringArray::from(vec![r.watch_kinds.clone()])),
         ],
     )?)
 }

--- a/src-tauri/src/diagnostics.rs
+++ b/src-tauri/src/diagnostics.rs
@@ -155,6 +155,36 @@ impl Event {
 ///
 /// This writes through `writeln!`, which returns the error instead, and
 /// drops it. Progress chatter is never worth a crash.
+/// The `log` facade, routed into the app log. Linked crates (cider) log
+/// instead of printing since cider 0.6.2 — printing to a closed stderr
+/// aborted this app in the field — and without a logger installed those
+/// lines vanish silently. Warnings and above become notes with the
+/// crate's target as prefix; debug and trace stay off.
+struct NoteLogger;
+
+impl log::Log for NoteLogger {
+    fn enabled(&self, metadata: &log::Metadata) -> bool {
+        metadata.level() <= log::Level::Info
+    }
+
+    fn log(&self, record: &log::Record) {
+        if self.enabled(record.metadata()) {
+            crate::note!("{}: {}", record.target(), record.args());
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+static NOTE_LOGGER: NoteLogger = NoteLogger;
+
+/// Install the bridge once, at setup. A second call is a no-op.
+pub fn install_log_bridge() {
+    if log::set_logger(&NOTE_LOGGER).is_ok() {
+        log::set_max_level(log::LevelFilter::Info);
+    }
+}
+
 #[macro_export]
 macro_rules! note {
     ($($arg:tt)*) => {{

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -1,0 +1,128 @@
+//! The live event stream for agents (docs/RFC-events.md §8).
+//!
+//! `GET /events?since=<ms>` beside the MCP endpoint, bearer-gated by the
+//! same middleware: Server-Sent Events, one JSON `SourceEvent` per frame.
+//! The connection replays the rolling window from `since` (the table is the
+//! replay; the broadcast is in-memory and lossy by design), then tails every
+//! event `db.add_source_event` writes. A disconnected client costs nothing —
+//! the channel drops frames nobody is reading. `alchemy events --follow` is
+//! this endpoint with a pretty-printer.
+
+use std::convert::Infallible;
+use std::sync::OnceLock;
+
+use axum::response::sse::{Event, KeepAlive, Sse};
+use futures::stream::{self, Stream, StreamExt};
+use tauri::{AppHandle, Manager};
+use tokio::sync::broadcast;
+
+use crate::commands::AppState;
+use crate::models::SourceEvent;
+
+/// Frames buffered per subscriber before a slow reader starts losing the
+/// oldest; a reader that lags simply skips to the newest, and the table has
+/// the rest.
+const BUFFER: usize = 256;
+
+static TX: OnceLock<broadcast::Sender<SourceEvent>> = OnceLock::new();
+
+fn sender() -> &'static broadcast::Sender<SourceEvent> {
+    TX.get_or_init(|| broadcast::channel(BUFFER).0)
+}
+
+/// Fan an event out to every live stream. Called from the one write point
+/// (`Db::add_source_event`); a send with no receivers is a no-op.
+pub fn publish(event: &SourceEvent) {
+    let _ = sender().send(event.clone());
+}
+
+/// `?since=<ms>` — only events after this millisecond timestamp; absent or
+/// unparseable means the whole rolling window. Parsed by hand: axum's
+/// `Query` extractor is a feature this build does not enable.
+fn since_of(uri: &axum::http::Uri) -> i64 {
+    uri.query()
+        .unwrap_or("")
+        .split('&')
+        .find_map(|pair| pair.strip_prefix("since="))
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or(0)
+}
+
+fn frame(e: &SourceEvent) -> Result<Event, Infallible> {
+    let data = serde_json::to_string(e).unwrap_or_else(|_| "{}".to_string());
+    Ok(Event::default().id(e.id.clone()).data(data))
+}
+
+/// The SSE handler: replay, then tail.
+pub async fn sse(
+    axum::extract::State(app): axum::extract::State<AppHandle>,
+    uri: axum::http::Uri,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    // Subscribe before reading the table so nothing written between the
+    // read and the tail is missed; duplicates are filtered by id below.
+    let rx = sender().subscribe();
+    let state = app.state::<AppState>();
+    let mut replay = state
+        .db
+        .source_events_since(since_of(&uri))
+        .await
+        .unwrap_or_default();
+    replay.reverse(); // oldest first — a log reads forward
+    let seen: std::collections::HashSet<String> = replay.iter().map(|e| e.id.clone()).collect();
+    let since = since_of(&uri);
+    let live = stream::unfold((rx, seen), move |(mut rx, mut seen)| async move {
+        loop {
+            match rx.recv().await {
+                Ok(e) => {
+                    if e.at <= since || !seen.insert(e.id.clone()) {
+                        continue;
+                    }
+                    return Some((e, (rx, seen)));
+                }
+                Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(broadcast::error::RecvError::Closed) => return None,
+            }
+        }
+    });
+    let frames = stream::iter(replay).chain(live).map(|e| frame(&e));
+    Sse::new(frames).keep_alive(KeepAlive::default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event(id: &str, at: i64) -> SourceEvent {
+        SourceEvent {
+            id: id.into(),
+            notebook_id: "nb".into(),
+            source_id: "src".into(),
+            source_title: "A feed".into(),
+            kind: "added".into(),
+            detail: "new entry".into(),
+            diff: String::new(),
+            at,
+        }
+    }
+
+    #[test]
+    fn since_is_read_from_the_query_string() {
+        let uri: axum::http::Uri = "/events?since=1788300000000&x=1".parse().unwrap();
+        assert_eq!(since_of(&uri), 1_788_300_000_000);
+        let bare: axum::http::Uri = "/events".parse().unwrap();
+        assert_eq!(since_of(&bare), 0);
+        let junk: axum::http::Uri = "/events?since=yesterday".parse().unwrap();
+        assert_eq!(since_of(&junk), 0, "unparseable means the whole window");
+    }
+
+    #[tokio::test]
+    async fn published_events_reach_a_subscriber_as_json_frames() {
+        let mut rx = sender().subscribe();
+        publish(&event("e1", 5));
+        let got = rx.recv().await.expect("one frame");
+        assert_eq!(got.id, "e1");
+        let json = serde_json::to_string(&got).unwrap();
+        assert!(json.contains("\"kind\":\"added\""), "{json}");
+        assert!(frame(&got).is_ok());
+    }
+}

--- a/src-tauri/src/feeds.rs
+++ b/src-tauri/src/feeds.rs
@@ -896,7 +896,14 @@ pub async fn poll_one(
         MAX_CADENCE_MS
     };
     let outcome = async {
-        let fetched = fetch(&parent.url, &st).await?;
+        // A forced poll wants the document, not a 304: send no validators,
+        // so the index rewrite below always has a body to work from.
+        let conditional = if force {
+            FeedState::default()
+        } else {
+            st.clone()
+        };
+        let fetched = fetch(&parent.url, &conditional).await?;
         let Fetched::Body {
             body,
             etag,
@@ -932,8 +939,13 @@ pub async fn poll_one(
         } else {
             parsed.title.clone()
         };
-        if !landed.is_empty() {
+        // A forced poll (manual Refresh) always rewrites the index, so a
+        // renamed feed or a changed index format reaches parents that
+        // predate it; the sweep rewrites only when something landed.
+        if !landed.is_empty() || force {
             rewrite_index(state, parent, &title, &parsed.description).await?;
+        }
+        if !landed.is_empty() {
             let detail = match landed.len() {
                 1 => format!("new entry \u{00b7} {}", landed[0]),
                 n => format!("{n} new entries"),

--- a/src-tauri/src/feeds.rs
+++ b/src-tauri/src/feeds.rs
@@ -1,0 +1,1252 @@
+//! Feed sources (docs/RFC-events.md §2): RSS, Atom, and JSON Feed as living
+//! sources, plus the feed-shaped hosts (GitHub releases, Wikipedia page
+//! history, arXiv queries, Substack, Reddit, Medium).
+//!
+//! A feed is a folder source whose root is a URL: the parent row carries
+//! `source_type: "feed"` and a **rolling index** of its kept entries as its
+//! text; each entry is an ordinary `url` child with `parent_id` set and
+//! `mtime` = the entry's published time. Retrieval, gallery, tags, and
+//! hygiene work unchanged because children are just sources.
+//!
+//! Cost rules (RFC "Cost rules"): a poll is one conditional GET; a 304 costs
+//! nothing downstream. New entries ingest through the normal chunk/embed
+//! path, capped per feed and per pass. A poll writes at most one `added`
+//! event per feed. Nothing here calls a model.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+
+use anyhow::{anyhow, Context, Result};
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, Manager};
+
+use crate::commands::{self, AppState};
+use crate::models::{Source, SourceEvent};
+
+/// New entries ingested per feed per pass; the rest wait for the next one.
+const MAX_NEW_PER_FEED: usize = 5;
+/// New entries ingested across every feed per pass.
+const MAX_NEW_PER_PASS: usize = 20;
+/// Summary-only entries whose pages get fetched per pass — a page fetch is
+/// the expensive end of a poll; the rest keep the feed's summary as text.
+const MAX_PAGE_FETCHES_PER_PASS: usize = 3;
+/// Entries the rolling index lists (older children stay; the retirement
+/// pass in RFC-living-notebook proposes them for archive).
+pub const KEEP: usize = 50;
+/// Poll cadence bounds. Derived per feed from its own timestamps.
+const MIN_CADENCE_MS: i64 = 30 * 60 * 1000;
+const MAX_CADENCE_MS: i64 = 24 * 60 * 60 * 1000;
+/// Strikes before a feed is reported unreachable (mirrors hygiene).
+const UNREACHABLE_AFTER: i64 = 3;
+/// Bytes read when probing a well-known path — enough to see `<rss`/`<feed`.
+const PROBE_BYTES: usize = 4 * 1024;
+/// Entry text handed to the child source, capped.
+const ENTRY_TEXT_CAP: usize = 40_000;
+
+const WELL_KNOWN: [&str; 7] = [
+    "/feed",
+    "/rss",
+    "/rss.xml",
+    "/atom.xml",
+    "/feed.xml",
+    "/index.xml",
+    "/feed.json",
+];
+
+// ---- Sniffing and discovery (pure) ---------------------------------------
+
+/// Does this response body read as a feed rather than a page? Checked
+/// before readability ever sees it (ingest::extract_url).
+pub fn looks_like_feed(content_type: &str, body: &str) -> bool {
+    let ct = content_type.to_ascii_lowercase();
+    let head: String = body.trim_start().chars().take(2_000).collect();
+    let lower = head.to_ascii_lowercase();
+    if ct.contains("rss+xml") || ct.contains("atom+xml") || ct.contains("feed+json") {
+        return true;
+    }
+    if lower.starts_with('{') {
+        return lower.contains("\"version\"") && lower.contains("jsonfeed.org");
+    }
+    let xml_ish =
+        lower.starts_with("<?xml") || lower.starts_with("<rss") || lower.starts_with("<feed");
+    xml_ish
+        && (lower.contains("<rss") || lower.contains("<feed") || lower.contains("<rdf:rdf"))
+        && !lower.contains("<html")
+}
+
+/// Tier 1: `<link rel="alternate" type="application/rss+xml|atom+xml|
+/// feed+json">` in a page already in hand. Costs no fetch.
+pub fn discover_in_html(html: &str, base: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let lower = html.to_ascii_lowercase();
+    let mut at = 0usize;
+    while let Some(start) = lower[at..].find("<link") {
+        let start = at + start;
+        let Some(end_rel) = lower[start..].find('>') else {
+            break;
+        };
+        let end = start + end_rel;
+        let tag = &html[start..=end];
+        at = end + 1;
+        let tl = tag.to_ascii_lowercase();
+        if !tl.contains("alternate") {
+            continue;
+        }
+        let ty = attr(&tl, "type").unwrap_or_default();
+        if !(ty.contains("rss+xml") || ty.contains("atom+xml") || ty.contains("feed+json")) {
+            continue;
+        }
+        let Some(href) = attr(tag, "href") else {
+            continue;
+        };
+        if let Some(abs) = resolve(base, href.trim()) {
+            if !out.contains(&abs) {
+                out.push(abs);
+            }
+        }
+    }
+    out
+}
+
+/// Value of `name="…"` (or `name='…'`) inside one tag; case-insensitive on
+/// the attribute name because `tag` may be lowercased by the caller.
+fn attr(tag: &str, name: &str) -> Option<String> {
+    let lower = tag.to_ascii_lowercase();
+    let mut from = 0;
+    while let Some(i) = lower[from..].find(name) {
+        let i = from + i;
+        let after = &lower[i + name.len()..];
+        let trimmed = after.trim_start();
+        if !trimmed.starts_with('=') {
+            from = i + name.len();
+            continue;
+        }
+        // Position of the value start in the original string.
+        let eq = i + name.len() + (after.len() - trimmed.len());
+        let rest = &tag[eq + 1..].trim_start();
+        let quote = rest.chars().next()?;
+        let value = if quote == '"' || quote == '\'' {
+            rest[1..].split(quote).next()?
+        } else {
+            rest.split(|c: char| c.is_whitespace() || c == '>').next()?
+        };
+        return Some(value.to_string());
+    }
+    None
+}
+
+/// Resolve `href` against `base` (absolute, protocol-relative, root- and
+/// path-relative). `None` for anything that is not http(s) once resolved.
+fn resolve(base: &str, href: &str) -> Option<String> {
+    let out = if href.starts_with("http://") || href.starts_with("https://") {
+        href.to_string()
+    } else if let Some(rest) = href.strip_prefix("//") {
+        format!("https://{rest}")
+    } else {
+        let (scheme, rest) = base.split_once("://")?;
+        let (host, path) = rest.split_once('/').unwrap_or((rest, ""));
+        if let Some(root) = href.strip_prefix('/') {
+            format!("{scheme}://{host}/{root}")
+        } else {
+            let dir = match path.rfind('/') {
+                Some(i) => &path[..i],
+                None => "",
+            };
+            if dir.is_empty() {
+                format!("{scheme}://{host}/{href}")
+            } else {
+                format!("{scheme}://{host}/{dir}/{href}")
+            }
+        }
+    };
+    (out.starts_with("http://") || out.starts_with("https://")).then_some(out)
+}
+
+/// One feed the app can offer to follow (docs/RFC-events.md §2).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FeedCandidate {
+    pub url: String,
+    /// Short human label: "Releases", "Page history", "Feed", …
+    pub label: String,
+    /// "page" (advertised by the page), "host" (a known host's shape),
+    /// "well-known" (found at a conventional path).
+    pub tier: String,
+}
+
+fn candidate(url: impl Into<String>, label: &str, tier: &str) -> FeedCandidate {
+    FeedCandidate {
+        url: url.into(),
+        label: label.to_string(),
+        tier: tier.to_string(),
+    }
+}
+
+/// Tier 3: hosts whose URL shape implies a feed. A table, not a code path.
+/// arXiv is the deliberate exception: a paper has no feed and a category is
+/// the whole field, so it offers a search feed built from the notebook's
+/// standing queries (RFC "Decisions") — nothing when there are none.
+pub fn host_rules(page_url: &str, standing_queries: &[String]) -> Vec<FeedCandidate> {
+    let Some((_, rest)) = page_url.split_once("://") else {
+        return Vec::new();
+    };
+    let (host, path) = rest.split_once('/').unwrap_or((rest, ""));
+    let host = host.trim_start_matches("www.").to_ascii_lowercase();
+    let path = path.split(['?', '#']).next().unwrap_or("");
+    let parts: Vec<&str> = path.split('/').filter(|p| !p.is_empty()).collect();
+    let mut out = Vec::new();
+    match host.as_str() {
+        "github.com" if parts.len() >= 2 => {
+            let (owner, repo) = (parts[0], parts[1].trim_end_matches(".git"));
+            out.push(candidate(
+                format!("https://github.com/{owner}/{repo}/releases.atom"),
+                "Releases",
+                "host",
+            ));
+            out.push(candidate(
+                format!("https://github.com/{owner}/{repo}/commits.atom"),
+                "Commits",
+                "host",
+            ));
+        }
+        h if h.ends_with("wikipedia.org") && parts.len() >= 2 && parts[0] == "wiki" => {
+            out.push(candidate(
+                format!(
+                    "https://{h}/w/index.php?title={}&action=history&feed=atom",
+                    parts[1]
+                ),
+                "Page history",
+                "host",
+            ));
+        }
+        "youtube.com" | "m.youtube.com" if parts.len() >= 2 && parts[0] == "channel" => {
+            out.push(candidate(
+                format!(
+                    "https://www.youtube.com/feeds/videos.xml?channel_id={}",
+                    parts[1]
+                ),
+                "New videos",
+                "host",
+            ));
+        }
+        "arxiv.org" | "export.arxiv.org"
+            if !parts.is_empty() && matches!(parts[0], "abs" | "pdf" | "html") =>
+        {
+            if let Some(url) = arxiv_query_feed(standing_queries) {
+                out.push(candidate(
+                    url,
+                    "arXiv papers matching your open questions",
+                    "host",
+                ));
+            }
+        }
+        h if h.ends_with(".substack.com") => {
+            out.push(candidate(format!("https://{h}/feed"), "Posts", "host"));
+        }
+        "reddit.com" | "old.reddit.com" if parts.len() >= 2 && parts[0] == "r" => {
+            out.push(candidate(
+                format!("https://www.reddit.com/r/{}/.rss", parts[1]),
+                "New posts",
+                "host",
+            ));
+        }
+        "medium.com" if !parts.is_empty() => {
+            out.push(candidate(
+                format!("https://medium.com/feed/{}", parts[0]),
+                "Posts",
+                "host",
+            ));
+        }
+        _ => {}
+    }
+    out
+}
+
+/// The arXiv API query feed for a notebook's standing queries — at most
+/// four, quoted, OR-ed, newest first. `None` without queries: a feed of
+/// everything would be the noise the decision refused.
+fn arxiv_query_feed(queries: &[String]) -> Option<String> {
+    use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
+    let terms: Vec<String> = queries
+        .iter()
+        .map(|q| q.trim().replace('"', ""))
+        .filter(|q| q.len() >= 8)
+        .take(4)
+        .map(|q| format!("all:%22{}%22", utf8_percent_encode(&q, NON_ALPHANUMERIC)))
+        .collect();
+    if terms.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "https://export.arxiv.org/api/query?search_query={}&sortBy=submittedDate&sortOrder=descending&max_results=25",
+        terms.join("+OR+")
+    ))
+}
+
+/// Tier 2: the conventional paths on the page's origin. Network — only from
+/// the explicit "Follow updates…" path, never from a sweep.
+pub async fn probe_well_known(page_url: &str) -> Vec<String> {
+    let Some((scheme, rest)) = page_url.split_once("://") else {
+        return Vec::new();
+    };
+    let host = rest.split('/').next().unwrap_or("");
+    if host.is_empty() {
+        return Vec::new();
+    }
+    let Ok(client) = client() else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for path in WELL_KNOWN {
+        let url = format!("{scheme}://{host}{path}");
+        let Ok(resp) = client.get(&url).send().await else {
+            continue;
+        };
+        if !resp.status().is_success() {
+            continue;
+        }
+        let ct = resp
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        let Ok(bytes) = resp.bytes().await else {
+            continue;
+        };
+        let head = String::from_utf8_lossy(&bytes[..bytes.len().min(PROBE_BYTES)]).into_owned();
+        if looks_like_feed(&ct, &head) {
+            out.push(url);
+        }
+    }
+    out
+}
+
+// ---- Parsing (pure) --------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct Entry {
+    pub id: String,
+    pub title: String,
+    pub link: String,
+    pub published_ms: i64,
+    /// Plain text: the entry's content when the feed carries it, else its
+    /// summary. `full` says which.
+    pub text: String,
+    pub full: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct Parsed {
+    pub title: String,
+    pub description: String,
+    /// Newest first.
+    pub entries: Vec<Entry>,
+}
+
+/// Parse RSS / Atom / JSON Feed. Entries without a link are dropped — a
+/// child source needs an origin to refresh from and to dedupe on.
+pub fn parse(body: &str, base: &str) -> Result<Parsed> {
+    let feed = feed_rs::parser::parse(body.as_bytes()).context("could not parse feed")?;
+    let text_of = |t: &Option<feed_rs::model::Text>| -> String {
+        t.as_ref().map(|t| plain(&t.content)).unwrap_or_default()
+    };
+    let mut entries: Vec<Entry> = feed
+        .entries
+        .iter()
+        .filter_map(|e| {
+            let link = e
+                .links
+                .iter()
+                .find(|l| l.rel.as_deref().is_none_or(|r| r == "alternate"))
+                .or(e.links.first())
+                .map(|l| l.href.clone())
+                .and_then(|h| resolve(base, &h))?;
+            let published = e
+                .published
+                .or(e.updated)
+                .map(|d| d.timestamp_millis())
+                .unwrap_or(0);
+            let content = e
+                .content
+                .as_ref()
+                .and_then(|c| c.body.as_ref())
+                .map(|b| plain(b))
+                .filter(|t| !t.trim().is_empty());
+            let (text, full) = match content {
+                Some(c) => (c, true),
+                None => (text_of(&e.summary), false),
+            };
+            let title = text_of(&e.title);
+            let title = if title.trim().is_empty() {
+                link.clone()
+            } else {
+                title
+            };
+            Some(Entry {
+                id: if e.id.is_empty() {
+                    link.clone()
+                } else {
+                    e.id.clone()
+                },
+                title,
+                link,
+                published_ms: published,
+                text: text.chars().take(ENTRY_TEXT_CAP).collect(),
+                full,
+            })
+        })
+        .collect();
+    entries.sort_by_key(|e| std::cmp::Reverse(e.published_ms));
+    Ok(Parsed {
+        title: text_of(&feed.title),
+        description: text_of(&feed.description),
+        entries,
+    })
+}
+
+/// HTML or text → plain text. Feeds carry HTML in content and often in
+/// summaries; the same readability converter pages use keeps structure and
+/// links as markdown.
+fn plain(s: &str) -> String {
+    let t = s.trim();
+    if t.contains('<') && t.contains('>') {
+        crate::ingest::html_fragment_to_text(t)
+    } else {
+        t.to_string()
+    }
+}
+
+fn day(ms: i64) -> String {
+    chrono::DateTime::from_timestamp_millis(ms)
+        .map(|d| d.format("%Y-%m-%d").to_string())
+        .unwrap_or_else(|| "undated".to_string())
+}
+
+/// The child source's text: a rigid provenance block a card can parse
+/// (RFC §7 — `title / published / link` then the body), same idea as the
+/// byline header pages get.
+pub fn entry_text(e: &Entry) -> String {
+    let mut out = format!(
+        "# {}\nPublished: {}\nLink: {}\n\n",
+        e.title.trim(),
+        day(e.published_ms),
+        e.link
+    );
+    out.push_str(e.text.trim());
+    out
+}
+
+/// The parent's rolling index: description plus one line per kept entry,
+/// newest first — `- YYYY-MM-DD — [Title](link)`, the line the feed card
+/// parses (src/lib/liveCards.ts). "What's new in the Tauri blog" retrieves
+/// this; a specific claim retrieves the child.
+pub fn index_text(title: &str, description: &str, entries: &[(i64, String, String)]) -> String {
+    let mut out = format!("# {}\n", title.trim());
+    if !description.trim().is_empty() {
+        out.push_str(description.trim());
+        out.push('\n');
+    }
+    out.push_str(&format!(
+        "\nFeed of {} {}, newest first:\n\n",
+        entries.len(),
+        if entries.len() == 1 {
+            "entry"
+        } else {
+            "entries"
+        }
+    ));
+    for (ms, t, link) in entries.iter().take(KEEP) {
+        out.push_str(&format!(
+            "- {} \u{2014} [{}]({})\n",
+            day(*ms),
+            t.trim(),
+            link
+        ));
+    }
+    out
+}
+
+/// Poll cadence from the feed's own rhythm: the median gap between entry
+/// timestamps, clamped to [30 min, 24 h]. Feeds without usable dates poll
+/// at the ceiling.
+pub fn cadence_ms(published: &[i64]) -> i64 {
+    let mut ts: Vec<i64> = published.iter().copied().filter(|t| *t > 0).collect();
+    ts.sort_unstable();
+    ts.dedup();
+    if ts.len() < 2 {
+        return MAX_CADENCE_MS;
+    }
+    let mut gaps: Vec<i64> = ts.windows(2).map(|w| w[1] - w[0]).collect();
+    gaps.sort_unstable();
+    let median = gaps[gaps.len() / 2];
+    median.clamp(MIN_CADENCE_MS, MAX_CADENCE_MS)
+}
+
+// ---- Persistent poll state (one JSON sidecar, like git_hosts.json) ---------
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct FeedState {
+    #[serde(default)]
+    etag: String,
+    #[serde(default)]
+    last_modified: String,
+    #[serde(default)]
+    next_poll_at: i64,
+    #[serde(default)]
+    failures: i64,
+    #[serde(default)]
+    cadence_ms: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Discovered {
+    source_id: String,
+    source_title: String,
+    seen_at: i64,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct Store {
+    /// Poll state by feed parent source id.
+    #[serde(default)]
+    state: HashMap<String, FeedState>,
+    /// Tier-1 discoveries by notebook id, then feed url.
+    #[serde(default)]
+    discovered: HashMap<String, HashMap<String, Discovered>>,
+}
+
+static STORE: Mutex<Option<Store>> = Mutex::new(None);
+
+fn store_path(data_dir: &Path) -> PathBuf {
+    data_dir.join("feeds.json")
+}
+
+fn with_store<T>(data_dir: &Path, f: impl FnOnce(&mut Store) -> T, save: bool) -> T {
+    let mut guard = STORE.lock().unwrap_or_else(|p| p.into_inner());
+    let store = guard.get_or_insert_with(|| {
+        std::fs::read_to_string(store_path(data_dir))
+            .ok()
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_default()
+    });
+    let out = f(store);
+    if save {
+        if let Ok(json) = serde_json::to_string_pretty(&*store) {
+            let _ = std::fs::write(store_path(data_dir), json);
+        }
+    }
+    out
+}
+
+/// Remember feeds a just-imported page advertised (tier 1), so the Grow
+/// pane can propose them without a second fetch.
+pub fn remember_discovered(state: &AppState, notebook_id: &str, source: &Source, feeds: &[String]) {
+    if feeds.is_empty() {
+        return;
+    }
+    let dir = commands::app_data_dir(state);
+    let now = commands::now();
+    with_store(
+        &dir,
+        |s| {
+            let nb = s.discovered.entry(notebook_id.to_string()).or_default();
+            for url in feeds {
+                nb.insert(
+                    url.clone(),
+                    Discovered {
+                        source_id: source.id.clone(),
+                        source_title: source.title.clone(),
+                        seen_at: now,
+                    },
+                );
+            }
+        },
+        true,
+    );
+}
+
+/// Discovered feeds as growth proposals of kind `feed`, minus the ones the
+/// notebook already follows and the ones whose page is gone.
+pub fn discovered_proposals(
+    state: &AppState,
+    notebook_id: &str,
+    sources: &[Source],
+) -> Vec<crate::growth::GrowthProposal> {
+    let dir = commands::app_data_dir(state);
+    let followed: std::collections::HashSet<&str> = sources
+        .iter()
+        .filter(|s| s.source_type == "feed")
+        .map(|s| s.url.trim_end_matches('/'))
+        .collect();
+    let live: std::collections::HashSet<&str> = sources.iter().map(|s| s.id.as_str()).collect();
+    let found = with_store(
+        &dir,
+        |s| s.discovered.get(notebook_id).cloned().unwrap_or_default(),
+        false,
+    );
+    let mut out: Vec<crate::growth::GrowthProposal> = found
+        .into_iter()
+        .filter(|(url, d)| {
+            !followed.contains(url.trim_end_matches('/')) && live.contains(d.source_id.as_str())
+        })
+        .map(|(url, d)| crate::growth::GrowthProposal {
+            kind: "feed".into(),
+            url,
+            anchor: format!("Follow {}", d.source_title),
+            mentions: 0,
+            source_count: 1,
+            matched_query: String::new(),
+            score: 0.5,
+        })
+        .collect();
+    out.sort_by(|a, b| a.anchor.cmp(&b.anchor));
+    out
+}
+
+/// Everything the app can offer to follow for one source: what its page
+/// advertised, what its host's shape implies, and what sits at the
+/// conventional paths (the one tier that fetches, so it runs last and only
+/// here). Deduped, page tier first.
+pub async fn discover_for_source(state: &AppState, source: &Source) -> Vec<FeedCandidate> {
+    let dir = commands::app_data_dir(state);
+    let mut out: Vec<FeedCandidate> = Vec::new();
+    let advertised: Vec<String> = with_store(
+        &dir,
+        |s| {
+            s.discovered
+                .get(&source.notebook_id)
+                .map(|m| {
+                    m.iter()
+                        .filter(|(_, d)| d.source_id == source.id)
+                        .map(|(u, _)| u.clone())
+                        .collect()
+                })
+                .unwrap_or_default()
+        },
+        false,
+    );
+    for url in advertised {
+        out.push(candidate(url, "Feed", "page"));
+    }
+    let queries =
+        crate::growth::standing_queries(&state.trace_dir, &source.notebook_id, commands::now());
+    for c in host_rules(&source.url, &queries) {
+        if !out.iter().any(|o| o.url == c.url) {
+            out.push(c);
+        }
+    }
+    if out.is_empty() {
+        for url in probe_well_known(&source.url).await {
+            if !out.iter().any(|o| o.url == url) {
+                out.push(candidate(url, "Feed", "well-known"));
+            }
+        }
+    }
+    out
+}
+
+// ---- Fetching --------------------------------------------------------------
+
+fn client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .user_agent("Alchemy/0.5 (+https://thrashr888.github.io/alchemy/; feed reader)")
+        .timeout(std::time::Duration::from_secs(20))
+        .build()
+        .context("failed to build HTTP client")
+}
+
+enum Fetched {
+    NotModified,
+    Body {
+        body: String,
+        etag: String,
+        last_modified: String,
+    },
+}
+
+async fn fetch(url: &str, st: &FeedState) -> Result<Fetched> {
+    let client = client()?;
+    let mut req = client.get(url).header(
+        reqwest::header::ACCEPT,
+        "application/rss+xml, application/atom+xml, application/feed+json, application/xml;q=0.9, */*;q=0.5",
+    );
+    if !st.etag.is_empty() {
+        req = req.header(reqwest::header::IF_NONE_MATCH, st.etag.clone());
+    }
+    if !st.last_modified.is_empty() {
+        req = req.header(reqwest::header::IF_MODIFIED_SINCE, st.last_modified.clone());
+    }
+    let resp = req
+        .send()
+        .await
+        .with_context(|| format!("could not reach {url}"))?;
+    if resp.status() == reqwest::StatusCode::NOT_MODIFIED {
+        return Ok(Fetched::NotModified);
+    }
+    if !resp.status().is_success() {
+        anyhow::bail!("{url} returned HTTP {}", resp.status().as_u16());
+    }
+    let header = |name: reqwest::header::HeaderName| -> String {
+        resp.headers()
+            .get(name)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string()
+    };
+    let etag = header(reqwest::header::ETAG);
+    let last_modified = header(reqwest::header::LAST_MODIFIED);
+    let body = resp.text().await.context("could not read feed body")?;
+    Ok(Fetched::Body {
+        body,
+        etag,
+        last_modified,
+    })
+}
+
+// ---- Connect and poll ------------------------------------------------------
+
+fn kept_entries(children: &[&Source]) -> Vec<(i64, String, String)> {
+    let mut kept: Vec<(i64, String, String)> = children
+        .iter()
+        .map(|c| (c.mtime, c.title.clone(), c.url.clone()))
+        .collect();
+    kept.sort_by_key(|(ms, _, _)| std::cmp::Reverse(*ms));
+    kept.truncate(KEEP);
+    kept
+}
+
+/// Rewrite the parent's rolling index from its current children. The
+/// parent is folder-like, so `reingest` writes no `updated` event for it —
+/// the poll's own `added` event is the arrival.
+async fn rewrite_index(
+    state: &AppState,
+    parent: &Source,
+    title: &str,
+    description: &str,
+) -> Result<Source> {
+    let all = state.db.list_sources(&parent.notebook_id).await?;
+    let children: Vec<&Source> = all.iter().filter(|s| s.parent_id == parent.id).collect();
+    let text = index_text(title, description, &kept_entries(&children));
+    let extracted = crate::ingest::Extracted {
+        title: title.to_string(),
+        source_type: "feed".to_string(),
+        url: parent.url.clone(),
+        text,
+        author: String::new(),
+        image_url: String::new(),
+        feeds: Vec::new(),
+    };
+    let fresh = Source {
+        status: "ready".to_string(),
+        error: String::new(),
+        ..parent.clone()
+    };
+    commands::reingest(state, &fresh, extracted, None, true).await
+}
+
+/// Ingest new entries as children. Returns the titles that landed.
+/// `page_budget` is shared across a pass: summary-only entries fetch their
+/// page while it lasts, then keep the summary.
+async fn ingest_entries(
+    state: &AppState,
+    parent: &Source,
+    entries: &[Entry],
+    page_budget: &mut usize,
+) -> Vec<String> {
+    let mut landed = Vec::new();
+    for e in entries {
+        let mut text = entry_text(e);
+        if !e.full && *page_budget > 0 {
+            *page_budget -= 1;
+            if let Ok(page) = crate::ingest::extract_url(&e.link).await {
+                if page.source_type != "feed" && page.text.chars().count() > e.text.chars().count()
+                {
+                    text = format!(
+                        "# {}\nPublished: {}\nLink: {}\n\n{}",
+                        e.title.trim(),
+                        day(e.published_ms),
+                        e.link,
+                        page.text.trim()
+                    );
+                }
+            }
+        }
+        let extracted = crate::ingest::Extracted {
+            title: e.title.clone(),
+            source_type: "url".to_string(),
+            url: e.link.clone(),
+            text,
+            author: String::new(),
+            image_url: String::new(),
+            feeds: Vec::new(),
+        };
+        match commands::store_new_source(
+            state,
+            &parent.notebook_id,
+            extracted,
+            &parent.id,
+            e.published_ms,
+            None,
+            true,
+        )
+        .await
+        {
+            Ok(_) => landed.push(e.title.clone()),
+            Err(err) => crate::note!("feed {}: entry {} failed: {err:#}", parent.title, e.link),
+        }
+    }
+    landed
+}
+
+/// A feed URL pasted (or discovered and accepted) becomes a parent plus its
+/// newest entries. `body` is the feed document `extract_url` already
+/// fetched — one GET, not two. No event: the user asked for this.
+pub async fn connect(state: &AppState, notebook_id: &str, url: &str, body: &str) -> Result<Source> {
+    let parsed = parse(body, url)?;
+    if parsed.entries.is_empty() {
+        anyhow::bail!("{url} is a feed with no entries");
+    }
+    let title = if parsed.title.trim().is_empty() {
+        url.to_string()
+    } else {
+        parsed.title.clone()
+    };
+    let cadence = cadence_ms(
+        &parsed
+            .entries
+            .iter()
+            .map(|e| e.published_ms)
+            .collect::<Vec<_>>(),
+    );
+    let stamp = crate::mac::content_stamp(
+        &parsed
+            .entries
+            .first()
+            .map(|e| e.id.clone())
+            .unwrap_or_default(),
+    );
+    let extracted = crate::ingest::Extracted {
+        title: title.clone(),
+        source_type: "feed".to_string(),
+        url: url.to_string(),
+        text: index_text(&title, &parsed.description, &[]),
+        author: String::new(),
+        image_url: String::new(),
+        feeds: Vec::new(),
+    };
+    let parent =
+        commands::store_new_source(state, notebook_id, extracted, "", stamp, None, false).await?;
+    let mut page_budget = MAX_PAGE_FETCHES_PER_PASS;
+    let first: Vec<Entry> = parsed
+        .entries
+        .iter()
+        .take(MAX_NEW_PER_FEED * 2)
+        .cloned()
+        .collect();
+    ingest_entries(state, &parent, &first, &mut page_budget).await;
+    let parent = rewrite_index(state, &parent, &title, &parsed.description).await?;
+    let dir = commands::app_data_dir(state);
+    with_store(
+        &dir,
+        |s| {
+            s.state.insert(
+                parent.id.clone(),
+                FeedState {
+                    etag: String::new(),
+                    last_modified: String::new(),
+                    next_poll_at: commands::now() + cadence,
+                    failures: 0,
+                    cadence_ms: cadence,
+                },
+            );
+        },
+        true,
+    );
+    Ok(Source {
+        content: String::new(),
+        ..parent
+    })
+}
+
+/// One poll: conditional GET, new entries in, index rewritten, one `added`
+/// event. `force` ignores the cadence (manual Refresh). Returns how many
+/// entries landed. Errors count a strike and back the feed off.
+pub async fn poll_one(
+    state: &AppState,
+    parent: &Source,
+    force: bool,
+    page_budget: &mut usize,
+) -> Result<usize> {
+    let dir = commands::app_data_dir(state);
+    let now = commands::now();
+    let st = with_store(
+        &dir,
+        |s| s.state.get(&parent.id).cloned().unwrap_or_default(),
+        false,
+    );
+    if !force && now < st.next_poll_at {
+        return Ok(0);
+    }
+    let cadence = if st.cadence_ms > 0 {
+        st.cadence_ms
+    } else {
+        MAX_CADENCE_MS
+    };
+    let outcome = async {
+        let fetched = fetch(&parent.url, &st).await?;
+        let Fetched::Body {
+            body,
+            etag,
+            last_modified,
+        } = fetched
+        else {
+            return Ok::<(usize, FeedState), anyhow::Error>((
+                0,
+                FeedState {
+                    next_poll_at: now + cadence,
+                    failures: 0,
+                    ..st.clone()
+                },
+            ));
+        };
+        let parsed = parse(&body, &parent.url)?;
+        let all = state.db.list_sources(&parent.notebook_id).await?;
+        let known: std::collections::HashSet<&str> = all
+            .iter()
+            .filter(|s| s.parent_id == parent.id)
+            .map(|s| s.url.trim_end_matches('/'))
+            .collect();
+        let fresh: Vec<Entry> = parsed
+            .entries
+            .iter()
+            .filter(|e| !known.contains(e.link.trim_end_matches('/')))
+            .take(MAX_NEW_PER_FEED)
+            .cloned()
+            .collect();
+        let landed = ingest_entries(state, parent, &fresh, page_budget).await;
+        let title = if parsed.title.trim().is_empty() {
+            parent.title.clone()
+        } else {
+            parsed.title.clone()
+        };
+        if !landed.is_empty() {
+            rewrite_index(state, parent, &title, &parsed.description).await?;
+            let detail = match landed.len() {
+                1 => format!("new entry \u{00b7} {}", landed[0]),
+                n => format!("{n} new entries"),
+            };
+            let _ = state
+                .db
+                .add_source_event(&SourceEvent {
+                    id: commands::new_id(),
+                    notebook_id: parent.notebook_id.clone(),
+                    source_id: parent.id.clone(),
+                    source_title: title.clone(),
+                    kind: "added".into(),
+                    detail,
+                    diff: landed
+                        .iter()
+                        .map(|t| format!("+ {t}"))
+                        .collect::<Vec<_>>()
+                        .join("\n"),
+                    at: commands::now(),
+                })
+                .await;
+        }
+        let cadence = cadence_ms(
+            &parsed
+                .entries
+                .iter()
+                .map(|e| e.published_ms)
+                .collect::<Vec<_>>(),
+        );
+        Ok((
+            landed.len(),
+            FeedState {
+                etag,
+                last_modified,
+                next_poll_at: now + cadence,
+                failures: 0,
+                cadence_ms: cadence,
+            },
+        ))
+    }
+    .await;
+    match outcome {
+        Ok((n, next)) => {
+            with_store(&dir, |s| s.state.insert(parent.id.clone(), next), true);
+            Ok(n)
+        }
+        Err(err) => {
+            let failures = st.failures + 1;
+            let backoff = (cadence << failures.min(5)).min(MAX_CADENCE_MS);
+            with_store(
+                &dir,
+                |s| {
+                    s.state.insert(
+                        parent.id.clone(),
+                        FeedState {
+                            next_poll_at: now + backoff,
+                            failures,
+                            ..st.clone()
+                        },
+                    )
+                },
+                true,
+            );
+            if failures == UNREACHABLE_AFTER {
+                let _ = state
+                    .db
+                    .add_source_event(&SourceEvent {
+                        id: commands::new_id(),
+                        notebook_id: parent.notebook_id.clone(),
+                        source_id: parent.id.clone(),
+                        source_title: parent.title.clone(),
+                        kind: "unreachable".into(),
+                        detail: format!("{failures} polls failed"),
+                        diff: format!("{err:#}").chars().take(200).collect(),
+                        at: commands::now(),
+                    })
+                    .await;
+            }
+            Err(err)
+        }
+    }
+}
+
+static POLLING: AtomicBool = AtomicBool::new(false);
+
+/// The scheduler's feed pass: every due feed, single-flight, under the
+/// per-pass caps. Announces changed notebooks with `sources://changed` the
+/// way the folder sweep does. Not budgeted against the nightly ceiling —
+/// polling is not model work.
+pub fn spawn_poll(app: &AppHandle) {
+    if POLLING
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return;
+    }
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        if let Err(err) = run_poll(&app).await {
+            crate::diagnostics::error("feeds", format!("poll pass failed: {err:#}"));
+        }
+        POLLING.store(false, Ordering::SeqCst);
+    });
+}
+
+async fn run_poll(app: &AppHandle) -> Result<()> {
+    let state = app.state::<AppState>();
+    let archived = state.db.archived_notebook_ids().await.unwrap_or_default();
+    let feeds = state.db.all_feed_sources().await?;
+    let mut page_budget = MAX_PAGE_FETCHES_PER_PASS;
+    let mut landed_total = 0usize;
+    let mut changed: HashMap<String, usize> = HashMap::new();
+    for feed in &feeds {
+        if archived.contains(&feed.notebook_id) || landed_total >= MAX_NEW_PER_PASS {
+            continue;
+        }
+        match poll_one(&state, feed, false, &mut page_budget).await {
+            Ok(0) => {}
+            Ok(n) => {
+                landed_total += n;
+                *changed.entry(feed.notebook_id.clone()).or_default() += n;
+            }
+            Err(err) => crate::note!("feed poll: \u{201c}{}\u{201d} failed: {err:#}", feed.title),
+        }
+    }
+    for (notebook_id, added) in changed {
+        let _ = app.emit(
+            "sources://changed",
+            serde_json::json!({
+                "notebookId": notebook_id,
+                "scan": { "added": added, "updated": 0, "removed": 0, "failed": 0 },
+            }),
+        );
+    }
+    Ok(())
+}
+
+/// Manual Refresh on a feed parent (docs/RFC-events.md §2): poll now,
+/// ignoring the cadence, with a fresh page budget.
+pub async fn refresh(state: &AppState, parent: &Source) -> Result<Source> {
+    let mut page_budget = MAX_PAGE_FETCHES_PER_PASS;
+    poll_one(state, parent, true, &mut page_budget).await?;
+    let fresh = state
+        .db
+        .get_source(&parent.id)
+        .await?
+        .ok_or_else(|| anyhow!("Source not found"))?;
+    Ok(Source {
+        content: String::new(),
+        ..fresh
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const RSS: &str = r#"<?xml version="1.0"?>
+<rss version="2.0"><channel><title>Tauri Blog</title><description>News</description>
+<item><title>Tauri 2.5</title><link>https://v2.tauri.app/blog/tauri-25/</link><guid>a</guid><pubDate>Mon, 01 Sep 2026 10:00:00 GMT</pubDate><description>&lt;p&gt;Short &lt;b&gt;summary&lt;/b&gt;.&lt;/p&gt;</description></item>
+<item><title>Tauri 2.4</title><link>/blog/tauri-24/</link><guid>b</guid><pubDate>Mon, 25 Aug 2026 10:00:00 GMT</pubDate><content:encoded xmlns:content="http://purl.org/rss/1.0/modules/content/">&lt;p&gt;Full body here.&lt;/p&gt;</content:encoded></item>
+<item><title>No link</title><guid>c</guid></item>
+</channel></rss>"#;
+
+    #[test]
+    fn sniffs_feeds_but_not_pages() {
+        assert!(looks_like_feed("application/rss+xml", ""));
+        assert!(looks_like_feed("text/xml", RSS));
+        assert!(looks_like_feed(
+            "application/xml",
+            "<?xml version=\"1.0\"?><feed xmlns=\"http://www.w3.org/2005/Atom\"><title>x</title></feed>"
+        ));
+        assert!(looks_like_feed(
+            "application/json",
+            r#"{"version":"https://jsonfeed.org/version/1.1","title":"x","items":[]}"#
+        ));
+        assert!(!looks_like_feed(
+            "text/html",
+            "<!doctype html><html><head><title>Hi</title></head></html>"
+        ));
+        assert!(!looks_like_feed(
+            "text/html",
+            "<?xml version=\"1.0\"?><html xmlns=\"…\"><rss-like/></html>"
+        ));
+        assert!(!looks_like_feed(
+            "application/json",
+            r#"{"version": 2, "data": []}"#
+        ));
+    }
+
+    #[test]
+    fn discovers_alternate_links_and_resolves_them() {
+        let html = r#"<html><head>
+<link rel="stylesheet" href="/a.css">
+<link rel="alternate" type="application/rss+xml" title="RSS" href="/blog/rss.xml">
+<LINK REL="alternate" TYPE="application/atom+xml" HREF="https://other.example/atom">
+<link rel="alternate" type="application/feed+json" href='feed.json'>
+<link rel="alternate" type="text/html" hreflang="fr" href="/fr">
+</head></html>"#;
+        assert_eq!(
+            discover_in_html(html, "https://v2.tauri.app/blog/post/"),
+            vec![
+                "https://v2.tauri.app/blog/rss.xml",
+                "https://other.example/atom",
+                "https://v2.tauri.app/blog/post/feed.json",
+            ]
+        );
+        assert!(discover_in_html("<html><body>no links</body></html>", "https://x.y").is_empty());
+    }
+
+    #[test]
+    fn host_rules_follow_the_table() {
+        let q: Vec<String> = Vec::new();
+        let gh = host_rules("https://github.com/lancedb/lancedb/tree/main/rust", &q);
+        assert_eq!(
+            gh.iter().map(|c| c.url.as_str()).collect::<Vec<_>>(),
+            vec![
+                "https://github.com/lancedb/lancedb/releases.atom",
+                "https://github.com/lancedb/lancedb/commits.atom"
+            ]
+        );
+        let wp = host_rules(
+            "https://en.wikipedia.org/wiki/California_FAIR_Plan#History",
+            &q,
+        );
+        assert_eq!(
+            wp[0].url,
+            "https://en.wikipedia.org/w/index.php?title=California_FAIR_Plan&action=history&feed=atom"
+        );
+        assert_eq!(
+            host_rules("https://www.reddit.com/r/pottery/", &q)[0].url,
+            "https://www.reddit.com/r/pottery/.rss"
+        );
+        assert_eq!(
+            host_rules("https://alice.substack.com/p/hello", &q)[0].url,
+            "https://alice.substack.com/feed"
+        );
+        assert!(host_rules("https://example.com/article", &q).is_empty());
+        // arXiv: a query feed from standing questions, never a category.
+        assert!(host_rules("https://arxiv.org/abs/2307.03172", &q).is_empty());
+        let qs = vec![
+            "retrieval for long documents".to_string(),
+            "short".to_string(),
+        ];
+        let ax = host_rules("https://arxiv.org/pdf/2307.03172", &qs);
+        assert_eq!(ax.len(), 1);
+        assert!(ax[0]
+            .url
+            .starts_with("https://export.arxiv.org/api/query?search_query=all:%22retrieval"));
+        assert!(
+            !ax[0].url.contains("short"),
+            "queries under 8 chars are noise"
+        );
+    }
+
+    #[test]
+    fn parses_rss_with_relative_links_and_html() {
+        let p = parse(RSS, "https://v2.tauri.app/feed.xml").expect("parses");
+        assert_eq!(p.title, "Tauri Blog");
+        assert_eq!(p.entries.len(), 2, "the linkless item is dropped");
+        assert_eq!(p.entries[0].title, "Tauri 2.5");
+        assert_eq!(p.entries[0].link, "https://v2.tauri.app/blog/tauri-25/");
+        assert!(!p.entries[0].full);
+        assert!(p.entries[0].text.contains("Short"), "{}", p.entries[0].text);
+        assert!(!p.entries[0].text.contains("<b>"), "html is flattened");
+        assert_eq!(p.entries[1].link, "https://v2.tauri.app/blog/tauri-24/");
+        assert!(p.entries[1].full);
+        assert!(
+            p.entries[1].published_ms < p.entries[0].published_ms,
+            "newest first"
+        );
+    }
+
+    #[test]
+    fn entry_and_index_texts_are_rigid() {
+        let e = Entry {
+            id: "a".into(),
+            title: " Tauri 2.5 ".into(),
+            link: "https://v2.tauri.app/blog/tauri-25/".into(),
+            published_ms: 1_788_256_800_000,
+            text: "Body.".into(),
+            full: true,
+        };
+        let t = entry_text(&e);
+        assert!(t.starts_with("# Tauri 2.5\nPublished: 2026-09-01\nLink: https://v2.tauri.app/blog/tauri-25/\n\nBody."));
+        let idx = index_text(
+            "Tauri Blog",
+            "News",
+            &[(e.published_ms, e.title.clone(), e.link.clone())],
+        );
+        assert!(idx.contains("Feed of 1 entry, newest first:"));
+        assert!(
+            idx.contains("- 2026-09-01 \u{2014} [Tauri 2.5](https://v2.tauri.app/blog/tauri-25/)")
+        );
+    }
+
+    #[test]
+    fn cadence_is_the_median_gap_clamped() {
+        let h = 3_600_000;
+        assert_eq!(cadence_ms(&[]), MAX_CADENCE_MS, "undated feeds poll daily");
+        assert_eq!(cadence_ms(&[10 * h]), MAX_CADENCE_MS);
+        assert_eq!(cadence_ms(&[0, 2 * h, 4 * h, 6 * h]), 2 * h);
+        assert_eq!(
+            cadence_ms(&[0, 60_000, 120_000]),
+            MIN_CADENCE_MS,
+            "never faster than 30 minutes"
+        );
+        assert_eq!(
+            cadence_ms(&[0, 30 * 24 * h]),
+            MAX_CADENCE_MS,
+            "never slower than a day"
+        );
+        // Ordering does not matter; duplicates do not count as gaps.
+        assert_eq!(cadence_ms(&[6 * h, 0, 6 * h, 3 * h]), 3 * h);
+    }
+}

--- a/src-tauri/src/feeds.rs
+++ b/src-tauri/src/feeds.rs
@@ -19,15 +19,14 @@
 //! event per feed. Nothing here calls a model.
 
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Mutex;
 
 use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, Manager};
 
 use crate::commands::{self, AppState};
+use crate::db::Db;
 use crate::models::{Source, SourceEvent};
 
 /// New entries ingested per feed per pass; the rest wait for the next one.
@@ -601,7 +600,7 @@ pub fn cadence_ms(published: &[i64]) -> i64 {
     median.clamp(MIN_CADENCE_MS, MAX_CADENCE_MS)
 }
 
-// ---- Persistent poll state (one JSON sidecar, like git_hosts.json) ---------
+// ---- Persistent poll state (app_state rows, never a sidecar) ---------------
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 struct FeedState {
@@ -628,85 +627,88 @@ struct Discovered {
     seen_at: i64,
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
-struct Store {
-    /// Poll state by feed parent source id.
-    #[serde(default)]
-    state: HashMap<String, FeedState>,
-    /// Tier-1 discoveries by notebook id, then feed url.
-    #[serde(default)]
-    discovered: HashMap<String, HashMap<String, Discovered>>,
+fn state_key(source_id: &str) -> String {
+    format!("feed.state.{source_id}")
 }
 
-static STORE: Mutex<Option<Store>> = Mutex::new(None);
-
-fn store_path(data_dir: &Path) -> PathBuf {
-    data_dir.join("feeds.json")
+fn discovered_key(notebook_id: &str) -> String {
+    format!("feed.discovered.{notebook_id}")
 }
 
-fn with_store<T>(data_dir: &Path, f: impl FnOnce(&mut Store) -> T, save: bool) -> T {
-    let mut guard = STORE.lock().unwrap_or_else(|p| p.into_inner());
-    let store = guard.get_or_insert_with(|| {
-        std::fs::read_to_string(store_path(data_dir))
-            .ok()
-            .and_then(|s| serde_json::from_str(&s).ok())
-            .unwrap_or_default()
-    });
-    let out = f(store);
-    if save {
-        if let Ok(json) = serde_json::to_string_pretty(&*store) {
-            let _ = std::fs::write(store_path(data_dir), json);
+async fn load_state(db: &Db, source_id: &str) -> FeedState {
+    db.kv_get(&state_key(source_id))
+        .await
+        .ok()
+        .flatten()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+        .unwrap_or_default()
+}
+
+async fn save_state(db: &Db, source_id: &str, st: &FeedState) {
+    if let Ok(json) = serde_json::to_string(st) {
+        if let Err(err) = db.kv_set(&state_key(source_id), &json).await {
+            crate::note!("feeds: state for {source_id} not saved: {err:#}");
         }
     }
-    out
+}
+
+async fn load_discovered(db: &Db, notebook_id: &str) -> HashMap<String, Discovered> {
+    db.kv_get(&discovered_key(notebook_id))
+        .await
+        .ok()
+        .flatten()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+        .unwrap_or_default()
+}
+
+async fn save_discovered(db: &Db, notebook_id: &str, map: &HashMap<String, Discovered>) {
+    if let Ok(json) = serde_json::to_string(map) {
+        if let Err(err) = db.kv_set(&discovered_key(notebook_id), &json).await {
+            crate::note!("feeds: discovered feeds for {notebook_id} not saved: {err:#}");
+        }
+    }
 }
 
 /// Remember feeds a just-imported page advertised (tier 1), so the Grow
 /// pane can propose them without a second fetch.
-pub fn remember_discovered(state: &AppState, notebook_id: &str, source: &Source, feeds: &[String]) {
+pub async fn remember_discovered(
+    state: &AppState,
+    notebook_id: &str,
+    source: &Source,
+    feeds: &[String],
+) {
     if feeds.is_empty() {
         return;
     }
-    let dir = commands::app_data_dir(state);
     let now = commands::now();
-    with_store(
-        &dir,
-        |s| {
-            let nb = s.discovered.entry(notebook_id.to_string()).or_default();
-            for url in feeds {
-                nb.insert(
-                    url.clone(),
-                    Discovered {
-                        source_id: source.id.clone(),
-                        source_title: source.title.clone(),
-                        seen_at: now,
-                    },
-                );
-            }
-        },
-        true,
-    );
+    let mut map = load_discovered(&state.db, notebook_id).await;
+    for url in feeds {
+        map.insert(
+            url.clone(),
+            Discovered {
+                source_id: source.id.clone(),
+                source_title: source.title.clone(),
+                seen_at: now,
+            },
+        );
+    }
+    save_discovered(&state.db, notebook_id, &map).await;
 }
 
 /// Discovered feeds as growth proposals of kind `feed`, minus the ones the
 /// notebook already follows and the ones whose page is gone.
-pub fn discovered_proposals(
+pub async fn discovered_proposals(
     state: &AppState,
     notebook_id: &str,
     sources: &[Source],
 ) -> Vec<crate::growth::GrowthProposal> {
-    let dir = commands::app_data_dir(state);
     let followed: std::collections::HashSet<&str> = sources
         .iter()
         .filter(|s| s.source_type == "feed")
         .map(|s| s.url.trim_end_matches('/'))
         .collect();
     let live: std::collections::HashSet<&str> = sources.iter().map(|s| s.id.as_str()).collect();
-    let found = with_store(
-        &dir,
-        |s| s.discovered.get(notebook_id).cloned().unwrap_or_default(),
-        false,
-    );
+    let found = load_discovered(&state.db, notebook_id).await;
     let mut out: Vec<crate::growth::GrowthProposal> = found
         .into_iter()
         .filter(|(url, d)| {
@@ -731,23 +733,13 @@ pub fn discovered_proposals(
 /// conventional paths (the one tier that fetches, so it runs last and only
 /// here). Deduped, page tier first.
 pub async fn discover_for_source(state: &AppState, source: &Source) -> Vec<FeedCandidate> {
-    let dir = commands::app_data_dir(state);
     let mut out: Vec<FeedCandidate> = Vec::new();
-    let advertised: Vec<String> = with_store(
-        &dir,
-        |s| {
-            s.discovered
-                .get(&source.notebook_id)
-                .map(|m| {
-                    m.iter()
-                        .filter(|(_, d)| d.source_id == source.id)
-                        .map(|(u, _)| u.clone())
-                        .collect()
-                })
-                .unwrap_or_default()
-        },
-        false,
-    );
+    let advertised: Vec<String> = load_discovered(&state.db, &source.notebook_id)
+        .await
+        .iter()
+        .filter(|(_, d)| d.source_id == source.id)
+        .map(|(u, _)| u.clone())
+        .collect();
     for url in advertised {
         out.push(candidate(url, "Feed", "page"));
     }
@@ -880,8 +872,10 @@ async fn ingest_entries(
     parent: &Source,
     entries: &[Entry],
     page_budget: &mut usize,
+    delay: Option<std::time::Duration>,
 ) -> Vec<(String, String)> {
     let mut landed = Vec::new();
+    let mut fetched_any = false;
     for e in entries {
         let mut text = entry_text(e);
         let mut title = e.title.clone();
@@ -895,6 +889,11 @@ async fn ingest_entries(
         let mut fetched = false;
         if !e.full && *page_budget > 0 {
             *page_budget -= 1;
+            // The site's Crawl-delay, between our fetches only.
+            if let (Some(d), true) = (delay, fetched_any) {
+                tokio::time::sleep(d).await;
+            }
+            fetched_any = true;
             // The same path Add Source takes: the fast fetch, then the
             // rendered capture when a page comes back as a JS shell.
             if let Ok(page) = crate::capture::extract_url_rescued(&e.link).await {
@@ -952,6 +951,13 @@ pub async fn connect(state: &AppState, notebook_id: &str, url: &str, body: &str)
     if parsed.entries.is_empty() {
         anyhow::bail!("{url} is a feed with no entries");
     }
+    // A sitemap watch is a crawler, and a site's robots.txt is the rule it
+    // sets for crawlers. A disallowed sitemap is not watched at all.
+    if parsed.sitemap && !crate::robots::allowed(&state.db, url).await {
+        anyhow::bail!(
+            "{url} is off limits to crawlers under the site's robots.txt, so Alchemy won't watch it"
+        );
+    }
     let title = if parsed.title.trim().is_empty() {
         url.to_string()
     } else {
@@ -995,28 +1001,23 @@ pub async fn connect(state: &AppState, notebook_id: &str, url: &str, body: &str)
             .take(MAX_NEW_PER_FEED * 2)
             .cloned()
             .collect();
-        ingest_entries(state, &parent, &first, &mut page_budget).await;
+        ingest_entries(state, &parent, &first, &mut page_budget, None).await;
         Vec::new()
     };
     let parent = rewrite_index(state, &parent, &title, &parsed.description).await?;
-    let dir = commands::app_data_dir(state);
-    with_store(
-        &dir,
-        |s| {
-            s.state.insert(
-                parent.id.clone(),
-                FeedState {
-                    etag: String::new(),
-                    last_modified: String::new(),
-                    next_poll_at: commands::now() + cadence,
-                    failures: 0,
-                    cadence_ms: cadence,
-                    seen,
-                },
-            );
+    save_state(
+        &state.db,
+        &parent.id,
+        &FeedState {
+            etag: String::new(),
+            last_modified: String::new(),
+            next_poll_at: commands::now() + cadence,
+            failures: 0,
+            cadence_ms: cadence,
+            seen,
         },
-        true,
-    );
+    )
+    .await;
     Ok(Source {
         content: String::new(),
         ..parent
@@ -1032,13 +1033,8 @@ pub async fn poll_one(
     force: bool,
     page_budget: &mut usize,
 ) -> Result<usize> {
-    let dir = commands::app_data_dir(state);
     let now = commands::now();
-    let st = with_store(
-        &dir,
-        |s| s.state.get(&parent.id).cloned().unwrap_or_default(),
-        false,
-    );
+    let st = load_state(&state.db, &parent.id).await;
     if !force && now < st.next_poll_at {
         return Ok(0);
     }
@@ -1087,16 +1083,33 @@ pub async fn poll_one(
         } else {
             MAX_NEW_PER_FEED
         };
+        // Sitemap arrivals are crawled, so they obey robots.txt: disallowed
+        // pages are marked seen without a fetch (they are not "new" to us
+        // in any sense the site permits), and Crawl-delay spaces the rest.
+        let robots = if parsed.sitemap {
+            Some(crate::robots::rules_for(&state.db, &parent.url).await)
+        } else {
+            None
+        };
+        let mut disallowed: Vec<u64> = Vec::new();
         let fresh: Vec<Entry> = parsed
             .entries
             .iter()
             .filter(|e| {
                 !known.contains(e.link.trim_end_matches('/')) && !seen.contains(&url_hash(&e.link))
             })
+            .filter(|e| match &robots {
+                Some(r) if !r.allows(&crate::robots::path_of(&e.link)) => {
+                    disallowed.push(url_hash(&e.link));
+                    false
+                }
+                _ => true,
+            })
             .take(cap)
             .cloned()
             .collect();
-        let landed = ingest_entries(state, parent, &fresh, page_budget).await;
+        let delay = robots.as_ref().and_then(|r| r.delay());
+        let landed = ingest_entries(state, parent, &fresh, page_budget, delay).await;
         let title = if parsed.title.trim().is_empty() {
             parent.title.clone()
         } else {
@@ -1142,8 +1155,11 @@ pub async fn poll_one(
         // pass stays unseen and comes round again.
         let mut seen_next = st.seen.clone();
         if parsed.sitemap {
-            for (_, link) in &landed {
-                let h = url_hash(link);
+            for h in landed
+                .iter()
+                .map(|(_, link)| url_hash(link))
+                .chain(disallowed)
+            {
                 if !seen_next.contains(&h) {
                     seen_next.push(h);
                 }
@@ -1164,26 +1180,22 @@ pub async fn poll_one(
     .await;
     match outcome {
         Ok((n, next)) => {
-            with_store(&dir, |s| s.state.insert(parent.id.clone(), next), true);
+            save_state(&state.db, &parent.id, &next).await;
             Ok(n)
         }
         Err(err) => {
             let failures = st.failures + 1;
             let backoff = (cadence << failures.min(5)).min(MAX_CADENCE_MS);
-            with_store(
-                &dir,
-                |s| {
-                    s.state.insert(
-                        parent.id.clone(),
-                        FeedState {
-                            next_poll_at: now + backoff,
-                            failures,
-                            ..st.clone()
-                        },
-                    )
+            save_state(
+                &state.db,
+                &parent.id,
+                &FeedState {
+                    next_poll_at: now + backoff,
+                    failures,
+                    ..st.clone()
                 },
-                true,
-            );
+            )
+            .await;
             if failures == UNREACHABLE_AFTER {
                 let _ = state
                     .db

--- a/src-tauri/src/feeds.rs
+++ b/src-tauri/src/feeds.rs
@@ -8,6 +8,11 @@
 //! `mtime` = the entry's published time. Retrieval, gallery, tags, and
 //! hygiene work unchanged because children are just sources.
 //!
+//! A **sitemap watch** is the same parent with different arrival rules: a
+//! pasted `sitemap.xml` snapshots every URL it lists as already seen and
+//! ingests nothing — only pages that appear later arrive, each fetched
+//! through the normal page path. Watching a site is not copying it.
+//!
 //! Cost rules (RFC "Cost rules"): a poll is one conditional GET; a 304 costs
 //! nothing downstream. New entries ingest through the normal chunk/embed
 //! path, capped per feed and per pass. A poll writes at most one `added`
@@ -45,7 +50,7 @@ const PROBE_BYTES: usize = 4 * 1024;
 /// Entry text handed to the child source, capped.
 const ENTRY_TEXT_CAP: usize = 40_000;
 
-const WELL_KNOWN: [&str; 7] = [
+const WELL_KNOWN: [&str; 8] = [
     "/feed",
     "/rss",
     "/rss.xml",
@@ -53,6 +58,8 @@ const WELL_KNOWN: [&str; 7] = [
     "/feed.xml",
     "/index.xml",
     "/feed.json",
+    // Last, and only a watch: a site with no feed still lists its pages.
+    "/sitemap.xml",
 ];
 
 // ---- Sniffing and discovery (pure) ---------------------------------------
@@ -69,11 +76,25 @@ pub fn looks_like_feed(content_type: &str, body: &str) -> bool {
     if lower.starts_with('{') {
         return lower.contains("\"version\"") && lower.contains("jsonfeed.org");
     }
-    let xml_ish =
-        lower.starts_with("<?xml") || lower.starts_with("<rss") || lower.starts_with("<feed");
+    let xml_ish = lower.starts_with("<?xml")
+        || lower.starts_with("<rss")
+        || lower.starts_with("<feed")
+        || lower.starts_with("<urlset")
+        || lower.starts_with("<sitemapindex");
     xml_ish
-        && (lower.contains("<rss") || lower.contains("<feed") || lower.contains("<rdf:rdf"))
+        && (lower.contains("<rss")
+            || lower.contains("<feed")
+            || lower.contains("<rdf:rdf")
+            || lower.contains("<urlset")
+            || lower.contains("<sitemapindex"))
         && !lower.contains("<html")
+}
+
+/// Is this feed document a sitemap (RFC §2, the watch shape)?
+fn is_sitemap(body: &str) -> bool {
+    let head: String = body.trim_start().chars().take(2_000).collect();
+    let lower = head.to_ascii_lowercase();
+    lower.contains("<urlset") || lower.contains("<sitemapindex")
 }
 
 /// Tier 1: `<link rel="alternate" type="application/rss+xml|atom+xml|
@@ -344,11 +365,105 @@ pub struct Parsed {
     pub description: String,
     /// Newest first.
     pub entries: Vec<Entry>,
+    /// A sitemap watch: entries are bare links, and nothing ingests at
+    /// connect (see the module doc).
+    pub sitemap: bool,
 }
 
-/// Parse RSS / Atom / JSON Feed. Entries without a link are dropped — a
-/// child source needs an origin to refresh from and to dedupe on.
+/// A sitemap's `<url><loc>…</loc><lastmod>…</lastmod></url>` blocks as
+/// link-only entries, newest `lastmod` first (undated ones keep file order
+/// after the dated ones). A sitemap *index* is refused with the list it
+/// points at: the user picks one, the app never crawls a tree.
+fn parse_sitemap(body: &str, base: &str) -> Result<Parsed> {
+    let lower = body.to_ascii_lowercase();
+    if lower.contains("<sitemapindex") {
+        let children: Vec<String> = between_all(body, "<loc>", "</loc>")
+            .into_iter()
+            .take(6)
+            .collect();
+        anyhow::bail!(
+            "{base} is a sitemap index — paste one of the sitemaps it lists instead: {}",
+            children.join(", ")
+        );
+    }
+    let host = base
+        .split("://")
+        .nth(1)
+        .and_then(|r| r.split('/').next())
+        .unwrap_or(base)
+        .trim_start_matches("www.");
+    let mut entries: Vec<Entry> = Vec::new();
+    for block in body.split("<url>").skip(1) {
+        let block = block.split("</url>").next().unwrap_or("");
+        let Some(loc) = between(block, "<loc>", "</loc>") else {
+            continue;
+        };
+        let Some(link) = resolve(base, loc.trim()) else {
+            continue;
+        };
+        let published_ms = between(block, "<lastmod>", "</lastmod>")
+            .and_then(|d| parse_lastmod(d.trim()))
+            .unwrap_or(0);
+        entries.push(Entry {
+            id: link.clone(),
+            title: link.clone(),
+            link,
+            published_ms,
+            text: String::new(),
+            full: false,
+        });
+    }
+    let n = entries.len();
+    // Stable: dated pages newest first, undated ones after in file order.
+    entries.sort_by_key(|e| std::cmp::Reverse(e.published_ms));
+    Ok(Parsed {
+        title: format!("{host} \u{2014} new pages"),
+        description: format!(
+            "Watching the {n} pages listed at {base}. Pages added to the site arrive here as sources; nothing already listed is copied."
+        ),
+        entries,
+        sitemap: true,
+    })
+}
+
+fn between<'a>(s: &'a str, open: &str, close: &str) -> Option<&'a str> {
+    let i = s.find(open)? + open.len();
+    let j = s[i..].find(close)? + i;
+    Some(&s[i..j])
+}
+
+fn between_all(s: &str, open: &str, close: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut rest = s;
+    while let Some(found) = between(rest, open, close) {
+        out.push(found.trim().to_string());
+        let skip = rest.find(open).unwrap_or(0) + open.len() + found.len() + close.len();
+        rest = &rest[skip.min(rest.len())..];
+    }
+    out
+}
+
+/// `2026-09-01`, `2026-09-01T10:00:00Z`, or with an offset → epoch ms.
+fn parse_lastmod(s: &str) -> Option<i64> {
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
+        return Some(dt.timestamp_millis());
+    }
+    let date = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d").ok()?;
+    Some(date.and_hms_opt(0, 0, 0)?.and_utc().timestamp_millis())
+}
+
+/// A URL as the compact token the seen-set keeps (docs/RFC-events.md §2):
+/// trailing-slash-insensitive, so `/a` and `/a/` are one page.
+pub fn url_hash(url: &str) -> u64 {
+    crate::mac::content_stamp(url.trim_end_matches('/')) as u64
+}
+
+/// Parse RSS / Atom / JSON Feed — or a sitemap. Entries without a link are
+/// dropped — a child source needs an origin to refresh from and to dedupe on.
 pub fn parse(body: &str, base: &str) -> Result<Parsed> {
+    if is_sitemap(body) {
+        return parse_sitemap(body, base);
+    }
     let feed = feed_rs::parser::parse(body.as_bytes()).context("could not parse feed")?;
     let text_of = |t: &Option<feed_rs::model::Text>| -> String {
         t.as_ref().map(|t| plain(&t.content)).unwrap_or_default()
@@ -404,6 +519,7 @@ pub fn parse(body: &str, base: &str) -> Result<Parsed> {
         title: text_of(&feed.title),
         description: text_of(&feed.description),
         entries,
+        sitemap: false,
     })
 }
 
@@ -499,6 +615,10 @@ struct FeedState {
     failures: i64,
     #[serde(default)]
     cadence_ms: i64,
+    /// Sitemap watches only: `url_hash` of every page already seen, so a
+    /// connect ingests nothing and a poll ingests only what appeared.
+    #[serde(default)]
+    seen: Vec<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -641,7 +761,12 @@ pub async fn discover_for_source(state: &AppState, source: &Source) -> Vec<FeedC
     if out.is_empty() {
         for url in probe_well_known(&source.url).await {
             if !out.iter().any(|o| o.url == url) {
-                out.push(candidate(url, "Feed", "well-known"));
+                let label = if url.ends_with("/sitemap.xml") {
+                    "New pages (sitemap watch)"
+                } else {
+                    "Feed"
+                };
+                out.push(candidate(url, label, "well-known"));
             }
         }
     }
@@ -755,18 +880,33 @@ async fn ingest_entries(
     parent: &Source,
     entries: &[Entry],
     page_budget: &mut usize,
-) -> Vec<String> {
+) -> Vec<(String, String)> {
     let mut landed = Vec::new();
     for e in entries {
         let mut text = entry_text(e);
+        let mut title = e.title.clone();
+        // A sitemap entry is a bare link: without the page there is nothing
+        // to store, so it waits for a pass with budget (or a page that
+        // answers) rather than landing empty.
+        let link_only = !e.full && e.text.trim().is_empty();
+        if link_only && *page_budget == 0 {
+            continue;
+        }
+        let mut fetched = false;
         if !e.full && *page_budget > 0 {
             *page_budget -= 1;
-            if let Ok(page) = crate::ingest::extract_url(&e.link).await {
+            // The same path Add Source takes: the fast fetch, then the
+            // rendered capture when a page comes back as a JS shell.
+            if let Ok(page) = crate::capture::extract_url_rescued(&e.link).await {
                 if page.source_type != "feed" && page.text.chars().count() > e.text.chars().count()
                 {
+                    fetched = true;
+                    if link_only && !page.title.trim().is_empty() {
+                        title = page.title.trim().to_string();
+                    }
                     text = format!(
                         "# {}\nPublished: {}\nLink: {}\n\n{}",
-                        e.title.trim(),
+                        title.trim(),
                         day(e.published_ms),
                         e.link,
                         page.text.trim()
@@ -774,8 +914,11 @@ async fn ingest_entries(
                 }
             }
         }
+        if link_only && !fetched {
+            continue;
+        }
         let extracted = crate::ingest::Extracted {
-            title: e.title.clone(),
+            title: title.clone(),
             source_type: "url".to_string(),
             url: e.link.clone(),
             text,
@@ -794,7 +937,7 @@ async fn ingest_entries(
         )
         .await
         {
-            Ok(_) => landed.push(e.title.clone()),
+            Ok(_) => landed.push((title, e.link.clone())),
             Err(err) => crate::note!("feed {}: entry {} failed: {err:#}", parent.title, e.link),
         }
     }
@@ -839,14 +982,22 @@ pub async fn connect(state: &AppState, notebook_id: &str, url: &str, body: &str)
     };
     let parent =
         commands::store_new_source(state, notebook_id, extracted, "", stamp, None, false).await?;
-    let mut page_budget = MAX_PAGE_FETCHES_PER_PASS;
-    let first: Vec<Entry> = parsed
-        .entries
-        .iter()
-        .take(MAX_NEW_PER_FEED * 2)
-        .cloned()
-        .collect();
-    ingest_entries(state, &parent, &first, &mut page_budget).await;
+    // A feed connects with its newest entries; a sitemap watch connects
+    // with none — every page it lists today is marked seen, and only pages
+    // that appear from here on arrive.
+    let seen: Vec<u64> = if parsed.sitemap {
+        parsed.entries.iter().map(|e| url_hash(&e.link)).collect()
+    } else {
+        let mut page_budget = MAX_PAGE_FETCHES_PER_PASS;
+        let first: Vec<Entry> = parsed
+            .entries
+            .iter()
+            .take(MAX_NEW_PER_FEED * 2)
+            .cloned()
+            .collect();
+        ingest_entries(state, &parent, &first, &mut page_budget).await;
+        Vec::new()
+    };
     let parent = rewrite_index(state, &parent, &title, &parsed.description).await?;
     let dir = commands::app_data_dir(state);
     with_store(
@@ -860,6 +1011,7 @@ pub async fn connect(state: &AppState, notebook_id: &str, url: &str, body: &str)
                     next_poll_at: commands::now() + cadence,
                     failures: 0,
                     cadence_ms: cadence,
+                    seen,
                 },
             );
         },
@@ -920,17 +1072,28 @@ pub async fn poll_one(
             ));
         };
         let parsed = parse(&body, &parent.url)?;
+        // Anything the notebook already holds — under this feed or added
+        // by hand — is not new; a sitemap watch also remembers what it
+        // saw at connect, since those pages were never ingested.
         let all = state.db.list_sources(&parent.notebook_id).await?;
         let known: std::collections::HashSet<&str> = all
             .iter()
-            .filter(|s| s.parent_id == parent.id)
+            .filter(|s| !s.url.is_empty())
             .map(|s| s.url.trim_end_matches('/'))
             .collect();
+        let seen: std::collections::HashSet<u64> = st.seen.iter().copied().collect();
+        let cap = if parsed.sitemap {
+            MAX_NEW_PER_FEED.min(*page_budget)
+        } else {
+            MAX_NEW_PER_FEED
+        };
         let fresh: Vec<Entry> = parsed
             .entries
             .iter()
-            .filter(|e| !known.contains(e.link.trim_end_matches('/')))
-            .take(MAX_NEW_PER_FEED)
+            .filter(|e| {
+                !known.contains(e.link.trim_end_matches('/')) && !seen.contains(&url_hash(&e.link))
+            })
+            .take(cap)
             .cloned()
             .collect();
         let landed = ingest_entries(state, parent, &fresh, page_budget).await;
@@ -947,7 +1110,7 @@ pub async fn poll_one(
         }
         if !landed.is_empty() {
             let detail = match landed.len() {
-                1 => format!("new entry \u{00b7} {}", landed[0]),
+                1 => format!("new entry \u{00b7} {}", landed[0].0),
                 n => format!("{n} new entries"),
             };
             let _ = state
@@ -961,7 +1124,7 @@ pub async fn poll_one(
                     detail,
                     diff: landed
                         .iter()
-                        .map(|t| format!("+ {t}"))
+                        .map(|(t, _)| format!("+ {t}"))
                         .collect::<Vec<_>>()
                         .join("\n"),
                     at: commands::now(),
@@ -975,6 +1138,17 @@ pub async fn poll_one(
                 .map(|e| e.published_ms)
                 .collect::<Vec<_>>(),
         );
+        // The watch remembers what landed; what it could not fetch this
+        // pass stays unseen and comes round again.
+        let mut seen_next = st.seen.clone();
+        if parsed.sitemap {
+            for (_, link) in &landed {
+                let h = url_hash(link);
+                if !seen_next.contains(&h) {
+                    seen_next.push(h);
+                }
+            }
+        }
         Ok((
             landed.len(),
             FeedState {
@@ -983,6 +1157,7 @@ pub async fn poll_one(
                 next_poll_at: now + cadence,
                 failures: 0,
                 cadence_ms: cadence,
+                seen: seen_next,
             },
         ))
     }
@@ -1240,6 +1415,58 @@ mod tests {
         assert!(
             idx.contains("- 2026-09-01 \u{2014} [Tauri 2.5](https://v2.tauri.app/blog/tauri-25/)")
         );
+    }
+
+    const SITEMAP: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<url><loc>https://www.curated.supply/</loc></url>
+<url><loc>https://www.curated.supply/products/imac</loc><lastmod>2026-08-30</lastmod></url>
+<url><loc>https://www.curated.supply/products/iphone-pro-17</loc><lastmod>2026-09-01T10:00:00Z</lastmod></url>
+<url><loc>/products/relative</loc></url>
+</urlset>"#;
+
+    #[test]
+    fn sitemaps_are_feeds_of_bare_links_newest_first() {
+        assert!(looks_like_feed("text/xml", SITEMAP));
+        assert!(is_sitemap(SITEMAP));
+        assert!(!is_sitemap(RSS));
+        let p = parse(SITEMAP, "https://www.curated.supply/sitemap.xml").expect("parses");
+        assert!(p.sitemap);
+        assert_eq!(p.title, "curated.supply \u{2014} new pages");
+        assert!(p.description.contains("Watching the 4 pages"));
+        let links: Vec<&str> = p.entries.iter().map(|e| e.link.as_str()).collect();
+        assert_eq!(
+            links,
+            vec![
+                "https://www.curated.supply/products/iphone-pro-17",
+                "https://www.curated.supply/products/imac",
+                "https://www.curated.supply/",
+                "https://www.curated.supply/products/relative",
+            ],
+            "dated newest first, undated after in file order, relative resolved"
+        );
+        assert!(
+            p.entries.iter().all(|e| !e.full && e.text.is_empty()),
+            "bare links"
+        );
+        assert_eq!(
+            p.entries[0].title, p.entries[0].link,
+            "titled by the page once fetched"
+        );
+        assert_eq!(url_hash("https://a.b/x/"), url_hash("https://a.b/x"));
+        assert_ne!(url_hash("https://a.b/x"), url_hash("https://a.b/y"));
+    }
+
+    #[test]
+    fn sitemap_indexes_are_refused_with_their_children() {
+        let index = r#"<?xml version="1.0"?><sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>https://x.y/sitemap-products.xml</loc></sitemap>
+<sitemap><loc>https://x.y/sitemap-pages.xml</loc></sitemap></sitemapindex>"#;
+        let err = parse(index, "https://x.y/sitemap.xml")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("sitemap index"), "{err}");
+        assert!(err.contains("sitemap-products.xml") && err.contains("sitemap-pages.xml"));
     }
 
     #[test]

--- a/src-tauri/src/fswatch.rs
+++ b/src-tauri/src/fswatch.rs
@@ -1,0 +1,552 @@
+//! Detection cost (docs/RFC-events.md §4): the kernel tells us when an open
+//! notebook's folder changes, and nobody walks a folder nobody is looking at
+//! more than once in ten minutes.
+//!
+//! Two halves, both feeding `commands::resync_sources_filtered`:
+//!
+//! - **FSEvents for open notebooks.** Windows report the notebook they have
+//!   open (`set_open_notebook`); this module watches the roots of the *local*
+//!   folder sources (`folder`, `obsidian`) of those notebooks and nothing
+//!   else — git and Notion parents scan app-managed caches the app itself
+//!   writes, so watching them would only echo our own work. A burst of raw
+//!   events debounces two seconds per notebook into one scoped resync, which
+//!   already coalesces its `added`/`removed` events and emits one
+//!   `sources://changed`.
+//! - **The closed sweep.** The scheduler's minute tick passes
+//!   [`Sweep::Tick`]; local folder parents of notebooks that are not open
+//!   are skipped unless the ten-minute closed window has elapsed. Open
+//!   notebooks keep the minute walk as a belt to FSEvents' braces. Git and
+//!   Notion probes and Mac hash checks keep their own cadences regardless —
+//!   they are not directory walks.
+//!
+//! The watcher is best-effort by design: if it fails to start, the sweeps
+//! still run and the failure is recorded once. Detection must never take
+//! the app down.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use notify::event::ModifyKind;
+use notify::{EventKind, RecursiveMode, Watcher};
+use tauri::{AppHandle, Manager};
+use tokio::sync::mpsc;
+
+use crate::commands::{self, AppState};
+
+/// Quiet period after the last raw event before a notebook's resync fires.
+/// A sync tool writing 400 files must land as one rescan, not 400.
+pub const DEBOUNCE: Duration = Duration::from_secs(2);
+
+/// Ceiling on how long a continuously-busy folder can hold its window open
+/// before a resync fires anyway, so a folder that never goes quiet still
+/// makes progress.
+pub const MAX_HOLD: Duration = Duration::from_secs(30);
+
+/// How often the scheduler walks the folders of notebooks nobody has open.
+/// A constant, not a setting: the policy is the number.
+pub const CLOSED_SWEEP_MS: i64 = 10 * 60 * 1000;
+
+/// Which folder parents a resync pass walks. Everything but the minute tick
+/// uses [`Sweep::All`]: the manual Resync command, the notebook-open catch-up,
+/// and the watcher's own scoped fires all rescan what they always did.
+#[derive(Debug, Clone, Copy)]
+pub enum Sweep<'a> {
+    /// Walk every folder parent the notebook scope allows.
+    All,
+    /// The scheduler tick: local folder parents of notebooks outside `open`
+    /// walk only when `closed_due` (once per [`CLOSED_SWEEP_MS`]).
+    Tick {
+        open: &'a HashSet<String>,
+        closed_due: bool,
+    },
+}
+
+/// Whether a folder parent belongs in this pass. Pure, so the policy sits
+/// beside its tests rather than inside the walk.
+pub fn in_sweep(source_type: &str, notebook_id: &str, sweep: Sweep<'_>) -> bool {
+    match sweep {
+        Sweep::All => true,
+        Sweep::Tick { open, closed_due } => {
+            !is_local_folder(source_type) || closed_due || open.contains(notebook_id)
+        }
+    }
+}
+
+/// Folder parents whose root is a user directory on disk — the only ones
+/// FSEvents can usefully watch and the only ones the closed sweep throttles.
+pub fn is_local_folder(source_type: &str) -> bool {
+    matches!(source_type, "folder" | "obsidian")
+}
+
+// ---- Debounce -----------------------------------------------------------
+
+struct Window {
+    first: Instant,
+    last: Instant,
+}
+
+impl Window {
+    fn deadline(&self) -> Instant {
+        (self.last + DEBOUNCE).min(self.first + MAX_HOLD)
+    }
+}
+
+/// Per-notebook trailing debounce with a hold ceiling: a window opens at the
+/// first raw event, extends with each further event, and fires once the
+/// folder has been quiet for [`DEBOUNCE`] or busy for [`MAX_HOLD`]. Pure —
+/// it is handed the clock — so the policy is testable without a filesystem.
+#[derive(Default)]
+pub struct Debouncer {
+    pending: HashMap<String, Window>,
+}
+
+impl Debouncer {
+    /// Record a raw event for `notebook` at `now`.
+    pub fn touch(&mut self, notebook: &str, now: Instant) {
+        match self.pending.get_mut(notebook) {
+            Some(w) => w.last = now,
+            None => {
+                self.pending.insert(
+                    notebook.to_string(),
+                    Window {
+                        first: now,
+                        last: now,
+                    },
+                );
+            }
+        }
+    }
+
+    /// The earliest instant at which some notebook becomes due; `None` when
+    /// nothing is pending, so the loop can sleep on the receiver alone.
+    pub fn next_deadline(&self) -> Option<Instant> {
+        self.pending.values().map(Window::deadline).min()
+    }
+
+    /// Drain and return every notebook whose window has closed by `now`,
+    /// sorted for deterministic firing order.
+    pub fn due(&mut self, now: Instant) -> Vec<String> {
+        let mut out: Vec<String> = self
+            .pending
+            .iter()
+            .filter(|(_, w)| w.deadline() <= now)
+            .map(|(nb, _)| nb.clone())
+            .collect();
+        for nb in &out {
+            self.pending.remove(nb);
+        }
+        out.sort();
+        out
+    }
+}
+
+// ---- Path filtering -----------------------------------------------------
+
+/// Whether a notify event could reflect a change to folder contents. Reads
+/// (`Access`) and inode-metadata touches (`Modify(Metadata)`) never do; a
+/// spurious rescan costs an mtime walk, a missed one costs a stale source,
+/// so everything else is kept — cider's watcher draws the same line.
+pub fn is_content_change(kind: &EventKind) -> bool {
+    !matches!(
+        kind,
+        EventKind::Access(_) | EventKind::Modify(ModifyKind::Metadata(_))
+    )
+}
+
+/// Whether the folder scanner would even see `path` under `root`. Mirrors
+/// `commands::scan_folder`: dot entries are invisible except iCloud eviction
+/// stubs (`.name.icloud`, whose appearance and disappearance *is* the
+/// change), and vendored directories are pruned. Without this an Obsidian
+/// vault rescans every two seconds while `.obsidian/workspace.json` churns.
+pub fn is_scannable(root: &Path, path: &Path) -> bool {
+    let Ok(rel) = path.strip_prefix(root) else {
+        return false;
+    };
+    let mut components = rel.components().peekable();
+    while let Some(c) = components.next() {
+        let name = c.as_os_str().to_string_lossy();
+        let is_last = components.peek().is_none();
+        if let Some(rest) = name.strip_prefix('.') {
+            let icloud_stub = is_last && rest.ends_with(".icloud") && rest.len() > ".icloud".len();
+            if !icloud_stub {
+                return false;
+            }
+        } else if !is_last && commands::SKIP_DIRS.contains(&name.to_lowercase().as_str()) {
+            return false;
+        }
+    }
+    true
+}
+
+/// Which watched root `path` falls under, if any. Roots never nest in
+/// practice (a folder inside a folder source is a child, not a parent), so
+/// first match wins.
+fn notebook_for<'a>(roots: &'a HashMap<PathBuf, String>, path: &Path) -> Option<&'a str> {
+    roots
+        .iter()
+        .find(|(root, _)| path.starts_with(root) && is_scannable(root, path))
+        .map(|(_, nb)| nb.as_str())
+}
+
+// ---- The live watcher ---------------------------------------------------
+
+struct Live {
+    watcher: notify::RecommendedWatcher,
+    /// Root → notebook id, shared with the FSEvents callback so a rearm
+    /// changes routing without rebuilding the watcher.
+    roots: Arc<Mutex<HashMap<PathBuf, String>>>,
+    /// Roots whose `watch` failed, so the failure is recorded once.
+    failed: HashSet<PathBuf>,
+}
+
+static LIVE: Mutex<Option<Live>> = Mutex::new(None);
+/// Set when the watcher failed to construct: recorded once, then the sweeps
+/// carry detection alone rather than retrying (and re-logging) every tick.
+static FAILED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+/// Raw notebook ids from the callback thread into the debounce loop.
+static TX: OnceLock<mpsc::UnboundedSender<String>> = OnceLock::new();
+
+/// Spawn the debounce loop. Called once from setup; the watcher itself is
+/// built lazily on the first rearm that has something to watch.
+pub fn start(app: AppHandle) {
+    let (tx, rx) = mpsc::unbounded_channel();
+    if TX.set(tx).is_err() {
+        return;
+    }
+    tauri::async_runtime::spawn(run(app, rx));
+}
+
+async fn run(app: AppHandle, mut rx: mpsc::UnboundedReceiver<String>) {
+    let mut deb = Debouncer::default();
+    loop {
+        // Idle costs nothing: with no window open the loop parks on the
+        // receiver alone. The far deadline stands in for "never".
+        let deadline = deb
+            .next_deadline()
+            .unwrap_or_else(|| Instant::now() + Duration::from_secs(24 * 3600));
+        tokio::select! {
+            ev = rx.recv() => match ev {
+                Some(nb) => deb.touch(&nb, Instant::now()),
+                None => return,
+            },
+            _ = tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)) => {}
+        }
+        for nb in deb.due(Instant::now()) {
+            let state = app.state::<AppState>();
+            match commands::resync_sources_filtered(&app, &state, Some(&nb), Sweep::All).await {
+                Ok(Some(scan)) => {
+                    if scan.changed() {
+                        crate::note!(
+                            "fswatch: {nb}: +{} ~{} -{} ({} failed)",
+                            scan.added,
+                            scan.updated,
+                            scan.removed,
+                            scan.failed
+                        );
+                    }
+                }
+                // A manual import holds the scan lock: the change is real
+                // and must not be dropped, so re-open the window and try
+                // again after the next quiet period.
+                Ok(None) => deb.touch(&nb, Instant::now()),
+                Err(err) => crate::diagnostics::error("fswatch", format!("{nb}: resync: {err}")),
+            }
+        }
+    }
+}
+
+/// Re-derive the watched set from the open notebooks and their local folder
+/// sources. Cheap (one folder-table read, no content), so it runs on every
+/// open-set change and every scheduler tick; a watcher that already matches
+/// is left alone.
+pub async fn rearm(app: &AppHandle) {
+    let state = app.state::<AppState>();
+    prune_closed_windows(app, &state);
+    let open = state.open_notebook_ids();
+    let mut desired: HashMap<PathBuf, String> = HashMap::new();
+    if !open.is_empty() {
+        match state.db.all_folder_sources().await {
+            Ok(folders) => {
+                for f in folders {
+                    if !is_local_folder(&f.source_type) || !open.contains(&f.notebook_id) {
+                        continue;
+                    }
+                    let root = PathBuf::from(&f.url);
+                    if root.is_dir() {
+                        desired.insert(root, f.notebook_id);
+                    }
+                }
+            }
+            Err(err) => {
+                crate::note!("fswatch: folder list failed: {err:#}");
+                return;
+            }
+        }
+    }
+    apply(desired);
+}
+
+/// Drop registry entries for windows that no longer exist. `Destroyed`
+/// evicts on the hot path; this catches anything that slipped past it.
+fn prune_closed_windows(app: &AppHandle, state: &AppState) {
+    let live: HashSet<String> = app.webview_windows().keys().cloned().collect();
+    let mut open = state
+        .open_notebooks
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    open.retain(|label, _| live.contains(label));
+}
+
+/// Make the live watcher match `desired`, building it on first need.
+fn apply(desired: HashMap<PathBuf, String>) {
+    let mut guard = LIVE.lock().unwrap_or_else(|p| p.into_inner());
+    if guard.is_none() {
+        if desired.is_empty() || FAILED.load(std::sync::atomic::Ordering::Relaxed) {
+            return;
+        }
+        match build() {
+            Ok(live) => *guard = Some(live),
+            Err(err) => {
+                FAILED.store(true, std::sync::atomic::Ordering::Relaxed);
+                crate::diagnostics::error(
+                    "fswatch",
+                    format!("watcher failed to start; folder sweeps carry detection: {err:#}"),
+                );
+                return;
+            }
+        }
+    }
+    let live = guard.as_mut().expect("watcher built above");
+    let mut roots = live.roots.lock().unwrap_or_else(|p| p.into_inner());
+    let current: HashSet<PathBuf> = roots.keys().cloned().collect();
+    let wanted: HashSet<PathBuf> = desired.keys().cloned().collect();
+    for root in current.difference(&wanted) {
+        if let Err(err) = live.watcher.unwatch(root) {
+            crate::note!("fswatch: unwatch {}: {err}", root.display());
+        }
+        roots.remove(root);
+        crate::note!("fswatch: released {}", root.display());
+    }
+    let mut watched: HashSet<PathBuf> = current.intersection(&wanted).cloned().collect();
+    for root in wanted.difference(&current) {
+        match live.watcher.watch(root, RecursiveMode::Recursive) {
+            Ok(()) => {
+                crate::note!("fswatch: watching {}", root.display());
+                watched.insert(root.clone());
+                live.failed.remove(root);
+            }
+            // Recorded once per root: a root that stays unwatchable would
+            // otherwise re-log every tick, and the sweep covers it anyway.
+            Err(err) if live.failed.insert(root.clone()) => crate::diagnostics::error(
+                "fswatch",
+                format!("watch {}: {err}; the sweep covers it", root.display()),
+            ),
+            Err(_) => {}
+        }
+    }
+    // Routing follows the desired map even for roots already watched: a
+    // folder source moved between notebooks re-routes without a rewatch.
+    for (root, nb) in desired {
+        if watched.contains(&root) {
+            roots.insert(root, nb);
+        }
+    }
+}
+
+fn build() -> anyhow::Result<Live> {
+    let roots: Arc<Mutex<HashMap<PathBuf, String>>> = Arc::default();
+    let callback_roots = roots.clone();
+    let watcher = notify::recommended_watcher(move |result: notify::Result<notify::Event>| {
+        let Some(tx) = TX.get() else { return };
+        match result {
+            Ok(event) if is_content_change(&event.kind) => {
+                let roots = callback_roots.lock().unwrap_or_else(|p| p.into_inner());
+                // One send per notebook per raw event, not per path: the
+                // debouncer folds them anyway, but the channel need not
+                // carry a 400-file burst as 400 messages.
+                let mut hit: Vec<&str> = Vec::new();
+                for path in &event.paths {
+                    if let Some(nb) = notebook_for(&roots, path) {
+                        if !hit.contains(&nb) {
+                            hit.push(nb);
+                        }
+                    }
+                }
+                for nb in hit {
+                    let _ = tx.send(nb.to_string());
+                }
+            }
+            Ok(_) => {}
+            Err(err) => crate::note!("fswatch: {err}"),
+        }
+    })?;
+    Ok(Live {
+        watcher,
+        roots,
+        failed: HashSet::new(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn open(ids: &[&str]) -> HashSet<String> {
+        ids.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn tick_sweep_skips_closed_local_folders_until_due() {
+        let open = open(&["a"]);
+        let tick = Sweep::Tick {
+            open: &open,
+            closed_due: false,
+        };
+        assert!(
+            in_sweep("folder", "a", tick),
+            "open notebook walks every tick"
+        );
+        assert!(in_sweep("obsidian", "a", tick));
+        assert!(!in_sweep("folder", "b", tick), "closed notebook waits");
+        assert!(!in_sweep("obsidian", "b", tick));
+        assert!(in_sweep("git", "b", tick), "git keeps its own cadence");
+        assert!(
+            in_sweep("notion", "b", tick),
+            "notion keeps its own cadence"
+        );
+
+        let due = Sweep::Tick {
+            open: &open,
+            closed_due: true,
+        };
+        assert!(in_sweep("folder", "b", due), "the ten-minute window opens");
+        assert!(in_sweep("folder", "a", Sweep::All));
+        assert!(
+            in_sweep("folder", "b", Sweep::All),
+            "manual resync walks all"
+        );
+    }
+
+    #[test]
+    fn debounce_folds_a_burst_into_one_fire_after_quiet() {
+        let t0 = Instant::now();
+        let mut d = Debouncer::default();
+        for i in 0..400 {
+            d.touch("nb", t0 + Duration::from_millis(i * 3));
+        }
+        let last = t0 + Duration::from_millis(399 * 3);
+        assert_eq!(d.next_deadline(), Some(last + DEBOUNCE));
+        assert!(
+            d.due(last + Duration::from_secs(1)).is_empty(),
+            "still inside the window"
+        );
+        assert_eq!(d.due(last + DEBOUNCE), vec!["nb".to_string()]);
+        assert_eq!(d.next_deadline(), None, "nothing left pending");
+    }
+
+    #[test]
+    fn debounce_is_per_notebook_and_orders_fires() {
+        let t0 = Instant::now();
+        let mut d = Debouncer::default();
+        d.touch("b", t0);
+        d.touch("a", t0 + Duration::from_millis(500));
+        assert_eq!(
+            d.due(t0 + DEBOUNCE),
+            vec!["b".to_string()],
+            "a is still quiet-waiting"
+        );
+        assert_eq!(
+            d.due(t0 + Duration::from_millis(500) + DEBOUNCE),
+            vec!["a".to_string()]
+        );
+        d.touch("b", t0);
+        d.touch("a", t0);
+        assert_eq!(
+            d.due(t0 + DEBOUNCE),
+            vec!["a".to_string(), "b".to_string()],
+            "simultaneous fires are sorted"
+        );
+    }
+
+    #[test]
+    fn debounce_hold_ceiling_fires_a_folder_that_never_goes_quiet() {
+        let t0 = Instant::now();
+        let mut d = Debouncer::default();
+        let mut t = t0;
+        while t < t0 + MAX_HOLD + Duration::from_secs(5) {
+            d.touch("nb", t);
+            let fired = d.due(t);
+            if !fired.is_empty() {
+                assert!(t >= t0 + MAX_HOLD, "fired before the hold ceiling");
+                assert!(t < t0 + MAX_HOLD + Duration::from_secs(2));
+                return;
+            }
+            t += Duration::from_secs(1);
+        }
+        panic!("a continuously busy folder never fired");
+    }
+
+    #[test]
+    fn retouch_after_busy_reopens_the_window() {
+        let t0 = Instant::now();
+        let mut d = Debouncer::default();
+        d.touch("nb", t0);
+        assert_eq!(d.due(t0 + DEBOUNCE), vec!["nb".to_string()]);
+        // Resync reported busy: the loop touches again to retry.
+        d.touch("nb", t0 + DEBOUNCE);
+        assert!(d.due(t0 + DEBOUNCE + Duration::from_secs(1)).is_empty());
+        assert_eq!(d.due(t0 + DEBOUNCE * 2), vec!["nb".to_string()]);
+    }
+
+    #[test]
+    fn content_change_ignores_reads_and_metadata() {
+        use notify::event::{AccessKind, CreateKind, DataChange, MetadataKind, RemoveKind};
+        assert!(!is_content_change(&EventKind::Access(AccessKind::Read)));
+        assert!(!is_content_change(&EventKind::Modify(
+            ModifyKind::Metadata(MetadataKind::Any)
+        )));
+        assert!(is_content_change(&EventKind::Create(CreateKind::File)));
+        assert!(is_content_change(&EventKind::Modify(ModifyKind::Data(
+            DataChange::Content
+        ))));
+        assert!(is_content_change(&EventKind::Remove(RemoveKind::File)));
+        assert!(is_content_change(&EventKind::Any));
+    }
+
+    #[test]
+    fn scannable_mirrors_the_folder_walker() {
+        let root = Path::new("/v/vault");
+        assert!(is_scannable(root, Path::new("/v/vault/notes/a.md")));
+        assert!(
+            !is_scannable(root, Path::new("/v/vault/.obsidian/workspace.json")),
+            "dot dirs are invisible to the scanner"
+        );
+        assert!(!is_scannable(root, Path::new("/v/vault/.DS_Store")));
+        assert!(
+            is_scannable(root, Path::new("/v/vault/docs/.report.pdf.icloud")),
+            "iCloud stubs are the change"
+        );
+        assert!(!is_scannable(root, Path::new("/v/vault/.icloud")));
+        assert!(!is_scannable(
+            root,
+            Path::new("/v/vault/app/node_modules/x/index.js")
+        ));
+        assert!(!is_scannable(root, Path::new("/elsewhere/a.md")));
+    }
+
+    #[test]
+    fn notebook_routing_by_root() {
+        let mut roots = HashMap::new();
+        roots.insert(PathBuf::from("/a"), "nb-a".to_string());
+        roots.insert(PathBuf::from("/b/deep"), "nb-b".to_string());
+        assert_eq!(notebook_for(&roots, Path::new("/a/x.md")), Some("nb-a"));
+        assert_eq!(
+            notebook_for(&roots, Path::new("/b/deep/y/z.pdf")),
+            Some("nb-b")
+        );
+        assert_eq!(notebook_for(&roots, Path::new("/b/other.md")), None);
+        assert_eq!(notebook_for(&roots, Path::new("/a/.git/index")), None);
+    }
+}

--- a/src-tauri/src/gist.rs
+++ b/src-tauri/src/gist.rs
@@ -688,6 +688,7 @@ async fn enrich_source(
     // used (chunk_source, boilerplate filter and all) so re-chunking lines up
     // 1:1 with the rows — ordinal i of the fresh chunks is row i.
     let extracted = crate::ingest::Extracted {
+        feeds: Vec::new(),
         image_url: String::new(),
         author: String::new(),
         title: source.title.clone(),

--- a/src-tauri/src/hygiene.rs
+++ b/src-tauri/src/hygiene.rs
@@ -22,7 +22,7 @@ use serde::Serialize;
 use tauri::{AppHandle, Emitter, Manager};
 
 use crate::commands::{self, AppState};
-use crate::models::Source;
+use crate::models::{Source, SourceEvent};
 
 /// Consecutive background-probe failures before a url source stops being
 /// retried and is proposed for removal instead.
@@ -303,36 +303,51 @@ async fn refresh_stale_url(state: &AppState, src: &Source) -> anyhow::Result<boo
                     .await?;
                 Ok(false)
             } else if content_collapsed(&existing.content, &extracted.text) {
-                state
-                    .db
-                    .set_source_fetch(
-                        &src.id,
-                        effective_fetched_at(&existing),
-                        existing.fetch_failures + 1,
-                    )
-                    .await?;
-                anyhow::bail!(
+                let why = format!(
                     "page came back gutted ({} chars, was {}) — keeping the stored copy",
                     extracted.text.chars().count(),
                     existing.content.chars().count()
-                )
+                );
+                strike(state, &existing, &why).await?;
+                anyhow::bail!(why)
             } else {
                 commands::reingest(state, &existing, extracted, None, true).await?;
                 Ok(true)
             }
         }
         Err(err) => {
-            state
-                .db
-                .set_source_fetch(
-                    &src.id,
-                    effective_fetched_at(&existing),
-                    existing.fetch_failures + 1,
-                )
-                .await?;
+            strike(state, &existing, &format!("{err:#}")).await?;
             Err(err)
         }
     }
+}
+
+/// Count one failed probe on the row. The strike that reaches
+/// `UNREACHABLE_AFTER` also becomes an `unreachable` event
+/// (docs/RFC-events.md §1) — once, at the threshold, so a dead link is one
+/// arrival in the Brief rather than a row per retry for the rest of its life.
+async fn strike(state: &AppState, existing: &Source, why: &str) -> anyhow::Result<()> {
+    let failures = existing.fetch_failures + 1;
+    state
+        .db
+        .set_source_fetch(&existing.id, effective_fetched_at(existing), failures)
+        .await?;
+    if failures == UNREACHABLE_AFTER {
+        let _ = state
+            .db
+            .add_source_event(&SourceEvent {
+                id: commands::new_id(),
+                notebook_id: existing.notebook_id.clone(),
+                source_id: existing.id.clone(),
+                source_title: existing.title.clone(),
+                kind: "unreachable".into(),
+                detail: format!("{failures} refresh attempts failed"),
+                diff: why.chars().take(200).collect(),
+                at: commands::now(),
+            })
+            .await;
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src-tauri/src/hygiene.rs
+++ b/src-tauri/src/hygiene.rs
@@ -87,7 +87,7 @@ fn is_file_path(source: &Source) -> bool {
 fn is_folder_like(source: &Source) -> bool {
     matches!(
         source.source_type.as_str(),
-        "folder" | "obsidian" | "git" | "notion"
+        "folder" | "obsidian" | "git" | "notion" | "feed"
     )
 }
 

--- a/src-tauri/src/ingest.rs
+++ b/src-tauri/src/ingest.rs
@@ -31,6 +31,11 @@ pub struct Extracted {
     /// Lead image (og:image / twitter:image) for `url` sources; "" when the
     /// page has none. Powers the source gallery.
     pub image_url: String,
+    /// Feeds the page advertised (`<link rel="alternate" type="application/
+    /// rss+xml|atom+xml|feed+json">`), absolute — tier-1 discovery
+    /// (docs/RFC-events.md §2), free because the HTML was already in hand.
+    /// Empty for everything that is not a fetched or captured page.
+    pub feeds: Vec<String>,
 }
 
 /// Is this path an image we should OCR rather than read as text?
@@ -167,6 +172,7 @@ fn extract_file_inner(path: &str) -> Result<Extracted> {
             return Err(anyhow!("No readable text in {}", err_name(path)));
         }
         return Ok(Extracted {
+            feeds: Vec::new(),
             image_url: String::new(),
             author: String::new(),
             title: p
@@ -193,6 +199,7 @@ fn extract_file_inner(path: &str) -> Result<Extracted> {
             return Err(anyhow!("No readable text in {}", err_name(path)));
         }
         Ok(Extracted {
+            feeds: Vec::new(),
             image_url: String::new(),
             author: file_author(path),
             title: title.clone(),
@@ -284,6 +291,7 @@ fn extract_file_inner(path: &str) -> Result<Extracted> {
         return Err(anyhow!("No readable text in {}", err_name(path)));
     }
     Ok(Extracted {
+        feeds: Vec::new(),
         image_url: String::new(),
         // Stamped here — the one chokepoint every local-file ingest passes
         // through — so refresh and folder resync re-capture it for free.
@@ -738,6 +746,7 @@ pub async fn extract_url(raw_url: &str) -> Result<Extracted> {
                 ));
             }
             return Ok(Extracted {
+                feeds: Vec::new(),
                 author: String::new(),
                 // Anything beats the URL's last path segment, which on arXiv
                 // is a bare id ("2307.03172"): the /Title tag first, then the
@@ -758,6 +767,20 @@ pub async fn extract_url(raw_url: &str) -> Result<Extracted> {
     }
 
     let body = resp.text().await.unwrap_or_default();
+    // A feed is not a page: readability would shred it into a wall of
+    // titles. Hand the raw document up as a `feed` so the caller connects
+    // it as a living source (docs/RFC-events.md §2) — one GET, not two.
+    if crate::feeds::looks_like_feed(&content_type, &body) {
+        return Ok(Extracted {
+            feeds: Vec::new(),
+            author: String::new(),
+            title: String::new(),
+            source_type: "feed".to_string(),
+            url,
+            text: body,
+            image_url: String::new(),
+        });
+    }
     readable_page(body, status, url)
 }
 
@@ -853,6 +876,7 @@ fn readable_page(body: String, status: reqwest::StatusCode, url: String) -> Resu
     }
     let image_url = og_image(&body, &url).unwrap_or_default();
     Ok(Extracted {
+        feeds: crate::feeds::discover_in_html(&body, &url),
         author: String::new(),
         title,
         source_type: "url".to_string(),
@@ -1024,6 +1048,7 @@ async fn extract_google(
         return Err(anyhow!("this {} exported no text", kind.product()));
     }
     Ok(Extracted {
+        feeds: Vec::new(),
         image_url: String::new(),
         author: String::new(),
         title,
@@ -1107,6 +1132,28 @@ pub struct PageMeta {
     pub og_image: String,
 }
 
+/// An HTML fragment (a feed entry's body or summary) as markdown-ish plain
+/// text, through the same converter whole pages use. Falls back to a tag
+/// strip when the converter refuses the fragment.
+pub fn html_fragment_to_text(html: &str) -> String {
+    match htmd::convert(html) {
+        Ok(md) => normalize(&md),
+        Err(_) => {
+            let mut out = String::with_capacity(html.len());
+            let mut in_tag = false;
+            for c in html.chars() {
+                match c {
+                    '<' => in_tag = true,
+                    '>' => in_tag = false,
+                    _ if !in_tag => out.push(c),
+                    _ => {}
+                }
+            }
+            normalize(&out)
+        }
+    }
+}
+
 /// Build an `Extracted` from already-rendered HTML — the webview capture
 /// path (capture.rs). Same readability pipeline as fetched URLs and saved
 /// pages; the live DOM's `document.title` and OpenGraph title fill in when
@@ -1129,6 +1176,7 @@ pub fn extracted_from_html(html: &str, url: &str, dom_title: &str, meta: &PageMe
         .or_else(|| og_image(html, url))
         .unwrap_or_default();
     Extracted {
+        feeds: crate::feeds::discover_in_html(html, url),
         author: String::new(),
         title,
         source_type: "url".to_string(),
@@ -1223,6 +1271,7 @@ pub fn extract_pasted(title: &str, text: &str) -> Result<Extracted> {
         title.trim().to_string()
     };
     Ok(Extracted {
+        feeds: Vec::new(),
         image_url: String::new(),
         author: String::new(),
         title,
@@ -2305,6 +2354,7 @@ mod tests {
     #[test]
     fn chunk_source_dispatches_on_source_type() {
         let code = Extracted {
+            feeds: Vec::new(),
             image_url: String::new(),
             author: String::new(),
             title: "main.rs".into(),
@@ -2317,6 +2367,7 @@ mod tests {
         assert!(got[0].embed_text.starts_with("[main.rs]\n"));
 
         let prose = Extracted {
+            feeds: Vec::new(),
             image_url: String::new(),
             author: String::new(),
             title: "Notes".into(),
@@ -2485,6 +2536,7 @@ mod tests {
     #[test]
     fn markdown_chunking_strips_frontmatter_and_carries_tags() {
         let ex = Extracted {
+            feeds: Vec::new(),
             image_url: String::new(),
             author: String::new(),
             title: "Dialing In".into(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -41,6 +41,7 @@ mod outline_index;
 mod pdf;
 mod pptx;
 mod rag;
+mod robots;
 mod router;
 mod scheduler;
 mod secure_fs;
@@ -542,6 +543,8 @@ pub fn run() {
             commands::seed_scale_fixture,
             commands::growth_proposals,
             commands::discover_feeds,
+            commands::arrivals_seen_at,
+            commands::mark_arrivals_seen,
             commands::growth_web_search,
             commands::growth_local,
             commands::growth_retire,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ mod diagnostics;
 mod dockmenu;
 #[cfg(target_os = "macos")]
 mod dragout;
+mod events;
 mod examples;
 mod export;
 mod feeds;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ mod dockmenu;
 mod dragout;
 mod examples;
 mod export;
+mod feeds;
 mod filesearch;
 mod foreground;
 mod freshness;
@@ -525,6 +526,7 @@ pub fn run() {
             commands::cited_source_ids,
             commands::seed_scale_fixture,
             commands::growth_proposals,
+            commands::discover_feeds,
             commands::growth_web_search,
             commands::growth_local,
             commands::growth_retire,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ mod export;
 mod filesearch;
 mod foreground;
 mod freshness;
+mod fswatch;
 mod genqueue;
 mod gist;
 mod git;
@@ -146,6 +147,14 @@ pub fn run() {
             tauri::WindowEvent::Destroyed => {
                 if let Some(state) = window.app_handle().try_state::<commands::AppState>() {
                     state.glass_applied.lock().unwrap().remove(window.label());
+                    // Whatever notebook this window had open is no longer
+                    // open here; the next rearm drops its folders from the
+                    // FSEvents set (fswatch.rs).
+                    state
+                        .open_notebooks
+                        .lock()
+                        .unwrap_or_else(|p| p.into_inner())
+                        .remove(window.label());
                 }
             }
             // Refocusing Alchemy is the moment the accessibility text size can
@@ -293,8 +302,12 @@ pub fn run() {
                 cancel: std::sync::Mutex::new(std::collections::HashMap::new()),
                 folder_scan_lock: tokio::sync::Mutex::new(()),
                 glass_applied: std::sync::Mutex::new(std::collections::HashMap::new()),
+                open_notebooks: std::sync::Mutex::new(std::collections::HashMap::new()),
                 gen_queue: genqueue::GenQueue::load(&data_dir),
             });
+            // FSEvents for open notebooks' folders (docs/RFC-events.md §4);
+            // the watcher itself arms once a window reports a notebook.
+            fswatch::start(app.handle().clone());
             // The queue worker drains generations the webview only watches;
             // jobs interrupted by the last shutdown are already re-queued.
             genqueue::spawn_worker(app.handle().clone());
@@ -447,6 +460,7 @@ pub fn run() {
             commands::provider_readiness,
             commands::provider_readiness_one,
             commands::resync_sources,
+            commands::set_open_notebook,
             commands::add_source_url,
             commands::add_source_text,
             commands::update_source_text,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -32,6 +32,7 @@ mod inference;
 mod ingest;
 mod integrations;
 mod mac;
+mod macwatch;
 mod mcp;
 mod menu;
 mod models;
@@ -310,6 +311,10 @@ pub fn run() {
             // FSEvents for open notebooks' folders (docs/RFC-events.md §4);
             // the watcher itself arms once a window reports a notebook.
             fswatch::start(app.handle().clone());
+            // FSEvents over the Reminders, Calendar, and Notes stores through
+            // cider's watch (docs/RFC-events.md §4, phase 5); the minute
+            // sweep's Mac cadence stays underneath it.
+            macwatch::start(app.handle().clone());
             // The queue worker drains generations the webview only watches;
             // jobs interrupted by the last shutdown are already re-queued.
             genqueue::spawn_worker(app.handle().clone());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -314,7 +314,9 @@ pub fn run() {
             fswatch::start(app.handle().clone());
             // FSEvents over the Reminders, Calendar, and Notes stores through
             // cider's watch (docs/RFC-events.md §4, phase 5); the minute
-            // sweep's Mac cadence stays underneath it.
+            // sweep's Mac cadence stays underneath it. cider logs through
+            // the `log` facade; the bridge lands those lines in our log.
+            diagnostics::install_log_bridge();
             macwatch::start(app.handle().clone());
             // The queue worker drains generations the webview only watches;
             // jobs interrupted by the last shutdown are already re-queued.

--- a/src-tauri/src/mac.rs
+++ b/src-tauri/src/mac.rs
@@ -214,67 +214,14 @@ pub async fn fetch(uri: &str) -> anyhow::Result<(String, String)> {
             None,
         ))
         .await?;
-        let mut out = format!("# Calendar — next {days} days\n\n");
-        let mut last_day = String::new();
-        for e in data.as_array().unwrap_or(&vec![]) {
-            let start = e["start_date"].as_str().unwrap_or("");
-            let day = start.chars().take(10).collect::<String>();
-            if day != last_day && !day.is_empty() {
-                out.push_str(&format!("## {day}\n"));
-                last_day = day;
-            }
-            let time = if e["is_all_day"].as_bool() == Some(true) {
-                "all day".to_string()
-            } else {
-                start.chars().skip(11).take(5).collect()
-            };
-            out.push_str(&format!(
-                "- {} — {} ({})",
-                time,
-                e["title"].as_str().unwrap_or("Untitled"),
-                e["calendar"].as_str().unwrap_or("Calendar"),
-            ));
-            if let Some(loc) = e["location"].as_str() {
-                out.push_str(&format!(" at {loc}"));
-            }
-            out.push('\n');
-            if let Some(notes) = e["notes"].as_str() {
-                if !notes.trim().is_empty() {
-                    out.push_str(&format!("  - {}\n", notes.trim().replace('\n', " ")));
-                }
-            }
-        }
-        return Ok((format!("Calendar: next {days} days"), out));
+        return Ok((
+            format!("Calendar: next {days} days"),
+            render_calendar(days, &data),
+        ));
     }
     if let Some(list) = uri.strip_prefix("cider://reminders/list/") {
         let data = cider(cider_lib::reminders::list(Some(list))).await?;
-        let mut out = format!("# Reminders — {list}\n\n");
-        for r in data.as_array().unwrap_or(&vec![]) {
-            out.push_str(&format!(
-                "- [ ] {}",
-                r["title"].as_str().unwrap_or("Untitled")
-            ));
-            // Carry the id into the text: titles repeat (two identical bug
-            // reports is the case that prompted this), so it is the only way
-            // for a reader — or an agent — to name one reminder exactly when
-            // asking to complete it.
-            if let Some(id) = r["id"].as_str() {
-                out.push_str(&format!(" `{id}`"));
-            }
-            if let Some(due) = r["due_date"].as_str() {
-                out.push_str(&format!(
-                    " — due {}",
-                    due.chars().take(10).collect::<String>()
-                ));
-            }
-            out.push('\n');
-            if let Some(notes) = r["notes"].as_str() {
-                if !notes.trim().is_empty() {
-                    out.push_str(&format!("  - {}\n", notes.trim().replace('\n', " ")));
-                }
-            }
-        }
-        return Ok((format!("Reminders: {list}"), out));
+        return Ok((format!("Reminders: {list}"), render_reminders(list, &data)));
     }
     if let Some(id) = uri.strip_prefix("cider://notes/note/") {
         let n = cider(cider_lib::notes::get(id)).await?;
@@ -314,45 +261,10 @@ pub async fn fetch(uri: &str) -> anyhow::Result<(String, String)> {
             anyhow::bail!("Watchlist \"{list}\" not found in Apple Stocks (was it renamed?)");
         }
         let quotes = cider(cider_lib::stocks::fetch()).await?;
-        let mut out = format!("# Stocks — {list}\n\n");
-        let mut as_of = "";
-        let empty = vec![];
-        let rows = quotes.as_array().unwrap_or(&empty);
-        out.push_str("| Symbol | Name | Price | Change | Status |\n");
-        out.push_str("|---|---|---|---|---|\n");
-        for sym in &symbols {
-            let q = rows.iter().find(|q| q["symbol"].as_str() == Some(sym));
-            let (name, price, pct, status) = match q {
-                Some(q) => {
-                    if let Some(t) = q["as_of"].as_str() {
-                        if t > as_of {
-                            as_of = t;
-                        }
-                    }
-                    (
-                        q["name"].as_str().unwrap_or("").to_string(),
-                        q["price"]
-                            .as_f64()
-                            .map(|p| format!("{p:.2} {}", q["currency"].as_str().unwrap_or("")))
-                            .unwrap_or_default(),
-                        q["change_percent"]
-                            .as_f64()
-                            .map(|c| format!("{c:+.2}%"))
-                            .unwrap_or_default(),
-                        q["exchange_status"].as_str().unwrap_or("").to_string(),
-                    )
-                }
-                None => (String::new(), String::new(), String::new(), String::new()),
-            };
-            out.push_str(&format!(
-                "| {sym} | {name} | {price} | {pct} | {status} |\n"
-            ));
-        }
-        let as_of = as_of.to_string();
-        if !as_of.is_empty() {
-            out.push_str(&format!("\n_Prices as of {as_of} (Apple Stocks cache)._\n"));
-        }
-        return Ok((format!("Stocks: {list}"), out));
+        return Ok((
+            format!("Stocks: {list}"),
+            render_stocks(list, &symbols, &quotes),
+        ));
     }
     // Legacy folder-as-source origins keep syncing.
     if let Some(folder) = uri.strip_prefix("cider://notes/folder/") {
@@ -377,6 +289,129 @@ pub async fn fetch(uri: &str) -> anyhow::Result<(String, String)> {
         return Ok((format!("Notes: {folder}"), out));
     }
     anyhow::bail!("Unrecognized Mac source origin: {uri}")
+}
+
+// ---- Renderers -------------------------------------------------------------
+//
+// Pure functions from cider's JSON to the markdown a source stores. The shapes
+// are a contract, not a style: the chat's live answer cards
+// (src/lib/liveCards.ts, docs/RFC-events.md §7) parse this text back into
+// native tables, so every line is fixed-order and one item per line. The
+// tests below pin each shape; change one only together with its parser.
+
+/// `# Calendar — next N days`, a `## YYYY-MM-DD` heading per day, then one
+/// `- HH:MM — Title (Calendar)[ at Location]` per event (`all day` in the
+/// time slot for all-day events); notes ride as an indented `  - ` line.
+fn render_calendar(days: &str, data: &serde_json::Value) -> String {
+    let mut out = format!("# Calendar — next {days} days\n\n");
+    let mut last_day = String::new();
+    for e in data.as_array().unwrap_or(&vec![]) {
+        let start = e["start_date"].as_str().unwrap_or("");
+        let day = start.chars().take(10).collect::<String>();
+        if day != last_day && !day.is_empty() {
+            out.push_str(&format!("## {day}\n"));
+            last_day = day;
+        }
+        let time = if e["is_all_day"].as_bool() == Some(true) {
+            "all day".to_string()
+        } else {
+            start.chars().skip(11).take(5).collect()
+        };
+        out.push_str(&format!(
+            "- {} — {} ({})",
+            time,
+            e["title"].as_str().unwrap_or("Untitled"),
+            e["calendar"].as_str().unwrap_or("Calendar"),
+        ));
+        if let Some(loc) = e["location"].as_str() {
+            out.push_str(&format!(" at {loc}"));
+        }
+        out.push('\n');
+        if let Some(notes) = e["notes"].as_str() {
+            if !notes.trim().is_empty() {
+                out.push_str(&format!("  - {}\n", notes.trim().replace('\n', " ")));
+            }
+        }
+    }
+    out
+}
+
+/// `# Reminders — List`, then one `- [ ] Title \`id\`[ — due YYYY-MM-DD]`
+/// per open reminder; notes ride as an indented `  - ` line.
+fn render_reminders(list: &str, data: &serde_json::Value) -> String {
+    let mut out = format!("# Reminders — {list}\n\n");
+    for r in data.as_array().unwrap_or(&vec![]) {
+        out.push_str(&format!(
+            "- [ ] {}",
+            r["title"].as_str().unwrap_or("Untitled")
+        ));
+        // Carry the id into the text: titles repeat (two identical bug
+        // reports is the case that prompted this), so it is the only way
+        // for a reader — or an agent — to name one reminder exactly when
+        // asking to complete it.
+        if let Some(id) = r["id"].as_str() {
+            out.push_str(&format!(" `{id}`"));
+        }
+        if let Some(due) = r["due_date"].as_str() {
+            out.push_str(&format!(
+                " — due {}",
+                due.chars().take(10).collect::<String>()
+            ));
+        }
+        out.push('\n');
+        if let Some(notes) = r["notes"].as_str() {
+            if !notes.trim().is_empty() {
+                out.push_str(&format!("  - {}\n", notes.trim().replace('\n', " ")));
+            }
+        }
+    }
+    out
+}
+
+/// `# Stocks — List`, a five-column table `| Symbol | Name | Price | Change |
+/// Status |` in watchlist order (price as `123.45 USD`, change as `+1.23%`,
+/// blanks for symbols the quote cache lacks), then
+/// `_Prices as of <RFC 3339> (Apple Stocks cache)._` when any quote carried a
+/// time. Quotes are as fresh as the Stocks app/widget keeps them.
+fn render_stocks(list: &str, symbols: &[String], quotes: &serde_json::Value) -> String {
+    let mut out = format!("# Stocks — {list}\n\n");
+    let mut as_of = "";
+    let empty = vec![];
+    let rows = quotes.as_array().unwrap_or(&empty);
+    out.push_str("| Symbol | Name | Price | Change | Status |\n");
+    out.push_str("|---|---|---|---|---|\n");
+    for sym in symbols {
+        let q = rows.iter().find(|q| q["symbol"].as_str() == Some(sym));
+        let (name, price, pct, status) = match q {
+            Some(q) => {
+                if let Some(t) = q["as_of"].as_str() {
+                    if t > as_of {
+                        as_of = t;
+                    }
+                }
+                (
+                    q["name"].as_str().unwrap_or("").to_string(),
+                    q["price"]
+                        .as_f64()
+                        .map(|p| format!("{p:.2} {}", q["currency"].as_str().unwrap_or("")))
+                        .unwrap_or_default(),
+                    q["change_percent"]
+                        .as_f64()
+                        .map(|c| format!("{c:+.2}%"))
+                        .unwrap_or_default(),
+                    q["exchange_status"].as_str().unwrap_or("").to_string(),
+                )
+            }
+            None => (String::new(), String::new(), String::new(), String::new()),
+        };
+        out.push_str(&format!(
+            "| {sym} | {name} | {price} | {pct} | {status} |\n"
+        ));
+    }
+    if !as_of.is_empty() {
+        out.push_str(&format!("\n_Prices as of {as_of} (Apple Stocks cache)._\n"));
+    }
+    out
 }
 
 /// Is this origin a Mac item?
@@ -531,5 +566,64 @@ mod tests {
     async fn fetch_rejects_unrecognized_origin() {
         let err = fetch("cider://bogus/thing").await.unwrap_err();
         assert!(err.to_string().contains("Unrecognized Mac source origin"));
+    }
+
+    // The live-card contract (src/lib/liveCards.ts parses these): one item
+    // per line, fixed field order. A drift here is a card silently gone.
+    #[test]
+    fn calendar_renders_one_fixed_line_per_event() {
+        let data = serde_json::json!([
+            {"title": "Inspection", "calendar": "Home", "location": "12 Elm St",
+             "start_date": "2026-09-03T14:00:00", "is_all_day": false,
+             "notes": "bring the\nreport"},
+            {"title": "Labor Day", "calendar": "US Holidays",
+             "start_date": "2026-09-07T00:00:00", "is_all_day": true},
+        ]);
+        assert_eq!(
+            render_calendar("7", &data),
+            "# Calendar — next 7 days\n\n\
+             ## 2026-09-03\n\
+             - 14:00 — Inspection (Home) at 12 Elm St\n\
+             \x20 - bring the report\n\
+             ## 2026-09-07\n\
+             - all day — Labor Day (US Holidays)\n"
+        );
+    }
+
+    #[test]
+    fn reminders_render_title_id_and_due() {
+        let data = serde_json::json!([
+            {"id": "x-apple-reminder://A1", "title": "Call the insurer",
+             "list": "Home", "priority": 0, "due_date": "2026-09-04T16:00:00Z",
+             "notes": "policy 4471"},
+            {"id": "x-apple-reminder://B2", "title": "Buy stamps", "list": "Home",
+             "priority": 0},
+        ]);
+        assert_eq!(
+            render_reminders("Home", &data),
+            "# Reminders — Home\n\n\
+             - [ ] Call the insurer `x-apple-reminder://A1` — due 2026-09-04\n\
+             \x20 - policy 4471\n\
+             - [ ] Buy stamps `x-apple-reminder://B2`\n"
+        );
+    }
+
+    #[test]
+    fn stocks_render_a_five_column_table_and_as_of() {
+        let symbols = vec!["AAPL".to_string(), "ZZZZ".to_string()];
+        let quotes = serde_json::json!([
+            {"symbol": "AAPL", "name": "Apple Inc.", "price": 231.456,
+             "change_percent": -1.2345, "currency": "USD",
+             "exchange_status": "closed", "as_of": "2026-09-02T20:00:00Z"},
+        ]);
+        assert_eq!(
+            render_stocks("My Symbols", &symbols, &quotes),
+            "# Stocks — My Symbols\n\n\
+             | Symbol | Name | Price | Change | Status |\n\
+             |---|---|---|---|---|\n\
+             | AAPL | Apple Inc. | 231.46 USD | -1.23% | closed |\n\
+             | ZZZZ |  |  |  |  |\n\n\
+             _Prices as of 2026-09-02T20:00:00Z (Apple Stocks cache)._\n"
+        );
     }
 }

--- a/src-tauri/src/mac.rs
+++ b/src-tauri/src/mac.rs
@@ -105,7 +105,7 @@ pub fn open_privacy_settings() -> Result<(), String> {
 pub async fn mac_connect(provider: String) -> Result<(), String> {
     match provider.as_str() {
         "reminders" => cider(cider_lib::reminders::list(None)).await,
-        "calendar" => cider(cider_lib::calendar::list(Some(0), Some(1), None)).await,
+        "calendar" => cider(cider_lib::calendar::list(Some(0), Some(1), None, None)).await,
         "notes" => cider(cider_lib::notes::folders()).await,
         "stocks" => cider(cider_lib::stocks::watchlists()).await,
         other => return Err(format!("Unknown Mac provider: {other}")),
@@ -152,7 +152,7 @@ pub async fn list_mac_collections(provider: String) -> Result<Vec<MacCollection>
         // library fast; the picker searches and groups it by folder
         // client-side.
         "notes" => {
-            let data = cider(cider_lib::notes::list_brief(None))
+            let data = cider(cider_lib::notes::list_brief(None, None))
                 .await
                 .map_err(|e| format!("{e:#}"))?;
             Ok(data
@@ -212,6 +212,7 @@ pub async fn fetch(uri: &str) -> anyhow::Result<(String, String)> {
             Some(0),
             Some(days.parse().unwrap_or(7)),
             None,
+            None,
         ))
         .await?;
         return Ok((
@@ -268,7 +269,7 @@ pub async fn fetch(uri: &str) -> anyhow::Result<(String, String)> {
     }
     // Legacy folder-as-source origins keep syncing.
     if let Some(folder) = uri.strip_prefix("cider://notes/folder/") {
-        let data = cider(cider_lib::notes::list(Some(folder), None)).await?;
+        let data = cider(cider_lib::notes::list(Some(folder), None, None)).await?;
         let mut out = format!("# Apple Notes — {folder}\n\n");
         for n in data.as_array().unwrap_or(&vec![]) {
             out.push_str(&format!(
@@ -410,6 +411,231 @@ fn render_stocks(list: &str, symbols: &[String], quotes: &serde_json::Value) -> 
     }
     if !as_of.is_empty() {
         out.push_str(&format!("\n_Prices as of {as_of} (Apple Stocks cache)._\n"));
+    }
+    out
+}
+
+// ---- Item events -----------------------------------------------------------
+//
+// Phase 5 of docs/RFC-events.md: a Mac resync names *which item* changed,
+// not that "the list" did. The stored text already carries what a delta
+// needs — reminder ids and due dates, calendar days and times, one item per
+// line (the renderers above) — so the diff of the old and new renderings
+// *is* the delta: no high-water mark to persist, no second cider call, and
+// the same answer whether the change arrived through the store watch
+// (macwatch.rs), the minute sweep, or one of our own write-backs. cider 0.6's
+// `since` filters stay available for a pass that wants the store's own view.
+
+/// Item-level events between two renderings of one `cider://` source, as
+/// `(kind, detail)` pairs in the RFC §1 vocabulary (`completed`, `moved`,
+/// `added`, `removed`, `updated`). Empty for providers with no items to name
+/// — a note or a stocks table — where the generic `updated` diff is the
+/// right event, and empty when only sub-lines (reminder notes, event notes)
+/// changed, for the same reason.
+pub fn item_events(url: &str, old_text: &str, new_text: &str) -> Vec<(&'static str, String)> {
+    if url.starts_with("cider://reminders/list/") {
+        reminder_events(old_text, new_text)
+    } else if url.starts_with("cider://calendar/upcoming/") {
+        let today = chrono::Local::now().format("%Y-%m-%d").to_string();
+        calendar_events(old_text, new_text, &today)
+    } else {
+        Vec::new()
+    }
+}
+
+struct ReminderLine<'a> {
+    title: &'a str,
+    id: &'a str,
+    due: Option<&'a str>,
+}
+
+/// One `render_reminders` item line back into its parts; `None` for
+/// anything else (headings, the indented notes lines, a line with no id).
+fn parse_reminder_line(line: &str) -> Option<ReminderLine<'_>> {
+    let rest = line.strip_prefix("- [ ] ")?;
+    let (body, due) = match rest.rsplit_once(" \u{2014} due ") {
+        Some((body, due)) => (body, Some(due.trim())),
+        None => (rest, None),
+    };
+    let body = body.strip_suffix('`')?;
+    let (title, id) = body.rsplit_once(" `")?;
+    Some(ReminderLine { title, id, due })
+}
+
+/// cider lists open reminders only, so an id that vanished was completed
+/// (or deleted — the store does not say, and "done" is the common case).
+fn reminder_events(old: &str, new: &str) -> Vec<(&'static str, String)> {
+    let old_items: Vec<ReminderLine<'_>> = old.lines().filter_map(parse_reminder_line).collect();
+    let new_items: Vec<ReminderLine<'_>> = new.lines().filter_map(parse_reminder_line).collect();
+    let old_by_id: std::collections::HashMap<&str, &ReminderLine<'_>> =
+        old_items.iter().map(|r| (r.id, r)).collect();
+    let new_by_id: std::collections::HashMap<&str, &ReminderLine<'_>> =
+        new_items.iter().map(|r| (r.id, r)).collect();
+    let mut out = Vec::new();
+    for r in &old_items {
+        if !new_by_id.contains_key(r.id) {
+            out.push(("completed", format!("\u{2713} {}", r.title)));
+        }
+    }
+    for r in &new_items {
+        match old_by_id.get(r.id) {
+            None => out.push(("added", format!("new reminder \u{00b7} {}", r.title))),
+            Some(o) if o.due != r.due => out.push((
+                "moved",
+                format!(
+                    "{} \u{00b7} due {} \u{2192} {}",
+                    r.title,
+                    o.due.unwrap_or("no date"),
+                    r.due.unwrap_or("no date")
+                ),
+            )),
+            Some(o) if o.title != r.title => out.push((
+                "updated",
+                format!("renamed \u{00b7} {} \u{2192} {}", o.title, r.title),
+            )),
+            Some(_) => {}
+        }
+    }
+    out
+}
+
+struct CalendarLine<'a> {
+    /// `Title (Calendar)` — the location suffix is dropped so a venue change
+    /// reads as the same event.
+    key: &'a str,
+    day: &'a str,
+    time: &'a str,
+}
+
+/// Every `render_calendar` item line with the `## YYYY-MM-DD` it sits under.
+fn parse_calendar(text: &str) -> Vec<CalendarLine<'_>> {
+    let mut day = "";
+    let mut out = Vec::new();
+    for line in text.lines() {
+        if let Some(d) = line.strip_prefix("## ") {
+            day = d.trim();
+            continue;
+        }
+        // Note lines are indented (`  - `), so they miss this prefix.
+        let Some(rest) = line.strip_prefix("- ") else {
+            continue;
+        };
+        let Some((time, key)) = rest.split_once(" \u{2014} ") else {
+            continue;
+        };
+        if day.is_empty() {
+            continue;
+        }
+        let key = match key.rfind(") at ") {
+            Some(i) => &key[..=i],
+            None => key,
+        };
+        out.push(CalendarLine { key, day, time });
+    }
+    out
+}
+
+fn calendar_title(key: &str) -> &str {
+    key.rsplit_once(" (").map(|(t, _)| t).unwrap_or(key)
+}
+
+/// `Thu 2 PM`, `Thu Sep 3 2 PM` with the date, `Thu all day`; falls back
+/// to the raw fields when a line does not parse.
+fn when_label(day: &str, time: &str, with_date: bool) -> String {
+    let date = chrono::NaiveDate::parse_from_str(day, "%Y-%m-%d")
+        .map(|d| {
+            if with_date {
+                d.format("%a %b %-d").to_string()
+            } else {
+                d.format("%a").to_string()
+            }
+        })
+        .unwrap_or_else(|_| day.to_string());
+    let clock = match time.split_once(':') {
+        Some((h, m)) => match (h.parse::<u32>(), m.parse::<u32>()) {
+            (Ok(h), Ok(m)) if h < 24 && m < 60 => {
+                let (h12, half) = match h {
+                    0 => (12, "AM"),
+                    1..=11 => (h, "AM"),
+                    12 => (12, "PM"),
+                    _ => (h - 12, "PM"),
+                };
+                if m == 0 {
+                    format!("{h12} {half}")
+                } else {
+                    format!("{h12}:{m:02} {half}")
+                }
+            }
+            _ => time.to_string(),
+        },
+        None => time.to_string(),
+    };
+    format!("{date} {clock}")
+}
+
+/// A rolling window slides every fetch: days before `today` fell off the
+/// front and days past the old rendering's last event are new to the window,
+/// not new to the calendar. Both are dropped before matching, so a daily
+/// standup never reads as seven removals and seven arrivals. Within the
+/// overlap, exact `(title, day, time)` matches cancel; a leftover new line
+/// pairs with a leftover old line of the same title as `moved`, and what is
+/// still left is `added` or `removed`.
+fn calendar_events(old: &str, new: &str, today: &str) -> Vec<(&'static str, String)> {
+    let old_lines = parse_calendar(old);
+    let new_lines = parse_calendar(new);
+    let old_last_day = old_lines.iter().map(|l| l.day).max();
+    let mut old_left: Vec<&CalendarLine<'_>> =
+        old_lines.iter().filter(|l| l.day >= today).collect();
+    let mut new_left: Vec<&CalendarLine<'_>> = Vec::new();
+    for n in new_lines
+        .iter()
+        .filter(|l| old_last_day.is_none_or(|last| l.day <= last))
+    {
+        match old_left
+            .iter()
+            .position(|o| o.key == n.key && o.day == n.day && o.time == n.time)
+        {
+            Some(i) => {
+                old_left.remove(i);
+            }
+            None => new_left.push(n),
+        }
+    }
+    let mut out = Vec::new();
+    for n in new_left {
+        match old_left.iter().position(|o| o.key == n.key) {
+            Some(i) => {
+                let o = old_left.remove(i);
+                let with_date = o.day != n.day;
+                out.push((
+                    "moved",
+                    format!(
+                        "{} \u{00b7} {} \u{2192} {}",
+                        calendar_title(n.key),
+                        when_label(o.day, o.time, with_date),
+                        when_label(n.day, n.time, with_date)
+                    ),
+                ));
+            }
+            None => out.push((
+                "added",
+                format!(
+                    "new event \u{00b7} {} \u{00b7} {}",
+                    calendar_title(n.key),
+                    when_label(n.day, n.time, true)
+                ),
+            )),
+        }
+    }
+    for o in old_left {
+        out.push((
+            "removed",
+            format!(
+                "event gone \u{00b7} {} \u{00b7} {}",
+                calendar_title(o.key),
+                when_label(o.day, o.time, true)
+            ),
+        ));
     }
     out
 }
@@ -625,5 +851,173 @@ mod tests {
              | ZZZZ |  |  |  |  |\n\n\
              _Prices as of 2026-09-02T20:00:00Z (Apple Stocks cache)._\n"
         );
+    }
+
+    // ---- Item events (docs/RFC-events.md phase 5) ----
+
+    const REMINDERS_OLD: &str = "# Reminders — Home\n\n\
+        - [ ] Call the insurer `x-apple-reminder://A1` — due 2026-09-04\n\
+        \x20 - policy 4471\n\
+        - [ ] Buy stamps `x-apple-reminder://B2`\n\
+        - [ ] Fix the gate `x-apple-reminder://C3` — due 2026-09-10\n";
+
+    #[test]
+    fn completing_a_reminder_is_one_completed_event() {
+        let new = REMINDERS_OLD.replace(
+            "- [ ] Call the insurer `x-apple-reminder://A1` — due 2026-09-04\n\
+             \x20 - policy 4471\n",
+            "",
+        );
+        assert_eq!(
+            item_events("cider://reminders/list/Home", REMINDERS_OLD, &new),
+            vec![("completed", "✓ Call the insurer".to_string())]
+        );
+    }
+
+    #[test]
+    fn reminder_arrivals_moves_and_renames_are_named() {
+        let new = "# Reminders — Home\n\n\
+            - [ ] Call the insurer `x-apple-reminder://A1` — due 2026-09-06\n\
+            - [ ] Buy more stamps `x-apple-reminder://B2`\n\
+            - [ ] Fix the gate `x-apple-reminder://C3`\n\
+            - [ ] Renew the permit `x-apple-reminder://D4` — due 2026-09-30\n";
+        assert_eq!(
+            item_events("cider://reminders/list/Home", REMINDERS_OLD, new),
+            vec![
+                (
+                    "moved",
+                    "Call the insurer · due 2026-09-04 → 2026-09-06".to_string()
+                ),
+                (
+                    "updated",
+                    "renamed · Buy stamps → Buy more stamps".to_string()
+                ),
+                (
+                    "moved",
+                    "Fix the gate · due 2026-09-10 → no date".to_string()
+                ),
+                ("added", "new reminder · Renew the permit".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn reminder_note_edits_leave_the_generic_diff_to_speak() {
+        let new = REMINDERS_OLD.replace("policy 4471", "policy 4471, ask for Dana");
+        assert!(item_events("cider://reminders/list/Home", REMINDERS_OLD, &new).is_empty());
+        // Same text, same ids: nothing to say.
+        assert!(
+            item_events("cider://reminders/list/Home", REMINDERS_OLD, REMINDERS_OLD).is_empty()
+        );
+    }
+
+    const CALENDAR_OLD: &str = "# Calendar — next 7 days\n\n\
+        ## 2026-09-02\n\
+        - 09:00 — Standup (Work)\n\
+        - 14:00 — Inspection (Home) at 12 Elm St\n\
+        \x20 - bring the report\n\
+        ## 2026-09-03\n\
+        - 09:00 — Standup (Work)\n\
+        ## 2026-09-04\n\
+        - 09:00 — Standup (Work)\n\
+        - all day — Offsite (Work)\n";
+
+    #[test]
+    fn a_rescheduled_event_is_one_moved_event() {
+        let new = CALENDAR_OLD.replace(
+            "- 14:00 — Inspection (Home) at 12 Elm St\n\x20 - bring the report\n## 2026-09-03\n",
+            "## 2026-09-03\n- 10:00 — Inspection (Home) at 12 Elm St\n\x20 - bring the report\n",
+        );
+        assert_eq!(
+            calendar_events(CALENDAR_OLD, &new, "2026-09-02"),
+            vec![(
+                "moved",
+                "Inspection · Wed Sep 2 2 PM → Thu Sep 3 10 AM".to_string()
+            )]
+        );
+        // Same day, later: weekday only.
+        let later = CALENDAR_OLD.replace("- 14:00 — Inspection", "- 15:30 — Inspection");
+        assert_eq!(
+            calendar_events(CALENDAR_OLD, &later, "2026-09-02"),
+            vec![("moved", "Inspection · Wed 2 PM → Wed 3:30 PM".to_string())]
+        );
+    }
+
+    #[test]
+    fn calendar_arrivals_and_departures_inside_the_window() {
+        let new = CALENDAR_OLD
+            .replace("- all day — Offsite (Work)\n", "")
+            .replace(
+                "## 2026-09-03\n",
+                "## 2026-09-03\n- 12:00 — Lunch with Sam (Personal)\n",
+            );
+        assert_eq!(
+            calendar_events(CALENDAR_OLD, &new, "2026-09-02"),
+            vec![
+                (
+                    "added",
+                    "new event · Lunch with Sam · Thu Sep 3 12 PM".to_string()
+                ),
+                (
+                    "removed",
+                    "event gone · Offsite · Fri Sep 4 all day".to_string()
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_sliding_window_and_a_venue_change_are_not_events() {
+        // Two days on: the front two days fell off, two new days rolled in,
+        // and the daily standup is still the daily standup.
+        let slid = "# Calendar — next 7 days\n\n\
+            ## 2026-09-04\n\
+            - 09:00 — Standup (Work)\n\
+            - all day — Offsite (Work)\n\
+            ## 2026-09-05\n\
+            - 09:00 — Standup (Work)\n\
+            ## 2026-09-06\n\
+            - 09:00 — Standup (Work)\n";
+        assert!(calendar_events(CALENDAR_OLD, slid, "2026-09-04").is_empty());
+        let moved_venue = CALENDAR_OLD.replace("at 12 Elm St", "at 14 Elm St");
+        assert!(calendar_events(CALENDAR_OLD, &moved_venue, "2026-09-02").is_empty());
+        // An empty old rendering (a calendar with nothing in range) makes
+        // every new line an arrival.
+        assert_eq!(
+            calendar_events(
+                "# Calendar — next 7 days\n\n",
+                "## 2026-09-03\n- 09:00 — Dentist (Personal)\n",
+                "2026-09-02"
+            ),
+            vec![("added", "new event · Dentist · Thu Sep 3 9 AM".to_string())]
+        );
+    }
+
+    #[test]
+    fn notes_and_stocks_have_no_item_events() {
+        assert!(item_events(
+            "cider://notes/note/x-coredata://A/ICNote/p1",
+            "# A\n\nold",
+            "# A\n\nnew"
+        )
+        .is_empty());
+        assert!(item_events(
+            "cider://stocks/watchlist/My Symbols",
+            "| AAPL | 1 |",
+            "| AAPL | 2 |"
+        )
+        .is_empty());
+    }
+
+    #[test]
+    fn clock_labels_read_like_a_person_wrote_them() {
+        assert_eq!(when_label("2026-09-03", "00:00", false), "Thu 12 AM");
+        assert_eq!(when_label("2026-09-03", "12:00", false), "Thu 12 PM");
+        assert_eq!(
+            when_label("2026-09-03", "23:45", true),
+            "Thu Sep 3 11:45 PM"
+        );
+        assert_eq!(when_label("2026-09-03", "all day", false), "Thu all day");
+        assert_eq!(when_label("someday", "soon", false), "someday soon");
     }
 }

--- a/src-tauri/src/macwatch.rs
+++ b/src-tauri/src/macwatch.rs
@@ -1,0 +1,154 @@
+//! Resident watch over the Apple stores behind Mac sources
+//! (docs/RFC-events.md §4, phase 5).
+//!
+//! cider 0.6's `watch` registers FSEvents on the directories Reminders,
+//! Calendar, and Notes write to and folds each burst into one event per
+//! store. This module runs one such watch for the life of the app and, on
+//! an event, re-fetches every Mac source of that provider across notebooks
+//! (`commands::resync_mac_provider`): one cider read and a hash compare per
+//! source, a reingest only where the rendering changed, item-level events
+//! (`mac::item_events`) where it did. Idle cost is the kernel's, which is
+//! zero; the fifteen-minute Mac cadence in the minute sweep stays as belt
+//! to these braces.
+//!
+//! FSEvents only (`watch`, never `watch_via`): cider's CLI-bridge branch and
+//! its missing-store path print with `eprintln!`, which panics on a closed
+//! stderr and has aborted this app before (diagnostics.rs). The stores are
+//! filtered for presence here so the library never reaches that line, and
+//! the watch is skipped outright when stderr is already gone. The upstream
+//! fix — a quiet library path — is a cider follow-up.
+//!
+//! Best-effort throughout: a watch that cannot start is recorded once and
+//! the sweep carries detection alone. Nothing here may take the app down.
+
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use cider::sources::watch::{self, WatchSource};
+use tauri::{AppHandle, Manager};
+use tokio::sync::mpsc;
+
+use crate::commands::{self, AppState};
+use crate::fswatch::Debouncer;
+
+/// The stores whose contents become sources (mac.rs). Contacts, Home, and
+/// Shortcuts are not sources, so they are not watched.
+const SOURCES: [WatchSource; 3] = [
+    WatchSource::Reminders,
+    WatchSource::Calendar,
+    WatchSource::Notes,
+];
+
+/// cider's own window: raw file events inside it fold into one event per
+/// store.
+const STORE_DEBOUNCE: Duration = Duration::from_secs(2);
+
+/// The watched stores that exist under `home`. `watch` prints a stderr note
+/// for each missing one, and a store that is not there — no Full Disk
+/// Access, an app never opened — has nothing to watch anyway.
+pub fn present_sources(home: &Path) -> Vec<WatchSource> {
+    SOURCES
+        .into_iter()
+        .filter(|s| watch::store_paths(s, home).iter().all(|p| p.is_dir()))
+        .collect()
+}
+
+fn names(sources: &[WatchSource]) -> String {
+    sources
+        .iter()
+        .map(|s| s.name())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Spawn the watch and its resync loop. Called once from setup.
+pub fn start(app: AppHandle) {
+    let Some(home) = std::env::var_os("HOME").map(PathBuf::from) else {
+        crate::note!("macwatch: HOME unset; the minute sweep carries Mac sources");
+        return;
+    };
+    let sources = present_sources(&home);
+    if sources.is_empty() {
+        crate::note!("macwatch: no Apple stores readable; the minute sweep carries Mac sources");
+        return;
+    }
+    // This line is the log entry and the probe in one: cider announces the
+    // watch with `eprintln!`, so a stderr that refuses this write would
+    // panic the watch task on its first line.
+    if writeln!(std::io::stderr(), "macwatch: watching {}", names(&sources)).is_err() {
+        return;
+    }
+    let (tx, rx) = mpsc::unbounded_channel::<&'static str>();
+    tauri::async_runtime::spawn(run(app, rx));
+    tauri::async_runtime::spawn(async move {
+        let result = watch::watch(&sources, STORE_DEBOUNCE, move |event| {
+            // A closed receiver means the loop is gone; nothing to do.
+            let _ = tx.send(event.source.name());
+        })
+        .await;
+        match result {
+            Ok(()) => crate::note!("macwatch: watch ended; the minute sweep carries Mac sources"),
+            Err(err) => crate::diagnostics::error(
+                "macwatch",
+                format!("watch failed; the minute sweep carries Mac sources: {err:#}"),
+            ),
+        }
+    });
+}
+
+/// The resync loop: providers arrive from the watch, sit out a quiet period
+/// (the app syncing a list over iCloud writes its store several times a few
+/// seconds apart, and one re-fetch is enough), then re-fetch. Same trailing
+/// window and hold ceiling as the folder watcher.
+async fn run(app: AppHandle, mut rx: mpsc::UnboundedReceiver<&'static str>) {
+    let mut deb = Debouncer::default();
+    loop {
+        let deadline = deb
+            .next_deadline()
+            .unwrap_or_else(|| Instant::now() + Duration::from_secs(24 * 3600));
+        tokio::select! {
+            ev = rx.recv() => match ev {
+                Some(provider) => deb.touch(provider, Instant::now()),
+                None => return,
+            },
+            _ = tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)) => {}
+        }
+        for provider in deb.due(Instant::now()) {
+            let state = app.state::<AppState>();
+            match commands::resync_mac_provider(&app, &state, &provider).await {
+                Ok(scan) if scan.changed() => crate::note!(
+                    "macwatch: {provider}: ~{} ({} failed)",
+                    scan.updated,
+                    scan.failed
+                ),
+                Ok(_) => {}
+                Err(err) => {
+                    crate::diagnostics::error("macwatch", format!("{provider}: resync: {err}"))
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_stores_that_exist_are_watched() {
+        let home = tempfile::tempdir().unwrap();
+        assert!(present_sources(home.path()).is_empty());
+        for path in watch::store_paths(&WatchSource::Reminders, home.path()) {
+            std::fs::create_dir_all(path).unwrap();
+        }
+        assert_eq!(present_sources(home.path()), vec![WatchSource::Reminders]);
+        // A store that is a file, not a directory, is not a store.
+        for path in watch::store_paths(&WatchSource::Notes, home.path()) {
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(path, b"").unwrap();
+        }
+        assert_eq!(present_sources(home.path()), vec![WatchSource::Reminders]);
+        assert_eq!(names(&present_sources(home.path())), "reminders");
+    }
+}

--- a/src-tauri/src/macwatch.rs
+++ b/src-tauri/src/macwatch.rs
@@ -11,21 +11,21 @@
 //! zero; the fifteen-minute Mac cadence in the minute sweep stays as belt
 //! to these braces.
 //!
-//! FSEvents only (`watch`, never `watch_via`): cider's CLI-bridge branch and
-//! its missing-store path print with `eprintln!`, which panics on a closed
-//! stderr and has aborted this app before (diagnostics.rs). The stores are
-//! filtered for presence here so the library never reaches that line, and
-//! the watch is skipped outright when stderr is already gone. The upstream
-//! fix — a quiet library path — is a cider follow-up.
+//! `watch_via(Via::Auto)`: when Paul's `cider-bridge` CLI is installed the
+//! Reminders and Calendar stores stream EventKit's own change notifications
+//! (item-level, framework-debounced); everything else rides FSEvents. cider
+//! 0.6.2 made its library paths quiet — they log through the `log` facade,
+//! which diagnostics.rs routes into the app log — so nothing here can hit a
+//! closed stderr. Stores are still filtered for presence: a store that is
+//! not there has nothing to watch, and would only log a warning.
 //!
 //! Best-effort throughout: a watch that cannot start is recorded once and
 //! the sweep carries detection alone. Nothing here may take the app down.
 
-use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
-use cider::sources::watch::{self, WatchSource};
+use cider::sources::watch::{self, Via, WatchSource};
 use tauri::{AppHandle, Manager};
 use tokio::sync::mpsc;
 
@@ -73,20 +73,34 @@ pub fn start(app: AppHandle) {
         crate::note!("macwatch: no Apple stores readable; the minute sweep carries Mac sources");
         return;
     }
-    // This line is the log entry and the probe in one: cider announces the
-    // watch with `eprintln!`, so a stderr that refuses this write would
-    // panic the watch task on its first line.
-    if writeln!(std::io::stderr(), "macwatch: watching {}", names(&sources)).is_err() {
-        return;
-    }
+    crate::note!("macwatch: watching {}", names(&sources));
     let (tx, rx) = mpsc::unbounded_channel::<&'static str>();
     tauri::async_runtime::spawn(run(app, rx));
     tauri::async_runtime::spawn(async move {
-        let result = watch::watch(&sources, STORE_DEBOUNCE, move |event| {
-            // A closed receiver means the loop is gone; nothing to do.
-            let _ = tx.send(event.source.name());
-        })
-        .await;
+        // A closed receiver means the loop is gone; nothing to do.
+        let forward = |tx: mpsc::UnboundedSender<&'static str>| {
+            move |event: watch::WatchEvent| {
+                let _ = tx.send(event.source.name());
+            }
+        };
+        let result = match watch::watch_via(
+            &sources,
+            STORE_DEBOUNCE,
+            Via::Auto,
+            forward(tx.clone()),
+        )
+        .await
+        {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                // The bridge CLI can be installed yet unable to stream:
+                // EventKit access is granted per launching app, and a
+                // denial fails cider's joined watch, FSEvents half
+                // included. Files need no permission, so watch those.
+                crate::note!("macwatch: bridge watch failed ({err:#}); falling back to FSEvents");
+                watch::watch_via(&sources, STORE_DEBOUNCE, Via::Fsevents, forward(tx)).await
+            }
+        };
         match result {
             Ok(()) => crate::note!("macwatch: watch ended; the minute sweep carries Mac sources"),
             Err(err) => crate::diagnostics::error(

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -217,14 +217,22 @@ async fn start_server(
     // plus margin.
     let mut sessions = LocalSessionManager::default();
     sessions.session_config.keep_alive = Some(std::time::Duration::from_secs(30 * 60));
+    let handle = app.clone();
     let service = StreamableHttpService::new(
         move || Ok(AlchemyMcp::new(app.clone())),
         sessions.into(),
         StreamableHttpServerConfig::default(),
     );
-    let router = axum::Router::new().nest_service("/mcp", service).layer(
-        axum::middleware::from_fn_with_state(token, authorize_request),
-    );
+    // /events (docs/RFC-events.md §8) sits beside /mcp under the same
+    // bearer + no-Origin gate: a browser page can never open the stream.
+    let router = axum::Router::new()
+        .route("/events", axum::routing::get(crate::events::sse))
+        .with_state(handle)
+        .nest_service("/mcp", service)
+        .layer(axum::middleware::from_fn_with_state(
+            token,
+            authorize_request,
+        ));
 
     let ct = shutdown.clone();
     tauri::async_runtime::spawn(async move {
@@ -253,6 +261,7 @@ fn write_port_file(app: &AppHandle, port: u16, token: &str) -> anyhow::Result<()
     let info = serde_json::json!({
         "port": port,
         "url": format!("http://127.0.0.1:{port}/mcp"),
+        "events_url": format!("http://127.0.0.1:{port}/events"),
         "pid": std::process::id(),
         "token": token,
     });

--- a/src-tauri/src/mcp/sources.rs
+++ b/src-tauri/src/mcp/sources.rs
@@ -228,6 +228,12 @@ struct ActivityReq {
 }
 
 #[derive(serde::Deserialize, schemars::JsonSchema)]
+struct DiscoverFeedsReq {
+    /// The source (a web page) to find feeds for — from list_sources.
+    source_id: String,
+}
+
+#[derive(serde::Deserialize, schemars::JsonSchema)]
 struct ReceiptsReq {
     /// Look-back window in hours (default 168, one week; capped to the
     /// 30-day window the table keeps).
@@ -278,6 +284,24 @@ impl AlchemyMcp {
     }
 
     #[tool(
+        description = "Feeds the app can follow for a web source: what its page advertised (<link rel=alternate>), what its host's shape implies (GitHub releases/commits, Wikipedia page history, YouTube channel, Substack, Reddit, Medium; arXiv offers a query feed built from the notebook's open questions, never a whole category), and — only when those are empty — the conventional /feed, /rss.xml, /atom.xml paths on its origin. Each candidate has url, label, and tier (page | host | well-known). Nothing is followed: pass a candidate's url to add_source to follow it as a living feed source (entries arrive as children, and change-triggered reports can watch the parent's id with watch_kinds [\"added\"])."
+    )]
+    async fn discover_feeds(
+        &self,
+        Parameters(DiscoverFeedsReq { source_id }): Parameters<DiscoverFeedsReq>,
+    ) -> Result<CallToolResult, McpError> {
+        let state = self.state();
+        let source = state
+            .db
+            .get_source(&source_id)
+            .await
+            .map_err(|e| invalid(format!("{e:#}")))?
+            .ok_or_else(|| invalid("Source not found"))?;
+        let found = crate::feeds::discover_for_source(&state, &source).await;
+        json_result(&found)
+    }
+
+    #[tool(
         description = "What the Night Shift actually did: one receipt per run (scheduled reports, standing questions, and housekeeping chores), newest first. Each has name, kind, trigger, status (\"ok\" or \"failed\"), the note it wrote, the provider and model that answered, cost in millionths of a dollar (0 when nothing was metered — local runs are free), and start/end timestamps. Pass schedule_id for one standing order's history. Receipts are a rolling 30-day record; the durable artifacts are the notes themselves."
     )]
     async fn list_receipts(
@@ -317,7 +341,7 @@ impl AlchemyMcp {
     }
 
     #[tool(
-        description = "Add a source to a notebook. Provide exactly one of: url (fetched + article-extracted), urls (a batch of such URLs — one result per entry, see below), text (pasted content; give a title), or file_path (local pdf/md/txt/csv, the whole Office family incl. legacy doc/ppt/xls, OpenDocument, rtf, epub, or an image — images and scanned PDFs are OCR'd when a vision model is configured; office formats extract as markdown). url also accepts a cider:// origin to connect a Mac item as a living, auto-syncing source: cider://reminders/list/<list name>, cider://calendar/upcoming/<days>, cider://notes/note/<note id>, or cider://stocks/watchlist/<name>. Content is chunked and embedded automatically. Duplicate content or an already-added URL is rejected with an error naming the existing source — treat that as already done. A page that fetches but is a 404/error page or a bot wall lands with status \"error\" and a reason — check status before trusting a result. With urls, the response is a list of {url, ok, source, error}: ok is false for anything that isn't searchable content, and one bad URL never fails the rest. Examples: {\"notebook_id\":\"<id>\",\"url\":\"https://example.com/paper\"} · {\"notebook_id\":\"<id>\",\"urls\":[\"https://a.com/x\",\"https://b.org/y\"]} · {\"notebook_id\":\"<id>\",\"text\":\"pasted content…\",\"title\":\"Meeting notes\"} · {\"notebook_id\":\"<id>\",\"file_path\":\"/Users/me/Reports/q3.docx\"}"
+        description = "Add a source to a notebook. A feed URL (RSS, Atom, JSON Feed — e.g. a GitHub releases.atom or a blog's /feed) becomes a living feed source: a parent that polls on the feed's own cadence, with each entry a child source. Provide exactly one of: url (fetched + article-extracted), urls (a batch of such URLs — one result per entry, see below), text (pasted content; give a title), or file_path (local pdf/md/txt/csv, the whole Office family incl. legacy doc/ppt/xls, OpenDocument, rtf, epub, or an image — images and scanned PDFs are OCR'd when a vision model is configured; office formats extract as markdown). url also accepts a cider:// origin to connect a Mac item as a living, auto-syncing source: cider://reminders/list/<list name>, cider://calendar/upcoming/<days>, cider://notes/note/<note id>, or cider://stocks/watchlist/<name>. Content is chunked and embedded automatically. Duplicate content or an already-added URL is rejected with an error naming the existing source — treat that as already done. A page that fetches but is a 404/error page or a bot wall lands with status \"error\" and a reason — check status before trusting a result. With urls, the response is a list of {url, ok, source, error}: ok is false for anything that isn't searchable content, and one bad URL never fails the rest. Examples: {\"notebook_id\":\"<id>\",\"url\":\"https://example.com/paper\"} · {\"notebook_id\":\"<id>\",\"urls\":[\"https://a.com/x\",\"https://b.org/y\"]} · {\"notebook_id\":\"<id>\",\"text\":\"pasted content…\",\"title\":\"Meeting notes\"} · {\"notebook_id\":\"<id>\",\"file_path\":\"/Users/me/Reports/q3.docx\"}"
     )]
     async fn add_source(
         &self,

--- a/src-tauri/src/mcp/sources.rs
+++ b/src-tauri/src/mcp/sources.rs
@@ -207,9 +207,24 @@ struct SetImageReq {
 #[derive(serde::Deserialize, schemars::JsonSchema)]
 struct ActivityReq {
     /// Look-back window in hours (default 24, capped to the 30-day event
-    /// window the table keeps).
+    /// window the table keeps). Ignored when `since` is given.
     #[serde(default)]
     hours: Option<u32>,
+    /// Exact cursor: only events with a millisecond timestamp after this.
+    /// Pass the newest `at` you have seen to read just the delta.
+    #[serde(default)]
+    since: Option<i64>,
+    /// Only events in this notebook.
+    #[serde(default)]
+    notebook_id: Option<String>,
+    /// Only these event kinds ("added", "updated", "removed", "unreachable",
+    /// "completed", "moved").
+    #[serde(default)]
+    kinds: Option<Vec<String>>,
+    /// Only events on these source ids (a folder or feed parent's id covers
+    /// what arrived under it).
+    #[serde(default)]
+    source_ids: Option<Vec<String>>,
 }
 
 #[derive(serde::Deserialize, schemars::JsonSchema)]
@@ -228,20 +243,37 @@ impl AlchemyMcp {
     // -- Sources --
 
     #[tool(
-        description = "Recent source-change events across ALL notebooks (what the resident scheduler's resyncs observed): each event has notebook_id, source_id, source_title, kind, a short detail, and a millisecond timestamp, newest first. The same signal the Morning Brief's \"what changed\" reads. Default window 24 hours."
+        description = "Recent source-change events across ALL notebooks (what the resident scheduler's resyncs and sweeps observed): each event has notebook_id, source_id, source_title, kind (added, updated, removed, unreachable, completed, moved), a short detail, a capped diff or title list, and a millisecond timestamp `at`, newest first. The same signal the Morning Brief's \"what changed\" and change-triggered reports read. Default window 24 hours; to poll for deltas pass `since` = the newest `at` you have seen, and narrow with notebook_id, kinds, or source_ids."
     )]
     async fn list_source_events(
         &self,
-        Parameters(ActivityReq { hours }): Parameters<ActivityReq>,
+        Parameters(ActivityReq {
+            hours,
+            since,
+            notebook_id,
+            kinds,
+            source_ids,
+        }): Parameters<ActivityReq>,
     ) -> Result<CallToolResult, McpError> {
-        let hours = i64::from(hours.unwrap_or(24));
-        let since = commands::now() - hours * 60 * 60 * 1000;
-        let events = self
+        let since = since.unwrap_or_else(|| {
+            let hours = i64::from(hours.unwrap_or(24));
+            commands::now() - hours * 60 * 60 * 1000
+        });
+        let mut events = self
             .state()
             .db
             .source_events_since(since)
             .await
             .map_err(|e| invalid(format!("{e:#}")))?;
+        if let Some(nb) = notebook_id.filter(|s| !s.is_empty()) {
+            events.retain(|e| e.notebook_id == nb);
+        }
+        if let Some(kinds) = kinds.filter(|k| !k.is_empty()) {
+            events.retain(|e| kinds.contains(&e.kind));
+        }
+        if let Some(ids) = source_ids.filter(|s| !s.is_empty()) {
+            events.retain(|e| ids.contains(&e.source_id));
+        }
         json_result(&events)
     }
 

--- a/src-tauri/src/mcp/studio.rs
+++ b/src-tauri/src/mcp/studio.rs
@@ -76,6 +76,16 @@ struct ScheduleReportReq {
     /// interval as the minimum time between runs).
     #[serde(default)]
     trigger: Option<String>,
+    /// With trigger "change": only changes to these source ids pull the
+    /// trigger (ids from list_sources; a folder or feed parent covers its
+    /// children). Omit for any source in the notebook.
+    #[serde(default)]
+    watch_sources: Option<Vec<String>>,
+    /// With trigger "change": only these event kinds pull the trigger —
+    /// "added", "updated", "removed", "unreachable", "completed", "moved".
+    /// Omit for any kind.
+    #[serde(default)]
+    watch_kinds: Option<Vec<String>>,
 }
 
 #[derive(serde::Deserialize, schemars::JsonSchema)]
@@ -238,7 +248,7 @@ impl AlchemyMcp {
     }
 
     #[tool(
-        description = "Schedule a recurring report in a notebook: any generator kind, one of the user's templates (by template:<id> or name), \"custom\" with a prompt, or \"brief\" — the cross-notebook morning brief (reads across ALL notebooks, ranked needs-you → changed → record; schedule it in the \"Briefs\" notebook). Interval is hourly, daily, or weekly. Each run refreshes URL sources first, then writes a timestamped note the user sees in Studio → Reports."
+        description = "Schedule a recurring report in a notebook: any generator kind, one of the user's templates (by template:<id> or name), \"custom\" with a prompt, or \"brief\" — the cross-notebook morning brief (reads across ALL notebooks, ranked needs-you → changed → record; schedule it in the \"Briefs\" notebook). Interval is hourly, daily, or weekly. Each run refreshes URL sources first, then writes a timestamped note the user sees in Studio → Reports. A trigger of \"change\" makes it a standing question that runs when sources change (interval = minimum gap); narrow it with watch_sources and watch_kinds, e.g. watch_kinds [\"added\"] on a feed's id to run only when a new entry arrives."
     )]
     async fn schedule_report(
         &self,
@@ -249,9 +259,15 @@ impl AlchemyMcp {
             interval,
             prompt,
             trigger,
+            watch_sources,
+            watch_kinds,
         }): Parameters<ScheduleReportReq>,
     ) -> Result<CallToolResult, McpError> {
         let prompt = prompt.unwrap_or_default();
+        let (watch_sources, watch_kinds) = commands::reports::resolve_watch(
+            watch_sources.map(|v| v.join(" ")),
+            watch_kinds.map(|v| v.join(" ")),
+        );
         let trigger = match trigger.as_deref() {
             Some("change") => "change".to_string(),
             _ => "interval".to_string(),
@@ -284,6 +300,8 @@ impl AlchemyMcp {
             not_before: 0,
             interval_secs,
             enabled: true,
+            watch_sources,
+            watch_kinds,
             last_run_at: 0,
             created_at: commands::now(),
         };

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -291,7 +291,7 @@ pub struct SourceEvent {
     pub notebook_id: String,
     pub source_id: String,
     pub source_title: String,
-    /// "updated" (more kinds as watcher classes land).
+    /// One of `EVENT_KINDS` (docs/RFC-events.md §1).
     pub kind: String,
     /// Short human line ("page re-fetched · +12 −3 lines", …).
     #[serde(default)]
@@ -302,6 +302,38 @@ pub struct SourceEvent {
     #[serde(default)]
     pub diff: String,
     pub at: i64,
+}
+
+/// Every `SourceEvent.kind` a producer may write (docs/RFC-events.md §1).
+/// `updated` is a re-fetch or re-read of something already held; `added`
+/// and `removed` come from reconcilers (folder scans, git pulls, feed
+/// polls); `unreachable` is the hygiene strike that crosses the threshold;
+/// `completed` and `moved` are Mac item states (Reminders, Calendar).
+pub const EVENT_KINDS: [&str; 6] = [
+    "updated",
+    "added",
+    "removed",
+    "unreachable",
+    "completed",
+    "moved",
+];
+
+/// Normalize a space-separated watch list (`ReportSchedule::watch_sources`,
+/// `watch_kinds`): trim, drop empties and repeats, keep first-seen order.
+/// With `allowed`, anything outside the set is dropped too — an unknown
+/// event kind would make a standing question that never fires.
+pub fn normalize_watch_list(raw: &str, allowed: Option<&[&str]>) -> String {
+    let mut seen: Vec<&str> = Vec::new();
+    for token in raw.split_whitespace() {
+        if seen.contains(&token) {
+            continue;
+        }
+        if allowed.is_some_and(|ok| !ok.contains(&token)) {
+            continue;
+        }
+        seen.push(token);
+    }
+    seen.join(" ")
 }
 
 /// What one Night Shift run did (docs/RFC-night-shift-area.md §2). Written
@@ -384,6 +416,14 @@ pub struct ReportSchedule {
     pub not_before: i64,
     pub interval_secs: i64,
     pub enabled: bool,
+    /// Event filter for `trigger == "change"` (docs/RFC-events.md §5):
+    /// space-separated source ids this standing question watches. Empty
+    /// means any source in the notebook — the pre-filter behaviour.
+    #[serde(default)]
+    pub watch_sources: String,
+    /// Space-separated `EVENT_KINDS` that pull the trigger; empty means any.
+    #[serde(default)]
+    pub watch_kinds: String,
     /// Unix millis of the last successful run; 0 = never run.
     pub last_run_at: i64,
     pub created_at: i64,

--- a/src-tauri/src/robots.rs
+++ b/src-tauri/src/robots.rs
@@ -1,0 +1,299 @@
+//! robots.txt for the one place Alchemy crawls (docs/RFC-events.md §2):
+//! sitemap watches fetch pages the user never pasted, so the site's rules
+//! apply. Feeds and pasted URLs are what the site published for readers
+//! and are not gated here.
+//!
+//! One fetch per host, cached in the database for a day. Rules are matched
+//! for the `Alchemy` user-agent group first, then `*`; the longest matching
+//! `Allow`/`Disallow` path wins (the Google/RFC 9309 rule), `Crawl-delay`
+//! is honored between page fetches. A robots.txt that cannot be fetched
+//! allows everything except a `5xx`, which is read as "not now".
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::db::Db;
+
+/// Our token in `User-agent:` groups.
+pub const AGENT: &str = "Alchemy";
+/// Cache lifetime for a host's rules.
+const TTL_MS: i64 = 24 * 60 * 60 * 1000;
+/// Never wait longer than this between fetches, whatever the site asks.
+const MAX_DELAY: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct Rules {
+    /// (allow, path-prefix) in file order; `allow` false is a Disallow.
+    pub rules: Vec<(bool, String)>,
+    pub crawl_delay_secs: Option<f64>,
+    /// The origin answered 5xx (or nothing) — treat as temporarily closed.
+    pub unavailable: bool,
+}
+
+impl Rules {
+    /// Is this path fetchable under these rules? Longest match wins; ties
+    /// go to Allow; no match allows.
+    pub fn allows(&self, path: &str) -> bool {
+        if self.unavailable {
+            return false;
+        }
+        let mut best: Option<(usize, bool)> = None;
+        for (allow, prefix) in &self.rules {
+            if prefix.is_empty() {
+                // "Disallow:" with nothing means allow all; skip it.
+                continue;
+            }
+            if path_matches(path, prefix) {
+                let len = prefix.len();
+                match best {
+                    Some((l, a)) if l > len || (l == len && a) => {}
+                    _ => best = Some((len, *allow)),
+                }
+            }
+        }
+        best.map(|(_, allow)| allow).unwrap_or(true)
+    }
+
+    pub fn delay(&self) -> Option<Duration> {
+        self.crawl_delay_secs
+            .filter(|d| *d > 0.0)
+            .map(|d| Duration::from_secs_f64(d).min(MAX_DELAY))
+    }
+}
+
+/// robots.txt patterns: `*` wildcards, `$` anchors the end.
+fn path_matches(path: &str, pattern: &str) -> bool {
+    let anchored = pattern.ends_with('$');
+    let pattern = pattern.trim_end_matches('$');
+    let parts: Vec<&str> = pattern.split('*').collect();
+    let mut pos = 0usize;
+    for (i, part) in parts.iter().enumerate() {
+        if i == 0 {
+            if !path.starts_with(part) {
+                return false;
+            }
+            pos = part.len();
+            continue;
+        }
+        match path[pos..].find(part) {
+            Some(at) => pos += at + part.len(),
+            None => return false,
+        }
+    }
+    if anchored {
+        parts.len() > 1 && pos == path.len() || parts.len() == 1 && path == pattern
+    } else {
+        true
+    }
+}
+
+/// Parse a robots.txt for our agent: the `Alchemy` group when the file has
+/// one, else the `*` group. Groups are the runs of `User-agent:` lines and
+/// the rules that follow them, per RFC 9309.
+pub fn parse(text: &str) -> Rules {
+    let mut ours = Rules::default();
+    let mut any = Rules::default();
+    let mut in_ours = false;
+    let mut in_any = false;
+    let mut collecting_agents = false;
+    for raw in text.lines() {
+        let line = raw.split('#').next().unwrap_or("").trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Some((key, value)) = line.split_once(':') else {
+            continue;
+        };
+        let key = key.trim().to_ascii_lowercase();
+        let value = value.trim();
+        match key.as_str() {
+            "user-agent" => {
+                // A new group starts at the first agent line after rules.
+                if !collecting_agents {
+                    in_ours = false;
+                    in_any = false;
+                    collecting_agents = true;
+                }
+                let v = value.to_ascii_lowercase();
+                if v == AGENT.to_ascii_lowercase() {
+                    in_ours = true;
+                } else if v == "*" {
+                    in_any = true;
+                }
+            }
+            "allow" | "disallow" => {
+                collecting_agents = false;
+                let allow = key == "allow";
+                if in_ours {
+                    ours.rules.push((allow, value.to_string()));
+                }
+                if in_any {
+                    any.rules.push((allow, value.to_string()));
+                }
+            }
+            "crawl-delay" => {
+                collecting_agents = false;
+                let d = value.parse::<f64>().ok();
+                if in_ours {
+                    ours.crawl_delay_secs = d;
+                }
+                if in_any {
+                    any.crawl_delay_secs = d;
+                }
+            }
+            _ => {
+                collecting_agents = false;
+            }
+        }
+    }
+    if ours.rules.is_empty() && ours.crawl_delay_secs.is_none() {
+        any
+    } else {
+        ours
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct Cached {
+    fetched_at: i64,
+    rules: Rules,
+}
+
+fn origin_of(url: &str) -> Option<String> {
+    let (scheme, rest) = url.split_once("://")?;
+    let host = rest.split('/').next()?;
+    Some(format!("{scheme}://{host}"))
+}
+
+pub fn path_of(url: &str) -> String {
+    url.split_once("://")
+        .and_then(|(_, rest)| rest.find('/').map(|i| rest[i..].to_string()))
+        .unwrap_or_else(|| "/".to_string())
+}
+
+/// The rules for a URL's host, fetched at most once a day and kept in the
+/// database (`robots.<origin>`), never on disk.
+pub async fn rules_for(db: &Db, url: &str) -> Rules {
+    let Some(origin) = origin_of(url) else {
+        return Rules::default();
+    };
+    let key = format!("robots.{origin}");
+    let now = crate::commands::now();
+    if let Ok(Some(raw)) = db.kv_get(&key).await {
+        if let Ok(c) = serde_json::from_str::<Cached>(&raw) {
+            if now - c.fetched_at < TTL_MS {
+                return c.rules;
+            }
+        }
+    }
+    let rules = fetch(&origin).await;
+    if let Ok(json) = serde_json::to_string(&Cached {
+        fetched_at: now,
+        rules: rules.clone(),
+    }) {
+        let _ = db.kv_set(&key, &json).await;
+    }
+    rules
+}
+
+async fn fetch(origin: &str) -> Rules {
+    let client = match reqwest::Client::builder()
+        .user_agent(format!(
+            "{AGENT}/{} (+https://thrashr888.github.io/alchemy/)",
+            env!("CARGO_PKG_VERSION")
+        ))
+        .timeout(Duration::from_secs(15))
+        .build()
+    {
+        Ok(c) => c,
+        Err(_) => return Rules::default(),
+    };
+    match client.get(format!("{origin}/robots.txt")).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            let text = resp.text().await.unwrap_or_default();
+            parse(&text)
+        }
+        Ok(resp) if resp.status().is_server_error() => Rules {
+            unavailable: true,
+            ..Rules::default()
+        },
+        // 404 and friends: no rules, everything allowed.
+        Ok(_) => Rules::default(),
+        // Unreachable host: the page fetch will fail on its own; do not
+        // pretend the site forbade it.
+        Err(_) => Rules::default(),
+    }
+}
+
+/// May Alchemy fetch this URL as a crawler?
+pub async fn allowed(db: &Db, url: &str) -> bool {
+    rules_for(db, url).await.allows(&path_of(url))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ROBOTS: &str = "\
+# comment
+User-agent: Googlebot
+Disallow: /private/
+
+User-agent: *
+Disallow: /admin/
+Disallow: /tmp/*.pdf$
+Allow: /admin/public/
+Crawl-delay: 2
+
+User-agent: Alchemy
+Disallow: /products/
+Crawl-delay: 5
+";
+
+    #[test]
+    fn our_group_wins_over_the_wildcard() {
+        let r = parse(ROBOTS);
+        assert!(!r.allows("/products/hg-2"), "our own group's Disallow");
+        assert!(
+            r.allows("/admin/"),
+            "the * group's rules do not apply once we have our own"
+        );
+        assert_eq!(r.delay(), Some(Duration::from_secs(5)));
+    }
+
+    #[test]
+    fn the_wildcard_group_applies_when_we_are_not_named() {
+        let text = ROBOTS.replace("User-agent: Alchemy", "User-agent: Other");
+        let r = parse(&text);
+        assert!(!r.allows("/admin/secret"));
+        assert!(
+            r.allows("/admin/public/x"),
+            "longest match wins: Allow beats the shorter Disallow"
+        );
+        assert!(r.allows("/products/hg-2"));
+        assert!(!r.allows("/tmp/report.pdf"), "wildcard and end anchor");
+        assert!(r.allows("/tmp/report.pdf.bak"), "the $ anchor holds");
+        assert_eq!(r.delay(), Some(Duration::from_secs(2)));
+    }
+
+    #[test]
+    fn missing_or_empty_files_allow_everything() {
+        assert!(parse("").allows("/anything"));
+        assert!(
+            parse("User-agent: *\nDisallow:\n").allows("/x"),
+            "empty Disallow allows all"
+        );
+        assert!(!Rules {
+            unavailable: true,
+            ..Rules::default()
+        }
+        .allows("/x"));
+        assert_eq!(path_of("https://a.b/c/d?e"), "/c/d?e");
+        assert_eq!(path_of("https://a.b"), "/");
+        assert_eq!(
+            origin_of("https://www.x.y/p/q").as_deref(),
+            Some("https://www.x.y")
+        );
+    }
+}

--- a/src-tauri/src/scheduler.rs
+++ b/src-tauri/src/scheduler.rs
@@ -492,6 +492,9 @@ async fn run_pass(app: &AppHandle) {
     // 1. Freshness. Resync is cheap table/mtime work and always runs: a
     //    foregrounded window going stale is worse than a few tokens.
     let _ = commands::resync_sources_inner(app, &state, None).await;
+    // Feeds poll on their own cadences (docs/RFC-events.md §2): a
+    // conditional GET each, no model, so outside the nightly budget.
+    crate::feeds::spawn_poll(app);
 
     if crate::freshness::has_budget(&budget) {
         // Distillation, tags, and card suggestions converge even when no

--- a/src-tauri/src/scheduler.rs
+++ b/src-tauri/src/scheduler.rs
@@ -29,6 +29,11 @@ static PAUSED_UNTIL: AtomicI64 = AtomicI64::new(0);
 static LAST_MAINTAIN: AtomicI64 = AtomicI64::new(0);
 const MAINTAIN_EVERY_MS: i64 = 6 * 60 * 60 * 1000;
 
+/// Epoch ms of the last tick that walked closed notebooks' local folders.
+/// Between those, only open notebooks' folders walk each minute — FSEvents
+/// covers them anyway (fswatch.rs); this is the belt to its braces.
+static LAST_CLOSED_SWEEP: AtomicI64 = AtomicI64::new(0);
+
 /// Epoch ms of the last snapshot attempt. Checked hourly; the job itself is
 /// idempotent within a calendar day, so a machine that wakes at odd hours
 /// still gets exactly one snapshot per day.
@@ -483,8 +488,26 @@ async fn run_pass(app: &AppHandle) {
     };
 
     // 1. Freshness. Resync is cheap table/mtime work and always runs: a
-    //    foregrounded window going stale is worse than a few tokens.
-    let _ = commands::resync_sources_inner(app, &state, None).await;
+    //    foregrounded window going stale is worse than a few tokens. Local
+    //    folders of notebooks nobody has open walk once per CLOSED_SWEEP_MS
+    //    (docs/RFC-events.md §4); the stamp moves only when the walk ran,
+    //    so a tick that lost the scan lock does not cost the closed set
+    //    its turn.
+    let open = state.open_notebook_ids();
+    let closed_due =
+        now_ms() - LAST_CLOSED_SWEEP.load(Ordering::Relaxed) >= crate::fswatch::CLOSED_SWEEP_MS;
+    let sweep = crate::fswatch::Sweep::Tick {
+        open: &open,
+        closed_due,
+    };
+    if let Ok(Some(_)) = commands::resync_sources_filtered(app, &state, None, sweep).await {
+        if closed_due {
+            LAST_CLOSED_SWEEP.store(now_ms(), Ordering::Relaxed);
+        }
+    }
+    // Folder sources added or removed since the last tick change what the
+    // watcher should cover; the recompute is one folder-table read.
+    crate::fswatch::rearm(app).await;
 
     if crate::freshness::has_budget(&budget) {
         // Distillation, tags, and card suggestions converge even when no

--- a/src-tauri/src/scheduler.rs
+++ b/src-tauri/src/scheduler.rs
@@ -297,12 +297,19 @@ pub(crate) fn is_due(
         // to answer.
         "change" => {
             now - s.last_run_at >= s.interval_secs * 1000
-                && events
-                    .iter()
-                    .any(|e| e.notebook_id == s.notebook_id && e.at > s.last_run_at)
+                && events.iter().any(|e| watches(s, e) && e.at > s.last_run_at)
         }
         _ => now - s.last_run_at >= s.interval_secs * 1000,
     }
+}
+
+/// Does this standing question care about this event? Notebook first, then
+/// the optional source and kind filters (docs/RFC-events.md §5). An empty
+/// filter matches everything, which is what every pre-filter schedule meant.
+pub(crate) fn watches(s: &crate::models::ReportSchedule, e: &crate::models::SourceEvent) -> bool {
+    e.notebook_id == s.notebook_id
+        && (s.watch_sources.is_empty() || s.watch_sources.split(' ').any(|id| id == e.source_id))
+        && (s.watch_kinds.is_empty() || s.watch_kinds.split(' ').any(|k| k == e.kind))
 }
 
 /// When this run *should* have started. Pure, for the same reason `is_due`
@@ -332,7 +339,7 @@ pub(crate) fn due_at(
         // have wanted to know.
         "change" => events
             .iter()
-            .filter(|e| e.notebook_id == s.notebook_id && e.at > s.last_run_at)
+            .filter(|e| watches(s, e) && e.at > s.last_run_at)
             .map(|e| e.at)
             .min()
             .unwrap_or(s.last_run_at),
@@ -704,7 +711,7 @@ async fn run_pass(app: &AppHandle) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::{ReportSchedule, SourceEvent};
+    use crate::models::{normalize_watch_list, ReportSchedule, SourceEvent, EVENT_KINDS};
     use std::collections::HashSet;
 
     const HOUR: i64 = 3_600_000;
@@ -720,6 +727,8 @@ mod tests {
             not_before: 0,
             interval_secs: 3_600,
             enabled: true,
+            watch_sources: String::new(),
+            watch_kinds: String::new(),
             last_run_at: 0,
             created_at: 0,
         }
@@ -824,6 +833,51 @@ mod tests {
         assert!(
             !is_due(&throttled, now, &none, &[event(now - 1_000)]),
             "one run per interval at most"
+        );
+    }
+
+    #[test]
+    fn standing_questions_honour_their_filters() {
+        let none = HashSet::new();
+        let now = 10 * HOUR;
+        let mut question = schedule("change");
+        question.last_run_at = now - 2 * HOUR;
+        question.watch_sources = "feed-1 feed-2".into();
+        question.watch_kinds = "added".into();
+
+        let mut hit = event(now - HOUR);
+        hit.source_id = "feed-1".into();
+        hit.kind = "added".into();
+        let mut other_source = hit.clone();
+        other_source.source_id = "src".into();
+        let mut other_kind = hit.clone();
+        other_kind.kind = "updated".into();
+
+        assert!(is_due(&question, now, &none, &[hit.clone()]));
+        assert!(
+            !is_due(&question, now, &none, &[other_source.clone()]),
+            "another source's change is not this question's business"
+        );
+        assert!(
+            !is_due(&question, now, &none, &[other_kind]),
+            "an edit is not an arrival"
+        );
+        assert_eq!(
+            due_at(&question, &[other_source, hit]),
+            now - HOUR,
+            "due when the matching event landed, not the first event"
+        );
+
+        // Empty filters keep the pre-filter meaning: anything in the notebook.
+        let mut open = schedule("change");
+        open.last_run_at = now - 2 * HOUR;
+        assert!(is_due(&open, now, &none, &[event(now - HOUR)]));
+
+        assert_eq!(normalize_watch_list(" a  b a ", None), "a b");
+        assert_eq!(
+            normalize_watch_list("added bogus updated", Some(&EVENT_KINDS)),
+            "added updated",
+            "unknown kinds are dropped rather than stored as a filter nothing matches"
         );
     }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,6 +76,16 @@ function App() {
   // notebook must not grey out the menu over the Home window in front.
   // (A note pop-out has neither set of sidebars and stays out of it.)
   const inNotebook = !!currentId;
+  // Detection cost (docs/RFC-events.md §4): the backend watches the folders
+  // of notebooks some window has open and sweeps the rest slowly, so each
+  // window reports its notebook as it changes — null on the way to Home.
+  // Note pop-outs have no notebook of their own and stay out of it.
+  useEffect(() => {
+    if (!isTauri() || window.__ALCHEMY_NOTE__) return;
+    void api.setOpenNotebook(currentId).catch(() => {
+      /* older backend without the command — the minute sweep still runs */
+    });
+  }, [currentId]);
   const reportedContext = useRef<boolean | null>(null);
   useEffect(() => {
     if (!isTauri() || window.__ALCHEMY_NOTE__) return;

--- a/src/components/ArrivalsStrip.tsx
+++ b/src/components/ArrivalsStrip.tsx
@@ -1,0 +1,204 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { ChevronRight, Inbox } from "lucide-react";
+import { api } from "@/lib/api";
+import { useStore } from "@/lib/store";
+import {
+  EVENT_VERB,
+  loadSeenAt,
+  saveSeenAt,
+  tallyEvents,
+  unseenEvents,
+} from "@/lib/arrivals";
+import type { SourceEvent } from "@/lib/types";
+import { cn, relativeTime } from "@/lib/utils";
+import { CardAction } from "./ui";
+
+/**
+ * Arrivals (docs/RFC-events.md §6): one strip above the sources list when
+ * the watchers saw something since the reader last dismissed it. Reads
+ * `source_events` and nothing else; never calls a model. The watermark is
+ * per notebook in localStorage — a UI convenience, not a table.
+ */
+
+/** The events table keeps 30 days; a week is as far back as "since you
+ *  looked" stays meaningful in a panel. */
+const WINDOW_HOURS = 24 * 7;
+/** Rows shown when the strip is open; the rest stay in the tally. */
+const SHOWN = 30;
+/** Diff lines per row — a glance, not a review. */
+const DIFF_LINES = 6;
+
+export function useArrivals(notebookId: string | null) {
+  const [events, setEvents] = useState<SourceEvent[]>([]);
+  // Lazy initializer, and the effect below re-reads on notebook change:
+  // both are reads only, so StrictMode's double invocation cannot restore
+  // twice (the localStorage gotcha this repo already hit).
+  const [seenAt, setSeenAt] = useState(() => (notebookId ? loadSeenAt(notebookId) : 0));
+  useEffect(() => {
+    setSeenAt(notebookId ? loadSeenAt(notebookId) : 0);
+  }, [notebookId]);
+
+  const requestId = useRef(0);
+  const refresh = useCallback(async () => {
+    const id = ++requestId.current;
+    if (!notebookId) {
+      setEvents([]);
+      return;
+    }
+    try {
+      const rows = await api.listSourceEvents(WINDOW_HOURS, notebookId);
+      if (id === requestId.current) setEvents(rows);
+    } catch {
+      /* best-effort: the strip is a convenience, not a record */
+    }
+  }, [notebookId]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  // Producers emit after they write, but not always after the event row
+  // lands (reingest writes it inside the same pass) — a short settle keeps
+  // the re-read from racing the writer. Multi-window: listeners are not
+  // filtered by target, so filter by the payload's notebook.
+  useEffect(() => {
+    if (!notebookId) return;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const bump = () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => void refresh(), 400);
+    };
+    const unA = listen<{ notebookId: string }>("sources://changed", (e) => {
+      if (e.payload.notebookId === notebookId) bump();
+    });
+    const unB = listen<{ scope: string; notebookId: string | null }>(
+      "mcp://changed",
+      (e) => {
+        if (!e.payload.notebookId || e.payload.notebookId === notebookId) bump();
+      },
+    );
+    return () => {
+      if (timer) clearTimeout(timer);
+      void unA.then((f) => f());
+      void unB.then((f) => f());
+    };
+  }, [notebookId, refresh]);
+
+  const unseen = useMemo(() => unseenEvents(events, seenAt), [events, seenAt]);
+  const sourceIds = useMemo(() => new Set(unseen.map((e) => e.sourceId)), [unseen]);
+
+  const dismiss = useCallback(() => {
+    if (!notebookId) return;
+    // Not "now": a row that lands between the read and the click stays
+    // unseen, and clock skew across a resync never hides a real arrival.
+    const at = unseen.reduce((m, e) => Math.max(m, e.at), 0);
+    saveSeenAt(notebookId, at);
+    setSeenAt(at);
+  }, [notebookId, unseen]);
+
+  return { unseen, sourceIds, dismiss };
+}
+
+export function ArrivalsStrip({
+  unseen,
+  onDismiss,
+}: {
+  unseen: SourceEvent[];
+  onDismiss: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const sources = useStore((s) => s.sources);
+  const openInReader = useStore((s) => s.openInReader);
+  const present = useMemo(() => new Set(sources.map((s) => s.id)), [sources]);
+  const tallies = useMemo(() => tallyEvents(unseen), [unseen]);
+  if (unseen.length === 0 || tallies.length === 0) return null;
+  const shown = unseen.slice(0, SHOWN);
+  const line = tallies.join(" · ");
+  return (
+    <div className="mb-1 rounded-md border border-border bg-surface-2/60">
+      <div className="flex items-center gap-2 px-2 py-1.5">
+        <button
+          type="button"
+          onClick={() => setOpen((o) => !o)}
+          aria-expanded={open}
+          className="flex min-w-0 flex-1 items-center gap-2 text-left"
+          title={line}
+        >
+          <Inbox className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <span className="min-w-0 flex-1 truncate text-caption text-foreground">
+            {line}
+          </span>
+          <ChevronRight
+            className={cn(
+              "h-3 w-3 shrink-0 text-muted-foreground transition-transform duration-150",
+              open && "rotate-90",
+            )}
+          />
+        </button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="shrink-0 whitespace-nowrap text-micro text-muted-foreground transition-colors hover:text-foreground"
+          title="Clear the arrivals and the new-dots on their sources"
+        >
+          Mark seen
+        </button>
+      </div>
+      {open && (
+        <ul className="flex flex-col border-t border-border">
+          {shown.map((e) => {
+            const readable = e.kind !== "removed" && present.has(e.sourceId);
+            const diff = e.diff
+              ? e.diff.split("\n").slice(0, DIFF_LINES).join("\n")
+              : "";
+            const more = e.diff ? e.diff.split("\n").length - DIFF_LINES : 0;
+            return (
+              <li
+                key={e.id}
+                className={cn(
+                  "group relative border-b border-border px-2 py-1.5 last:border-b-0",
+                  readable && "cursor-pointer hover:bg-surface-2",
+                )}
+              >
+                {readable && (
+                  <CardAction
+                    label={`Open ${e.sourceTitle}`}
+                    onClick={() => openInReader({ type: "source", id: e.sourceId })}
+                  />
+                )}
+                <div className="pointer-events-none relative z-10 flex items-baseline gap-1.5 text-micro">
+                  <span className="shrink-0 text-muted-foreground">
+                    {EVENT_VERB[e.kind] ?? e.kind}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate text-foreground">
+                    {e.sourceTitle}
+                  </span>
+                  <span className="shrink-0 text-subtle-foreground">
+                    {relativeTime(e.at)}
+                  </span>
+                </div>
+                {e.detail && (
+                  <div className="pointer-events-none relative z-10 truncate text-micro text-muted-foreground">
+                    {e.detail}
+                  </div>
+                )}
+                {diff && (
+                  <pre className="pointer-events-none relative z-10 mt-1 overflow-hidden whitespace-pre-wrap break-words font-mono text-micro leading-snug text-subtle-foreground">
+                    {diff}
+                    {more > 0 && `\n… ${more} more`}
+                  </pre>
+                )}
+              </li>
+            );
+          })}
+          {unseen.length > SHOWN && (
+            <li className="px-2 py-1.5 text-micro text-subtle-foreground">
+              … and {unseen.length - SHOWN} more
+            </li>
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/ArrivalsStrip.tsx
+++ b/src/components/ArrivalsStrip.tsx
@@ -18,7 +18,7 @@ import { CardAction } from "./ui";
  * Arrivals (docs/RFC-events.md §6): one strip above the sources list when
  * the watchers saw something since the reader last dismissed it. Reads
  * `source_events` and nothing else; never calls a model. The watermark is
- * per notebook in localStorage — a UI convenience, not a table.
+ * per notebook in the database (`app_state`), read on open.
  */
 
 /** The events table keeps 30 days; a week is as far back as "since you
@@ -31,12 +31,20 @@ const DIFF_LINES = 6;
 
 export function useArrivals(notebookId: string | null) {
   const [events, setEvents] = useState<SourceEvent[]>([]);
-  // Lazy initializer, and the effect below re-reads on notebook change:
-  // both are reads only, so StrictMode's double invocation cannot restore
-  // twice (the localStorage gotcha this repo already hit).
-  const [seenAt, setSeenAt] = useState(() => (notebookId ? loadSeenAt(notebookId) : 0));
+  // Read from the database on open and on notebook change; until it
+  // answers, nothing counts as unseen (a flash of "25 new" would be wrong
+  // more often than right).
+  const [seenAt, setSeenAt] = useState(Number.MAX_SAFE_INTEGER);
   useEffect(() => {
-    setSeenAt(notebookId ? loadSeenAt(notebookId) : 0);
+    let live = true;
+    setSeenAt(Number.MAX_SAFE_INTEGER);
+    if (!notebookId) return;
+    void loadSeenAt(notebookId).then((at) => {
+      if (live) setSeenAt(at);
+    });
+    return () => {
+      live = false;
+    };
   }, [notebookId]);
 
   const requestId = useRef(0);

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -13,6 +13,7 @@ import {
 } from "./ui";
 import { useSourceActions } from "./SourceMenu";
 import { Markdown } from "./Markdown";
+import { LiveCards } from "./LiveCards";
 import { cn, chatReadingClass, fmtDateTime, isWebUrl, relativeTime } from "@/lib/utils";
 import { AgentPane } from "./AgentPane";
 import { AlchemySymbol } from "./AlchemyHero";
@@ -1472,6 +1473,10 @@ const ChatMessage = memo(function ChatMessage({
       >
         {message.content}
       </Markdown>
+      {/* Live answer cards (RFC-events §7): a cited Mac list or feed renders
+          its current data beneath the prose — derived from the citations at
+          render time, so nothing here is persisted or re-asked. */}
+      {message.citations.length > 0 && <LiveCards citations={message.citations} />}
       {message.citations.length > 0 && <Citations citations={message.citations} />}
       <MessageActions
         content={message.content}

--- a/src/components/FollowFeedModal.tsx
+++ b/src/components/FollowFeedModal.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from "react";
+import { Rss } from "lucide-react";
+import { Button, LoadingState, Modal } from "./ui";
+import { api } from "@/lib/api";
+import { useStore } from "@/lib/store";
+import type { FeedCandidate, Source } from "@/lib/types";
+
+const TIER_HINT: Record<FeedCandidate["tier"], string> = {
+  page: "advertised by the page",
+  host: "from the site\u2019s shape",
+  "well-known": "found at a conventional path",
+};
+
+/** "Follow updates\u2026" for a web source (docs/RFC-events.md \u00a72): every feed
+ *  the app can offer, each one click from becoming a living feed source.
+ *  Discovery may probe the origin's conventional paths, so it runs only
+ *  while this modal is open \u2014 never from a sweep. */
+export function FollowFeedModal({
+  source,
+  onClose,
+}: {
+  source: Source | null;
+  onClose: () => void;
+}) {
+  const [found, setFound] = useState<FeedCandidate[] | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const sources = useStore((s) => s.sources);
+  const addSourceUrl = useStore((s) => s.addSourceUrl);
+  const followed = new Set(
+    sources.filter((s) => s.sourceType === "feed").map((s) => s.url.replace(/\/$/, "")),
+  );
+
+  useEffect(() => {
+    if (!source) return;
+    setFound(null);
+    let live = true;
+    api
+      .discoverFeeds(source.id)
+      .then((list) => live && setFound(list))
+      .catch(() => live && setFound([]));
+    return () => {
+      live = false;
+    };
+  }, [source]);
+
+  const follow = async (c: FeedCandidate) => {
+    setBusy(c.url);
+    try {
+      await addSourceUrl(c.url);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <Modal
+      open={!!source}
+      onClose={onClose}
+      title="Follow updates"
+      width="max-w-md"
+    >
+      <div className="flex flex-col gap-3">
+        <p className="text-caption text-muted-foreground">
+          Feeds for <span className="text-foreground">{source?.title}</span>. Following one adds a
+          living source whose new entries arrive on their own.
+        </p>
+        {found === null ? (
+          <LoadingState label="Looking for feeds\u2026" />
+        ) : found.length === 0 ? (
+          <div className="rounded-md border border-dashed border-border px-3 py-2.5 text-caption text-subtle-foreground">
+            This page advertises no feed and its site has none at the usual paths.
+          </div>
+        ) : (
+          <div className="flex flex-col gap-1.5">
+            {found.map((c) => {
+              const already = followed.has(c.url.replace(/\/$/, ""));
+              return (
+                <div
+                  key={c.url}
+                  className="flex items-center gap-2 rounded-md border border-border px-3 py-2"
+                >
+                  <Rss className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-body text-foreground">{c.label}</div>
+                    <div className="truncate text-caption text-muted-foreground" title={c.url}>
+                      {c.url.replace(/^https?:\/\//, "")} \u00b7 {TIER_HINT[c.tier]}
+                    </div>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    disabled={already || busy !== null}
+                    onClick={() => void follow(c)}
+                    title={already ? "Already followed in this notebook" : "Follow this feed"}
+                  >
+                    {already ? "Following" : busy === c.url ? "Following\u2026" : "Follow"}
+                  </Button>
+                </div>
+              );
+            })}
+          </div>
+        )}
+        <div className="flex justify-end pt-1">
+          <Button type="button" variant="ghost" onClick={onClose}>
+            Done
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/GrowPane.tsx
+++ b/src/components/GrowPane.tsx
@@ -29,6 +29,7 @@ import {
   Tags,
   FileText,
   Globe,
+  Rss,
   Search,
   Sprout,
 } from "lucide-react";
@@ -304,6 +305,9 @@ export function GrowPane() {
       .finally(() => setIndexBusy(false));
   };
   const mined = visible(proposals ?? []).filter((p) => p.kind === "web");
+  // Feeds the notebook's own pages advertised (docs/RFC-events.md §2):
+  // remembered at import, followed only from here.
+  const feeds = visible(proposals ?? []).filter((p) => p.kind === "feed");
   const found = visible(web?.proposals ?? []);
 
   const row = (p: GrowthProposal) => (
@@ -348,10 +352,12 @@ export function GrowPane() {
         title={
           p.kind === "local"
             ? "Add this file as a source"
-            : "Fetch this page and add it as a source"
+            : p.kind === "feed"
+              ? "Follow this feed — new entries arrive as sources"
+              : "Fetch this page and add it as a source"
         }
       >
-        Add
+        {p.kind === "feed" ? "Follow" : "Add"}
       </Button>
       <Button
         variant="ghost"
@@ -475,6 +481,7 @@ export function GrowPane() {
                   down to one line when neither found anything. */}
               {locals.length === 0 &&
               mined.length === 0 &&
+              feeds.length === 0 &&
               localTier !== null ? (
                 <div className="rounded-md border border-dashed border-border px-3 py-2.5 text-caption text-subtle-foreground">
                   Nothing new on this Mac or in your sources right now.
@@ -496,6 +503,13 @@ export function GrowPane() {
                       "From your sources",
                       "pages your sources keep citing",
                       mined,
+                    )}
+                  {feeds.length > 0 &&
+                    section(
+                      <Rss className="h-3.5 w-3.5 text-muted-foreground" />,
+                      "Feeds",
+                      "your pages advertise these — follow one to keep up",
+                      feeds,
                     )}
                 </>
               )}

--- a/src/components/HomeReportsFeed.tsx
+++ b/src/components/HomeReportsFeed.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 import { useStore } from "@/lib/store";
-import type { Note } from "@/lib/types";
+import type { Note, SourceEvent } from "@/lib/types";
 import { cn, noteUnread, relativeTime } from "@/lib/utils";
+import { tallyEvents, unseenEvents } from "@/lib/arrivals";
 import { Button } from "./ui";
 import {
   ChevronDown,
@@ -16,10 +17,14 @@ export function AwayDigest({
   prevVisit,
   notebooks,
   reports,
+  events = [],
 }: {
   prevVisit: number;
   notebooks: { updatedAt: number }[];
   reports: Note[];
+  /** Source-change events across notebooks; the arrivals since the last
+   *  visit join the line (RFC-events §6). */
+  events?: SourceEvent[];
 }) {
   if (!prevVisit) return null;
   const newReports = reports.filter((report) => report.updatedAt > prevVisit).length;
@@ -30,6 +35,7 @@ export function AwayDigest({
     newReports > 0 && `${newReports} new ${newReports === 1 ? "report" : "reports"}`,
     updatedNotebooks > 0 &&
       `${updatedNotebooks} ${updatedNotebooks === 1 ? "notebook" : "notebooks"} updated`,
+    ...tallyEvents(unseenEvents(events, prevVisit)),
   ].filter(Boolean);
   if (parts.length === 0) return null;
   return (

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -644,6 +644,7 @@ export function HomeView({ onOpenSettings }: { onOpenSettings: () => void }) {
     recentNotes,
     stats,
     reports,
+    events: sourceEvents,
     loading: activityLoading,
     error: activityError,
     refresh: refreshActivity,
@@ -1067,6 +1068,7 @@ export function HomeView({ onOpenSettings }: { onOpenSettings: () => void }) {
                       prevVisit={prevVisit}
                       notebooks={notebooks}
                       reports={reports}
+                      events={sourceEvents}
                     />
                   )}
                 </div>

--- a/src/components/LiveCards.tsx
+++ b/src/components/LiveCards.tsx
@@ -1,0 +1,366 @@
+import { useEffect, useMemo, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import {
+  CalendarDays,
+  Circle,
+  CircleCheck,
+  ExternalLink,
+  ListChecks,
+  RefreshCw,
+  Rss,
+  TrendingUp,
+} from "lucide-react";
+import { api } from "@/lib/api";
+import { useStore } from "@/lib/store";
+import {
+  isStale,
+  liveKind,
+  parseLiveCard,
+  type CalendarCard,
+  type FeedCard,
+  type LiveCard,
+  type LiveKind,
+  type RemindersCard,
+  type StocksCard,
+} from "@/lib/liveCards";
+import type { Citation, Source } from "@/lib/types";
+import { cn, fmtDateTime, fmtDay, relativeTime } from "@/lib/utils";
+
+/**
+ * Live answer cards (docs/RFC-events.md §7). A reply that cites a live
+ * source — a Mac list or a feed — grows a native card beneath the prose,
+ * derived at render time from `Message.citations` and the source's STORED
+ * text. Nothing is persisted and no model runs: old transcripts light up,
+ * refresh re-fetches the source and the card re-renders, the prose stands.
+ * When the text does not parse there is no card at all.
+ */
+
+/** Rows per card before "+N more" — a card is a glance, the reader has the
+ *  whole list. */
+const SHOWN = 12;
+
+/** Source text by id, stamped with the fetch that produced it, so ten
+ *  replies citing the same watchlist read it once. */
+const contentCache = new Map<string, { stamp: string; text: string }>();
+
+export function LiveCards({ citations }: { citations: Citation[] }) {
+  const sources = useStore((s) => s.sources);
+  const live = useMemo(() => {
+    const seen = new Set<string>();
+    const out: { source: Source; kind: LiveKind }[] = [];
+    for (const c of citations) {
+      if (!c.sourceId || seen.has(c.sourceId)) continue;
+      seen.add(c.sourceId);
+      const source = sources.find((s) => s.id === c.sourceId);
+      const kind = source && liveKind(source);
+      if (source && kind) out.push({ source, kind });
+    }
+    return out;
+  }, [citations, sources]);
+  if (live.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-2">
+      {live.map(({ source, kind }) => (
+        <LiveCardView key={source.id} source={source} kind={kind} />
+      ))}
+    </div>
+  );
+}
+
+function LiveCardView({ source, kind }: { source: Source; kind: LiveKind }) {
+  const refreshSource = useStore((s) => s.refreshSource);
+  const [text, setText] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  // A resync in this notebook re-reads the text even when the list row's
+  // stamps have not reached this window yet (multi-window: filter by the
+  // payload's notebook, never the event target).
+  const [bump, setBump] = useState(0);
+  useEffect(() => {
+    const un = listen<{ notebookId: string }>("sources://changed", (e) => {
+      if (e.payload.notebookId === source.notebookId) setBump((b) => b + 1);
+    });
+    return () => void un.then((f) => f());
+  }, [source.notebookId]);
+
+  const stamp = `${source.fetchedAt}:${source.mtime}`;
+  useEffect(() => {
+    let stale = false;
+    const hit = contentCache.get(source.id);
+    if (hit && hit.stamp === stamp && bump === 0) {
+      setText(hit.text);
+      return;
+    }
+    api
+      .getSourceContent(source.id)
+      .then((t) => {
+        contentCache.set(source.id, { stamp, text: t });
+        if (!stale) setText(t);
+      })
+      .catch(() => {
+        if (!stale) setText(null);
+      });
+    return () => {
+      stale = true;
+    };
+  }, [source.id, stamp, bump]);
+
+  const card = useMemo(() => (text ? parseLiveCard(kind, text) : null), [kind, text]);
+  if (!card) return null;
+
+  const fetchedAt = source.fetchedAt || source.createdAt;
+  const stale = isStale(fetchedAt);
+  const Icon = ICON[kind];
+
+  async function refresh() {
+    setRefreshing(true);
+    try {
+      await refreshSource(source.id);
+    } finally {
+      setRefreshing(false);
+    }
+  }
+
+  return (
+    <section
+      aria-label={`${LABEL[kind]} from ${source.title}`}
+      className="overflow-hidden rounded-lg border border-border bg-surface"
+    >
+      <header className="flex items-center gap-2 border-b border-border px-3 py-1.5">
+        <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        <span className="min-w-0 flex-1 truncate text-caption font-medium text-foreground">
+          {source.title}
+        </span>
+        <span
+          className="shrink-0 text-micro text-subtle-foreground"
+          title={fetchedAt ? fmtDateTime(fetchedAt) : undefined}
+        >
+          {stale ? `as of ${fmtDateTime(fetchedAt)}` : fetchedAt ? `fetched ${relativeTime(fetchedAt)}` : ""}
+        </span>
+        <button
+          type="button"
+          onClick={() => void refresh()}
+          disabled={refreshing}
+          title="Fetch again"
+          aria-label={`Fetch ${source.title} again`}
+          className="shrink-0 rounded p-1 text-muted-foreground transition-colors hover:bg-surface-2 hover:text-foreground disabled:opacity-50"
+        >
+          <RefreshCw className={cn("h-3.5 w-3.5", refreshing && "animate-spin")} />
+        </button>
+      </header>
+      <CardBody card={card} />
+    </section>
+  );
+}
+
+const ICON = {
+  stocks: TrendingUp,
+  calendar: CalendarDays,
+  reminders: ListChecks,
+  feed: Rss,
+} as const;
+
+const LABEL: Record<LiveKind, string> = {
+  stocks: "Quotes",
+  calendar: "Events",
+  reminders: "Reminders",
+  feed: "Entries",
+};
+
+function CardBody({ card }: { card: LiveCard }) {
+  switch (card.kind) {
+    case "stocks":
+      return <StocksBody card={card} />;
+    case "calendar":
+      return <CalendarBody card={card} />;
+    case "reminders":
+      return <RemindersBody card={card} />;
+    case "feed":
+      return <FeedBody card={card} />;
+  }
+}
+
+function More({ n }: { n: number }) {
+  return n > 0 ? (
+    <div className="px-3 py-1.5 text-micro text-subtle-foreground">+{n} more in the source</div>
+  ) : null;
+}
+
+/** RFC 3339 → the app's date-time format; the raw string when it isn't one. */
+function fmtStamp(s: string): string {
+  const t = Date.parse(s);
+  return Number.isNaN(t) ? s : fmtDateTime(t);
+}
+
+/** YYYY-MM-DD → "Sep 4, 2026" in local time (parse as a date, not UTC
+ *  midnight, or the day shifts west of Greenwich). */
+function fmtIsoDay(d: string): string {
+  const [y, m, day] = d.split("-").map(Number);
+  return y && m && day ? fmtDay(new Date(y, m - 1, day).getTime()) : d;
+}
+
+function StocksBody({ card }: { card: StocksCard }) {
+  const rows = card.rows.slice(0, SHOWN);
+  return (
+    <>
+      <div className="overflow-x-auto">
+        <table className="w-full text-caption">
+          <thead>
+            <tr className="border-b border-border-strong text-micro font-medium text-muted-foreground">
+              <th className="px-3 py-1.5 text-left font-medium">Symbol</th>
+              <th className="px-3 py-1.5 text-right font-medium">Price</th>
+              <th className="px-3 py-1.5 text-right font-medium">Change</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.symbol} className="border-b border-border last:border-b-0">
+                <td className="px-3 py-1.5">
+                  <span className="font-medium text-foreground">{r.symbol}</span>
+                  {r.name && (
+                    <span className="ml-2 text-micro text-muted-foreground">{r.name}</span>
+                  )}
+                </td>
+                <td className="px-3 py-1.5 text-right tabular-nums text-foreground">
+                  {r.price || "—"}
+                </td>
+                <td
+                  className={cn(
+                    "px-3 py-1.5 text-right tabular-nums",
+                    r.changePct === null
+                      ? "text-subtle-foreground"
+                      : r.changePct > 0
+                        ? "text-success"
+                        : r.changePct < 0
+                          ? "text-destructive"
+                          : "text-muted-foreground",
+                  )}
+                >
+                  {r.change || "—"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <More n={card.rows.length - rows.length} />
+      {card.asOf && (
+        <div className="border-t border-border px-3 py-1.5 text-micro text-subtle-foreground">
+          Prices as of {fmtStamp(card.asOf)} · Apple Stocks
+        </div>
+      )}
+    </>
+  );
+}
+
+function CalendarBody({ card }: { card: CalendarCard }) {
+  const events = card.events.slice(0, SHOWN);
+  let lastDay = "";
+  return (
+    <>
+      <ul className="flex flex-col">
+        {events.map((e, i) => {
+          const heading = e.day !== lastDay ? e.day : null;
+          lastDay = e.day;
+          return (
+            <li key={i} className="border-b border-border last:border-b-0">
+              {heading && (
+                <div className="px-3 pt-2 text-micro font-medium text-muted-foreground">
+                  {fmtIsoDay(heading)}
+                </div>
+              )}
+              <div className="flex items-baseline gap-3 px-3 py-1.5 text-caption">
+                <span className="w-14 shrink-0 tabular-nums text-muted-foreground">{e.time}</span>
+                <span className="min-w-0 flex-1">
+                  <span className="text-foreground">{e.title}</span>
+                  <span className="ml-2 text-micro text-muted-foreground">{e.calendar}</span>
+                  {e.location && (
+                    <span className="block truncate text-micro text-subtle-foreground">
+                      {e.location}
+                    </span>
+                  )}
+                </span>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+      <More n={card.events.length - events.length} />
+    </>
+  );
+}
+
+function RemindersBody({ card }: { card: RemindersCard }) {
+  const items = card.items.slice(0, SHOWN);
+  return (
+    <>
+      <ul className="flex flex-col">
+        {items.map((r, i) => (
+          <li
+            key={r.id ?? i}
+            className="flex items-baseline gap-2 border-b border-border px-3 py-1.5 text-caption last:border-b-0"
+          >
+            {r.done ? (
+              <CircleCheck className="h-3.5 w-3.5 shrink-0 translate-y-0.5 text-success" aria-label="Done" />
+            ) : (
+              <Circle className="h-3.5 w-3.5 shrink-0 translate-y-0.5 text-subtle-foreground" aria-label="Open" />
+            )}
+            <span className="min-w-0 flex-1">
+              <span className={cn("text-foreground", r.done && "text-muted-foreground line-through")}>
+                {r.title}
+              </span>
+              {r.notes && (
+                <span className="block truncate text-micro text-subtle-foreground">{r.notes}</span>
+              )}
+            </span>
+            {r.due && (
+              <span className="shrink-0 text-micro tabular-nums text-muted-foreground">
+                due {fmtIsoDay(r.due)}
+              </span>
+            )}
+          </li>
+        ))}
+      </ul>
+      <More n={card.items.length - items.length} />
+    </>
+  );
+}
+
+function FeedBody({ card }: { card: FeedCard }) {
+  const entries = card.entries.slice(0, SHOWN);
+  return (
+    <>
+      <ul className="flex flex-col">
+        {entries.map((e, i) => (
+          <li
+            key={e.link ?? i}
+            className="flex items-baseline gap-3 border-b border-border px-3 py-1.5 text-caption last:border-b-0"
+          >
+            <span className="w-20 shrink-0 tabular-nums text-micro text-muted-foreground">
+              {fmtIsoDay(e.published.slice(0, 10))}
+            </span>
+            <span className="min-w-0 flex-1">
+              {e.link ? (
+                <button
+                  type="button"
+                  onClick={() => void openUrl(e.link!)}
+                  className="inline-flex max-w-full items-center gap-1 text-left text-citation hover:underline"
+                  title={e.link}
+                >
+                  <span className="truncate">{e.title}</span>
+                  <ExternalLink className="h-3 w-3 shrink-0" />
+                </button>
+              ) : (
+                <span className="text-foreground">{e.title}</span>
+              )}
+              {e.excerpt && (
+                <span className="block truncate text-micro text-subtle-foreground">{e.excerpt}</span>
+              )}
+            </span>
+          </li>
+        ))}
+      </ul>
+      <More n={card.entries.length - entries.length} />
+    </>
+  );
+}

--- a/src/components/ReaderPane.tsx
+++ b/src/components/ReaderPane.tsx
@@ -1431,6 +1431,7 @@ export const SOURCE_TYPE_LABEL: Record<Source["sourceType"], string> = {
   git: "Git repository",
   notion: "Notion pages",
   obsidian: "Obsidian vault",
+  feed: "Feed",
 };
 
 /** Git provenance parsed from the content header line the ingesters write

--- a/src/components/ReaderPane.tsx
+++ b/src/components/ReaderPane.tsx
@@ -324,12 +324,31 @@ function findTextRange(container: HTMLElement, needle: string): Range | null {
       }
     }
   }
-  let target = mdToPlain(needle).toLowerCase().replace(/\s+/g, "");
+  const plain = mdToPlain(needle);
+  let target = plain.toLowerCase().replace(/\s+/g, "");
   if (target.length < 12) return null;
   let at = hay.indexOf(target);
   if (at === -1 && target.length > 80) {
     target = target.slice(0, 80);
     at = hay.indexOf(target);
+  }
+  // Living sources rewrite their text between the answer and the reader
+  // opening — a Stocks watchlist resyncs every minute, so the cited row's
+  // price is already gone and the prefix no longer exists. Anchor on the
+  // first line of the snippet that still does (a table's header row)
+  // rather than give up: losing the rendered view over a moved decimal is
+  // the wrong trade.
+  if (at === -1) {
+    for (const line of plain.split("\n")) {
+      const t = line.toLowerCase().replace(/\s+/g, "");
+      if (t.length < 12) continue;
+      const i = hay.indexOf(t);
+      if (i !== -1) {
+        target = t;
+        at = i;
+        break;
+      }
+    }
   }
   if (at === -1) return null;
   const start = map[at];
@@ -2138,7 +2157,12 @@ function SourceReader({
       // this still asks the content rather than trusting the type.
       source.sourceType === "pdf") &&
       contentLooksMarkdown);
-  const richMode = markdownShaped && !(highlight && anchorFailed);
+  // A failed anchor falls back to the plain view so the passage can still
+  // be marked — except for Mac sources, whose text is regenerated on every
+  // sync: a stale citation is the normal case there, and the plain view
+  // renders their tables as pipes. They keep the rendered view, unmarked.
+  const richMode =
+    markdownShaped && !(highlight && anchorFailed && source.sourceType !== "mac");
   // Code-file sources render with the same shiki view the repo reader uses
   // (CodeView). Shiki swaps the code block's DOM in asynchronously, which
   // would detach a citation Range anchored before the swap — so when a

--- a/src/components/ReaderPane.tsx
+++ b/src/components/ReaderPane.tsx
@@ -2145,6 +2145,9 @@ function SourceReader({
   );
   const markdownShaped =
     source.sourceType === "markdown" ||
+    // A feed parent's text is its rolling index, written as markdown by
+    // construction (feeds.rs::index_text).
+    source.sourceType === "feed" ||
     ((source.sourceType === "text" ||
       source.sourceType === "url" ||
       // Apple integrations (Notes, Calendar, Reminders, Stocks) come out of

--- a/src/components/Reports.tsx
+++ b/src/components/Reports.tsx
@@ -1,7 +1,8 @@
 import { useMemo, useState } from "react";
 import { useStore } from "@/lib/store";
 import { api } from "@/lib/api";
-import { Button, EmptyState, Input, Textarea, Modal, Spinner } from "./ui";
+import { Button, EmptyState, Input, Textarea, Modal, RowMenu, Select, Spinner } from "./ui";
+import { FOLDER_TYPES } from "./SourceMenu";
 import { cn, fmtDay } from "@/lib/utils";
 import {
   Clock,
@@ -76,8 +77,15 @@ export function Reports() {
   const generating = useStore((s) => s.generatingKind === "report");
   const notes = useStore((s) => s.notes);
   // Top-level sources only: a folder or feed parent's id covers what
-  // arrives under it, so children would be noise in the picker.
+  // arrives under it, so children would be noise in the picker. Living
+  // sources (folders, feeds, git, Mac apps, watched pages) lead; the rest
+  // change only when something edits them — an agent or the CLI can, so
+  // they stay pickable, just below a fold.
   const watchable = useStore((s) => s.sources).filter((src) => !src.parentId);
+  const isLiving = (t: string) =>
+    FOLDER_TYPES.includes(t) || t === "mac" || t === "url";
+  const living = watchable.filter((src) => isLiving(src.sourceType));
+  const editOnly = watchable.filter((src) => !isLiving(src.sourceType));
   const markNotesRead = useStore((s) => s.markNotesRead);
 
   // Each schedule keeps one living note (collapse_report_notes) titled after
@@ -135,6 +143,10 @@ export function Reports() {
   const [watchKinds, setWatchKinds] = useState<string[]>([]);
   const toggleIn = (list: string[], v: string) =>
     list.includes(v) ? list.filter((x) => x !== v) : [...list, v];
+  const allWatchIds = watchable.map((src) => src.id);
+  const allChecked =
+    watchable.length > 0 && allWatchIds.every((id) => watchSources.includes(id));
+  const someChecked = watchSources.length > 0 && !allChecked;
 
   function openEditor() {
     setEditTarget(null);
@@ -192,7 +204,7 @@ export function Reports() {
           hint="Reports refresh your URL sources on a schedule, then write a timestamped note."
         />
       ) : (
-        <div className="mt-2 flex flex-col gap-1">
+        <div className="mt-2 flex select-none flex-col gap-1">
           {schedules.map((r) => (
             <div key={r.id} className="group flex items-center gap-2 rounded-md px-2 py-1.5 hover:bg-surface-2">
               <button
@@ -219,6 +231,8 @@ export function Reports() {
                   </span>
                 </div>
               </div>
+              {/* Two quick actions on hover; the rest ride the ⋯ menu, which
+                  right-clicking the row opens too (DESIGN.md §4). */}
               <div className="hidden items-center gap-0.5 group-hover:flex group-focus-within:flex">
                 <button
                   type="button"
@@ -240,25 +254,42 @@ export function Reports() {
                 >
                   {generating ? <Spinner className="h-3.5 w-3.5" /> : <Play className="h-3.5 w-3.5" />}
                 </button>
-                <button
-                  type="button"
-                  className="rounded p-1 text-muted-foreground hover:text-foreground"
-                  onClick={() => openEdit(r)}
-                  title="Edit"
-                  aria-label={`Edit "${r.name}"`}
-                >
-                  <Pencil className="h-3.5 w-3.5" />
-                </button>
-                <button
-                  type="button"
-                  className="rounded p-1 text-muted-foreground hover:text-destructive"
-                  onClick={() => remove(r.id)}
-                  title="Delete"
-                  aria-label={`Delete "${r.name}"`}
-                >
-                  <Trash2 className="h-3.5 w-3.5" />
-                </button>
               </div>
+              <RowMenu
+                label={`Options for "${r.name}"`}
+                items={[
+                  ...(latestNote(r)
+                    ? [
+                        {
+                          label: "Open the latest result",
+                          icon: <FileText className="h-3.5 w-3.5" />,
+                          onClick: () => showLatest(r),
+                        },
+                      ]
+                    : []),
+                  {
+                    label: "Run now",
+                    icon: <Play className="h-3.5 w-3.5" />,
+                    onClick: () => void runNow(r.id),
+                  },
+                  {
+                    label: r.enabled ? "Pause" : "Enable",
+                    icon: <Power className="h-3.5 w-3.5" />,
+                    onClick: () => void update({ ...r, enabled: !r.enabled }),
+                  },
+                  {
+                    label: "Edit…",
+                    icon: <Pencil className="h-3.5 w-3.5" />,
+                    onClick: () => openEdit(r),
+                  },
+                  {
+                    label: "Delete",
+                    icon: <Trash2 className="h-3.5 w-3.5" />,
+                    danger: true,
+                    onClick: () => void remove(r.id),
+                  },
+                ]}
+              />
             </div>
           ))}
         </div>
@@ -269,8 +300,24 @@ export function Reports() {
         onClose={() => setEditing(false)}
         title={editTarget ? "Edit report" : "Schedule a report"}
         width="max-w-md"
+        footer={
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="ghost" onClick={() => setEditing(false)}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              form="report-form"
+              variant="primary"
+              disabled={!name.trim() || (kind === "custom" && !prompt.trim())}
+            >
+              {editTarget ? "Save" : "Schedule"}
+            </Button>
+          </div>
+        }
       >
         <form
+          id="report-form"
           onSubmit={(e) => {
             e.preventDefault();
             setEditing(false);
@@ -358,27 +405,50 @@ export function Reports() {
               <Field label="Which sources" htmlFor="report-watch-sources">
                 <div
                   id="report-watch-sources"
-                  className="max-h-40 overflow-y-auto rounded-md border border-input bg-surface-2"
+                  className="max-h-48 overflow-y-auto rounded-md border border-input bg-surface-2"
                   role="group"
                   aria-label="Sources to watch"
                 >
                   {watchable.length === 0 ? (
                     <p className="px-3 py-2 text-micro text-subtle-foreground">No sources yet.</p>
                   ) : (
-                    watchable.map((src) => (
-                      <label
-                        key={src.id}
-                        className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-caption text-foreground hover:bg-primary/15"
-                      >
+                    <>
+                      <label className="flex cursor-pointer items-center gap-2 border-b border-border px-3 py-1.5 text-caption text-foreground hover:bg-primary/15">
                         <input
                           type="checkbox"
                           className="select-quiet"
-                          checked={watchSources.includes(src.id)}
-                          onChange={() => setWatchSources(toggleIn(watchSources, src.id))}
+                          checked={allChecked}
+                          ref={(el) => {
+                            if (el) el.indeterminate = someChecked;
+                          }}
+                          onChange={() => setWatchSources(allChecked ? [] : allWatchIds)}
                         />
-                        <span className="truncate">{src.title}</span>
+                        <span className="font-medium">All sources</span>
                       </label>
-                    ))
+                      {living.map((src) => (
+                        <SourcePick
+                          key={src.id}
+                          title={src.title}
+                          checked={watchSources.includes(src.id)}
+                          onToggle={() => setWatchSources(toggleIn(watchSources, src.id))}
+                        />
+                      ))}
+                      {editOnly.length > 0 && (
+                        <>
+                          <div className="px-3 pb-0.5 pt-2 text-micro uppercase tracking-wide text-subtle-foreground">
+                            Change only when edited
+                          </div>
+                          {editOnly.map((src) => (
+                            <SourcePick
+                              key={src.id}
+                              title={src.title}
+                              checked={watchSources.includes(src.id)}
+                              onToggle={() => setWatchSources(toggleIn(watchSources, src.id))}
+                            />
+                          ))}
+                        </>
+                      )}
+                    </>
                   )}
                 </div>
                 <p className="text-micro text-subtle-foreground">
@@ -389,18 +459,6 @@ export function Reports() {
               </Field>
             </>
           )}
-          <div className="flex justify-end gap-2 pt-1">
-            <Button type="button" variant="ghost" onClick={() => setEditing(false)}>
-              Cancel
-            </Button>
-            <Button
-              type="submit"
-              variant="primary"
-              disabled={!name.trim() || (kind === "custom" && !prompt.trim())}
-            >
-              {editTarget ? "Save" : "Schedule"}
-            </Button>
-          </div>
         </form>
       </Modal>
     </div>
@@ -416,29 +474,19 @@ function Field({ label, htmlFor, children }: { label: string; htmlFor: string; c
   );
 }
 
-function Select({
-  id,
-  value,
-  onChange,
-  options,
+function SourcePick({
+  title,
+  checked,
+  onToggle,
 }: {
-  id: string;
-  value: string;
-  onChange: (v: string) => void;
-  options: { value: string; label: string }[];
+  title: string;
+  checked: boolean;
+  onToggle: () => void;
 }) {
   return (
-    <select
-      id={id}
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      className="w-full rounded-md border border-input bg-surface-2 py-2.5 pl-3 pr-9 text-body text-foreground outline-none focus:border-primary/60"
-    >
-      {options.map((o) => (
-        <option key={o.value} value={o.value}>
-          {o.label}
-        </option>
-      ))}
-    </select>
+    <label className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-caption text-foreground hover:bg-primary/15">
+      <input type="checkbox" className="select-quiet" checked={checked} onChange={onToggle} />
+      <span className="truncate">{title}</span>
+    </label>
   );
 }

--- a/src/components/Reports.tsx
+++ b/src/components/Reports.tsx
@@ -15,8 +15,46 @@ import {
   Pencil,
   Zap,
 } from "lucide-react";
-import type { Note, ReportSchedule } from "@/lib/types";
+import type { EventKind, Note, ReportSchedule } from "@/lib/types";
 import { ARTIFACTS } from "./studioArtifacts";
+
+/** The event kinds a standing question can filter on (docs/RFC-events.md
+ *  §5), in the order they read best as a sentence. Labels are what happened
+ *  to the source, not the row's kind string. */
+export const EVENT_KIND_LABELS: { value: EventKind; label: string }[] = [
+  { value: "added", label: "New" },
+  { value: "updated", label: "Edited" },
+  { value: "removed", label: "Removed" },
+  { value: "unreachable", label: "Unreachable" },
+  { value: "completed", label: "Completed" },
+  { value: "moved", label: "Rescheduled" },
+];
+
+const splitWatch = (s: string) => s.split(" ").filter(Boolean);
+
+/** One line under the row name: cadence, filters, last run — a single
+ *  truncating string so a filtered standing question never wraps into a
+ *  three-line stack beside its icon. */
+function cadenceLine(r: ReportSchedule): string {
+  const cadence =
+    r.trigger === "change"
+      ? `On change · at most ${intervalLabel(r.intervalSecs).toLowerCase()}${watchSummary(r)}`
+      : intervalLabel(r.intervalSecs);
+  return r.lastRunAt > 0 ? `${cadence} · last ${fmtDay(r.lastRunAt)}` : cadence;
+}
+
+/** "On change · at most daily · 2 sources · new, edited" — the row's one-line
+ *  summary of a standing question's filters; empty filters say nothing. */
+export function watchSummary(r: ReportSchedule): string {
+  const parts: string[] = [];
+  const sources = splitWatch(r.watchSources ?? "");
+  if (sources.length) parts.push(`${sources.length} ${sources.length === 1 ? "source" : "sources"}`);
+  const kinds = splitWatch(r.watchKinds ?? "")
+    .map((k) => EVENT_KIND_LABELS.find((l) => l.value === k)?.label.toLowerCase())
+    .filter((k): k is string => !!k);
+  if (kinds.length) parts.push(kinds.join(", "));
+  return parts.length ? ` · ${parts.join(" · ")}` : "";
+}
 
 const INTERVALS = [
   { label: "Hourly", secs: 3600 },
@@ -37,6 +75,9 @@ export function Reports() {
   const runNow = useStore((s) => s.runReportNow);
   const generating = useStore((s) => s.generatingKind === "report");
   const notes = useStore((s) => s.notes);
+  // Top-level sources only: a folder or feed parent's id covers what
+  // arrives under it, so children would be noise in the picker.
+  const watchable = useStore((s) => s.sources).filter((src) => !src.parentId);
   const markNotesRead = useStore((s) => s.markNotesRead);
 
   // Each schedule keeps one living note (collapse_report_notes) titled after
@@ -89,6 +130,11 @@ export function Reports() {
   const [prompt, setPrompt] = useState("");
   const [trigger, setTrigger] = useState<"interval" | "change">("interval");
   const [intervalSecs, setIntervalSecs] = useState(86400);
+  // Change-trigger filters; empty means any (docs/RFC-events.md §5).
+  const [watchSources, setWatchSources] = useState<string[]>([]);
+  const [watchKinds, setWatchKinds] = useState<string[]>([]);
+  const toggleIn = (list: string[], v: string) =>
+    list.includes(v) ? list.filter((x) => x !== v) : [...list, v];
 
   function openEditor() {
     setEditTarget(null);
@@ -97,6 +143,8 @@ export function Reports() {
     setPrompt("");
     setTrigger("interval");
     setIntervalSecs(86400);
+    setWatchSources([]);
+    setWatchKinds([]);
     setEditing(true);
   }
 
@@ -107,6 +155,8 @@ export function Reports() {
     setPrompt(r.prompt);
     setTrigger(r.trigger === "change" ? "change" : "interval");
     setIntervalSecs(r.intervalSecs);
+    setWatchSources(splitWatch(r.watchSources ?? ""));
+    setWatchKinds(splitWatch(r.watchKinds ?? ""));
     setEditing(true);
   }
 
@@ -158,16 +208,15 @@ export function Reports() {
                 <div className="truncate text-body text-foreground" title={r.name}>
                   {r.name}
                 </div>
-                <div className="flex items-center gap-1 text-micro text-subtle-foreground">
+                <div className="flex min-w-0 items-center gap-1 text-micro text-subtle-foreground">
                   {r.trigger === "change" ? (
-                    <Zap className="h-2.5 w-2.5" />
+                    <Zap className="h-2.5 w-2.5 shrink-0" />
                   ) : (
-                    <Clock className="h-2.5 w-2.5" />
+                    <Clock className="h-2.5 w-2.5 shrink-0" />
                   )}
-                  {r.trigger === "change"
-                    ? `On change · at most ${intervalLabel(r.intervalSecs).toLowerCase()}`
-                    : intervalLabel(r.intervalSecs)}
-                  {r.lastRunAt > 0 && <span>· last {fmtDay(r.lastRunAt)}</span>}
+                  <span className="truncate" title={cadenceLine(r)}>
+                    {cadenceLine(r)}
+                  </span>
                 </div>
               </div>
               <div className="hidden items-center gap-0.5 group-hover:flex group-focus-within:flex">
@@ -226,9 +275,22 @@ export function Reports() {
             e.preventDefault();
             setEditing(false);
             const p = kind === "custom" ? prompt : "";
+            // Filters only mean something on a standing question; a clock-fired
+            // report stores none so switching triggers later starts clean.
+            const ws = trigger === "change" ? watchSources.join(" ") : "";
+            const wk = trigger === "change" ? watchKinds.join(" ") : "";
             if (editTarget)
-              void update({ ...editTarget, name, kind, prompt: p, trigger, intervalSecs });
-            else void create(name, kind, p, trigger, intervalSecs);
+              void update({
+                ...editTarget,
+                name,
+                kind,
+                prompt: p,
+                trigger,
+                intervalSecs,
+                watchSources: ws,
+                watchKinds: wk,
+              });
+            else void create(name, kind, p, trigger, intervalSecs, ws, wk);
           }}
           className="flex flex-col gap-3"
         >
@@ -265,6 +327,68 @@ export function Reports() {
               options={INTERVALS.map((i) => ({ value: String(i.secs), label: i.label }))}
             />
           </Field>
+          {trigger === "change" && (
+            <>
+              <Field label="Which changes" htmlFor="report-watch-kinds">
+                <div id="report-watch-kinds" className="flex flex-wrap gap-1.5" role="group" aria-label="Event kinds">
+                  {EVENT_KIND_LABELS.map((k) => {
+                    const on = watchKinds.includes(k.value);
+                    return (
+                      <button
+                        key={k.value}
+                        type="button"
+                        aria-pressed={on}
+                        onClick={() => setWatchKinds(toggleIn(watchKinds, k.value))}
+                        className={cn(
+                          "rounded-full border px-2.5 py-1 text-micro transition-colors",
+                          on
+                            ? "border-primary/60 text-foreground"
+                            : "border-border text-muted-foreground hover:text-foreground",
+                        )}
+                      >
+                        {k.label}
+                      </button>
+                    );
+                  })}
+                </div>
+                <p className="text-micro text-subtle-foreground">
+                  {watchKinds.length ? "Only these kinds of change." : "Any kind of change."}
+                </p>
+              </Field>
+              <Field label="Which sources" htmlFor="report-watch-sources">
+                <div
+                  id="report-watch-sources"
+                  className="max-h-40 overflow-y-auto rounded-md border border-input bg-surface-2"
+                  role="group"
+                  aria-label="Sources to watch"
+                >
+                  {watchable.length === 0 ? (
+                    <p className="px-3 py-2 text-micro text-subtle-foreground">No sources yet.</p>
+                  ) : (
+                    watchable.map((src) => (
+                      <label
+                        key={src.id}
+                        className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-caption text-foreground hover:bg-primary/15"
+                      >
+                        <input
+                          type="checkbox"
+                          className="select-quiet"
+                          checked={watchSources.includes(src.id)}
+                          onChange={() => setWatchSources(toggleIn(watchSources, src.id))}
+                        />
+                        <span className="truncate">{src.title}</span>
+                      </label>
+                    ))
+                  )}
+                </div>
+                <p className="text-micro text-subtle-foreground">
+                  {watchSources.length
+                    ? `Only ${watchSources.length} of ${watchable.length} sources.`
+                    : "Any source in this notebook."}
+                </p>
+              </Field>
+            </>
+          )}
           <div className="flex justify-end gap-2 pt-1">
             <Button type="button" variant="ghost" onClick={() => setEditing(false)}>
               Cancel

--- a/src/components/SourceMenu.tsx
+++ b/src/components/SourceMenu.tsx
@@ -19,6 +19,7 @@ import {
   type TagEditState,
 } from "./SourceMetaModals";
 import { SourceImagePicker } from "./SourceImagePicker";
+import { FollowFeedModal } from "./FollowFeedModal";
 import { AttachToCardModal } from "./RegistrySection";
 import {
   Image as ImageIcon,
@@ -27,6 +28,7 @@ import {
   Pencil,
   Plus,
   RefreshCw,
+  Rss,
   Trash2,
 } from "lucide-react";
 
@@ -37,7 +39,7 @@ import {
  * everywhere at once; a surface that must drop one says which (`omit`),
  * rather than rebuilding the list with the verb missing. */
 
-export const FOLDER_TYPES = ["folder", "git", "notion", "obsidian"];
+export const FOLDER_TYPES = ["folder", "git", "notion", "obsidian", "feed"];
 
 /** A verb the host renders elsewhere (the reader's inline toolbar) and so
  *  leaves out of the menu. */
@@ -52,6 +54,8 @@ interface Host {
   setNoteEdit: (s: NonNullable<NoteEditState>) => void;
   editText: (s: Source) => void;
   editMacNote: (s: Source) => void;
+  /** "Follow updates…" — offer the feeds this page can be followed by. */
+  followUpdates: (s: Source) => void;
   addReminder: (s: Source) => void;
   chooseImage: (s: Source) => void;
   attach: (s: Source) => void;
@@ -79,7 +83,10 @@ export function sourceMenuItems(
     s.sourceType !== "mac" &&
     !isFolder &&
     s.status !== "placeholder";
-  const refreshLabel = isFolder
+  const refreshLabel =
+    s.sourceType === "feed"
+      ? "Check feed now"
+      : isFolder
     ? "Rescan folder now"
     : s.sourceType === "mac"
       ? "Sync now"
@@ -106,6 +113,17 @@ export function sourceMenuItems(
             label: refreshLabel,
             icon: <RefreshCw className="h-3.5 w-3.5" />,
             onClick: () => void st.refreshSource(s.id),
+          },
+        ]
+      : []),
+    // A web page may advertise a feed, or sit on a host whose shape implies
+    // one (docs/RFC-events.md §2). Following it is a separate, explicit act.
+    ...(s.sourceType === "url" && !s.parentId && isWebUrl(s.url)
+      ? [
+          {
+            label: "Follow updates…",
+            icon: <Rss className="h-3.5 w-3.5" />,
+            onClick: () => host.followUpdates(s),
           },
         ]
       : []),
@@ -188,6 +206,7 @@ export function useSourceActions() {
     macNote?: boolean;
   } | null>(null);
   const { confirm, dialog: confirmDialog } = useConfirm();
+  const [following, setFollowing] = useState<Source | null>(null);
   const editSourceText = useStore((s) => s.editSourceText);
   const updateMacNote = useStore((s) => s.updateMacNote);
   const addMacReminder = useStore((s) => s.addMacReminder);
@@ -211,6 +230,7 @@ export function useSourceActions() {
         );
     },
     addReminder: (s) => setAddingReminder({ sourceId: s.id, list: s.title }),
+    followUpdates: setFollowing,
     chooseImage: setImageFor,
     attach: setAttaching,
     remove: (s) => void removeSourcesGuarded([s.id], confirm),
@@ -236,6 +256,7 @@ export function useSourceActions() {
           onClose={() => setImageFor(null)}
         />
       )}
+      <FollowFeedModal source={following} onClose={() => setFollowing(null)} />
       <Modal
         open={!!editing}
         onClose={() => setEditing(null)}

--- a/src/components/SourcesPanel.tsx
+++ b/src/components/SourcesPanel.tsx
@@ -134,7 +134,7 @@ export function Favicon({ url }: { url: string }) {
   );
 }
 
-const FOLDER_TYPES = ["folder", "git", "notion", "obsidian"];
+const FOLDER_TYPES = ["folder", "git", "notion", "obsidian", "feed"];
 
 /** Facet kinds: coarse buckets a narrow panel can offer as chips. */
 type SourceKind = "web" | "files" | "images" | "apple" | "folders";

--- a/src/components/SourcesPanel.tsx
+++ b/src/components/SourcesPanel.tsx
@@ -28,6 +28,7 @@ import {
 import { sourceIcon } from "@/lib/sourceIcon";
 import { HYGIENE_LABEL, loadHygieneKept } from "@/lib/growth";
 import { useSourceActions } from "./SourceMenu";
+import { ArrivalsStrip, useArrivals } from "./ArrivalsStrip";
 import type { GrowthProposal, Source } from "@/lib/types";
 import {
   ChevronRight,
@@ -255,6 +256,8 @@ export function SourcesPanel() {
   const refreshSourcesBatch = useStore((s) => s.refreshSourcesBatch);
   const hygiene = useStore((s) => s.hygiene);
   const refreshHygiene = useStore((s) => s.refreshHygiene);
+  // Arrivals (RFC-events §6): what the watchers saw since the last dismiss.
+  const arrivals = useArrivals(currentId);
   const { confirm, dialog: confirmDialog } = useConfirm();
 
   // One source, one menu: the row verbs and every modal they open come
@@ -880,6 +883,9 @@ export function SourcesPanel() {
           </EmptyState>
         ) : (
           <>
+            {/* What changed since the reader last looked — one line of
+                tallies, the events on click, gone on "Mark seen". */}
+            <ArrivalsStrip unseen={arrivals.unseen} onDismiss={arrivals.dismiss} />
             {/* Master selection row: which sources feed chat & Studio. Always
                 labeled — a bare checkbox over empty space read as a blank,
                 menu-less source row in every notebook. */}
@@ -1153,6 +1159,16 @@ export function SourcesPanel() {
                             (s.url && hostname(s.url)) ||
                             "Untitled"}
                         </span>
+                        {/* New-dot: an unseen arrival landed here (folder
+                            children roll up to their parent). Cleared by
+                            the strip's Mark seen. */}
+                        {arrivals.sourceIds.has(s.id) && (
+                          <span
+                            aria-label="Changed since you last looked"
+                            title="Changed since you last looked"
+                            className="h-1.5 w-1.5 shrink-0 rounded-full bg-primary"
+                          />
+                        )}
                         {issueBySource.has(s.id) && (
                           <Badge
                             className="shrink-0"

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -6,6 +6,7 @@ import {
   Loader2,
   MoreHorizontal,
   X,
+  ChevronDown,
   CheckCircle2,
   AlertTriangle,
   Info,
@@ -749,6 +750,49 @@ export function Modal({
       </div>
     </div>,
     document.body,
+  );
+}
+
+/**
+ * The one select. A native `<select>` with `appearance-none` and a lucide
+ * chevron drawn over it: WKWebView ignores padding and height on a styled
+ * native control otherwise, so every hand-rolled select in the app came out
+ * flush against its border. Same 32px height and fill as `Input`.
+ */
+export function Select({
+  id,
+  value,
+  onChange,
+  options,
+  className,
+  ...rest
+}: {
+  id?: string;
+  value: string;
+  onChange: (v: string) => void;
+  options: { value: string; label: string }[];
+  className?: string;
+} & Omit<React.SelectHTMLAttributes<HTMLSelectElement>, "value" | "onChange">) {
+  return (
+    <div className={cn("relative", className)}>
+      <select
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="h-8 w-full appearance-none rounded-md border border-input bg-surface-2 pl-2.5 pr-8 text-body text-foreground outline-none transition-colors focus:border-ring/60"
+        {...rest}
+      >
+        {options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+      <ChevronDown
+        aria-hidden
+        className="pointer-events-none absolute right-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground"
+      />
+    </div>
   );
 }
 

--- a/src/components/useHomeActivity.ts
+++ b/src/components/useHomeActivity.ts
@@ -1,9 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { api } from "@/lib/api";
-import type { HomeActivity, Notebook } from "@/lib/types";
+import type { HomeActivity, Notebook, SourceEvent } from "@/lib/types";
 
 type HomeActivityData = Omit<HomeActivity, "stats"> & {
   stats: HomeActivity["stats"] | null;
+  /** Source-change events across every notebook, newest first — the
+   *  Arrivals tallies in the away digest (RFC-events §6). */
+  events: SourceEvent[];
 };
 
 const EMPTY_ACTIVITY: HomeActivityData = {
@@ -11,7 +14,11 @@ const EMPTY_ACTIVITY: HomeActivityData = {
   recentNotes: [],
   reports: [],
   stats: null,
+  events: [],
 };
+
+/** As far back as "since you were away" reaches; the table keeps 30 days. */
+const EVENTS_WINDOW_HOURS = 24 * 7;
 
 /** Load one backend snapshot so notes feed recent activity, reports, and stats
  * without three overlapping corpus scans. */
@@ -26,9 +33,14 @@ export function useHomeActivity(notebooks: Notebook[]) {
     setLoading(true);
 
     try {
-      const snapshot = await api.homeActivity();
+      // Events are a separate small read; a miss there must not blank the
+      // whole home, so it degrades to "no arrivals".
+      const [snapshot, events] = await Promise.all([
+        api.homeActivity(),
+        api.listSourceEvents(EVENTS_WINDOW_HOURS).catch((): SourceEvent[] => []),
+      ]);
       if (id !== requestId.current) return;
-      setData(snapshot);
+      setData({ ...snapshot, events });
       setError(null);
     } catch {
       if (id !== requestId.current) return;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -702,8 +702,10 @@ export const api = {
     run(cmd<number>("rematch_registry", { notebookId })),
 
   // Night Shift (the Home Staff section)
-  listSourceEvents: (hours = 24) =>
-    run(query<SourceEvent[]>("list_source_events", { hours })),
+  /** Source-change events, newest first. `notebookId` narrows to one
+   *  notebook (the Arrivals strip); omit it for Home and Staff. */
+  listSourceEvents: (hours = 24, notebookId?: string) =>
+    run(query<SourceEvent[]>("list_source_events", { hours, notebookId })),
   nightShiftStatus: () => run(query<NightShiftStatus>("night_shift_status")),
   snapshotStatus: () => run(query<SnapshotStatus>("snapshot_status")),
   snapshotNow: () => run(cmd<SnapshotStatus>("snapshot_now")),

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -10,6 +10,7 @@ import type {
   AiConfig,
   BuildInfo,
   GrowthOverview,
+  FeedCandidate,
   GrowthProposal,
   GrowthWebSearch,
   RetireProposal,
@@ -542,6 +543,8 @@ export const api = {
   /** Source ids ever cited in retrieval traces — the "uncited" facet. */
   citedSourceIds: () => run(query<string[]>("cited_source_ids", {})),
   /** The Grow surface: standing queries + the free tiers' proposals. */
+  discoverFeeds: (sourceId: string) =>
+    run(query<FeedCandidate[]>("discover_feeds", { sourceId })),
   growthProposals: (notebookId: string) =>
     run(query<GrowthOverview>("growth_proposals", { notebookId })),
   /** The Spotlight tier — mdfind is the slow part, loaded separately. */

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -439,6 +439,10 @@ export const api = {
    *  Home-only and notebook-only toggles enable and disable with it. */
   setMenuContext: (inNotebook: boolean) =>
     run(cmd<void>("set_menu_context", { inNotebook })),
+  /** Tell the backend which notebook this window has open (null = Home), so
+   *  FSEvents watches its folders and closed notebooks fall to the slow sweep. */
+  setOpenNotebook: (notebookId: string | null) =>
+    run(cmd<void>("set_open_notebook", { notebookId })),
   /** Settings → Shortcuts rows from the menu's command registry. */
   listShortcuts: () =>
     run(

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -720,6 +720,8 @@ export const api = {
     prompt: string,
     trigger: string,
     intervalSecs: number,
+    watchSources = "",
+    watchKinds = "",
   ) =>
     run(
       cmd<ReportSchedule>("create_report_schedule", {
@@ -729,6 +731,8 @@ export const api = {
         prompt,
         trigger,
         intervalSecs,
+        watchSources,
+        watchKinds,
       }),
     ),
   updateReportSchedule: (
@@ -739,6 +743,8 @@ export const api = {
     trigger: string,
     intervalSecs: number,
     enabled: boolean,
+    watchSources = "",
+    watchKinds = "",
   ) =>
     run(
       cmd<void>("update_report_schedule", {
@@ -749,6 +755,8 @@ export const api = {
         trigger,
         intervalSecs,
         enabled,
+        watchSources,
+        watchKinds,
       }),
     ),
   deleteReportSchedule: (id: string) =>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -547,6 +547,10 @@ export const api = {
   /** Source ids ever cited in retrieval traces — the "uncited" facet. */
   citedSourceIds: () => run(query<string[]>("cited_source_ids", {})),
   /** The Grow surface: standing queries + the free tiers' proposals. */
+  arrivalsSeenAt: (notebookId: string) =>
+    run(query<number>("arrivals_seen_at", { notebookId })),
+  markArrivalsSeen: (notebookId: string, at: number) =>
+    run(cmd<void>("mark_arrivals_seen", { notebookId, at })),
   discoverFeeds: (sourceId: string) =>
     run(query<FeedCandidate[]>("discover_feeds", { sourceId })),
   growthProposals: (notebookId: string) =>

--- a/src/lib/arrivals.test.ts
+++ b/src/lib/arrivals.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { eventCount, tallyEvents, unseenEvents } from "./arrivals";
+import type { SourceEvent } from "./types";
+
+const ev = (kind: string, sourceTitle: string, detail = "", at = 10): SourceEvent => ({
+  id: `${kind}-${sourceTitle}-${at}`,
+  notebookId: "nb",
+  sourceId: `src-${sourceTitle}`,
+  sourceTitle,
+  kind,
+  detail,
+  diff: "",
+  at,
+});
+
+describe("eventCount", () => {
+  it("reads the coalesced count off folder-scan rows and defaults to one", () => {
+    expect(eventCount(ev("added", "Docs", "3 new files"))).toBe(3);
+    expect(eventCount(ev("removed", "Docs", "12 files gone"))).toBe(12);
+    expect(eventCount(ev("added", "Docs", "new file · report.pdf"))).toBe(1);
+    // Only arrivals and departures coalesce; a diff's "+12 −3" is not a count.
+    expect(eventCount(ev("updated", "Docs", "12 lines changed"))).toBe(1);
+  });
+});
+
+describe("tallyEvents", () => {
+  it("groups by kind and source in the RFC's order", () => {
+    const parts = tallyEvents([
+      ev("added", "Tauri blog"),
+      ev("added", "Tauri blog"),
+      ev("added", "Tauri blog"),
+      ev("updated", "SFist"),
+      ev("completed", "Home"),
+      ev("completed", "Home"),
+      ev("moved", "Calendar"),
+      ev("unreachable", "Old site"),
+      ev("removed", "Docs", "2 files gone"),
+    ]);
+    expect(parts).toEqual([
+      "3 new from Tauri blog",
+      "SFist changed",
+      "2 gone from Docs",
+      "1 unreachable",
+      "2 reminders done",
+      "1 rescheduled",
+    ]);
+  });
+  it("collapses arrivals past three sources and counts plural changes", () => {
+    const parts = tallyEvents([
+      ev("added", "A", "2 new files"),
+      ev("added", "B"),
+      ev("added", "C"),
+      ev("added", "D"),
+      ev("updated", "X"),
+      ev("updated", "Y"),
+    ]);
+    expect(parts).toEqual(["5 new from 4 sources", "2 changed"]);
+  });
+  it("says nothing for nothing", () => {
+    expect(tallyEvents([])).toEqual([]);
+  });
+});
+
+describe("unseenEvents", () => {
+  it("keeps only rows newer than the watermark", () => {
+    const rows = [ev("added", "A", "", 30), ev("added", "B", "", 20), ev("added", "C", "", 10)];
+    expect(unseenEvents(rows, 20).map((e) => e.sourceTitle)).toEqual(["A"]);
+    expect(unseenEvents(rows, 0)).toHaveLength(3);
+  });
+});

--- a/src/lib/arrivals.ts
+++ b/src/lib/arrivals.ts
@@ -1,0 +1,96 @@
+import type { SourceEvent } from "./types";
+
+/**
+ * Arrivals (docs/RFC-events.md §6): what the watchers saw since the reader
+ * last looked. Pure helpers over `SourceEvent` rows — the strip in the
+ * sources panel and the Home digest both tally with these, and neither
+ * calls a model.
+ *
+ * The seen watermark is UI state, per notebook, in localStorage (the RFC's
+ * decision: notebooks are the isolation boundary the user reaches for, and
+ * nothing about events becomes notebook-partitioned storage).
+ */
+
+const SEEN_KEY = "arrivalsSeenAt:";
+
+/** Epoch ms the notebook's arrivals were last dismissed; 0 = never. */
+export function loadSeenAt(notebookId: string): number {
+  try {
+    const raw = localStorage.getItem(SEEN_KEY + notebookId);
+    const n = raw ? Number(raw) : 0;
+    return Number.isFinite(n) ? n : 0;
+  } catch {
+    return 0;
+  }
+}
+
+export function saveSeenAt(notebookId: string, at: number) {
+  try {
+    localStorage.setItem(SEEN_KEY + notebookId, String(at));
+  } catch {
+    /* storage full or unavailable — the strip just shows again next time */
+  }
+}
+
+/** How many items an event stands for. Folder scans coalesce a pass into
+ *  one row ("3 new files", "12 files gone") so a sync tool dropping 400
+ *  files never writes 400 rows; the count rides at the front of `detail`.
+ *  Everything else is one item. */
+export function eventCount(e: SourceEvent): number {
+  if (e.kind !== "added" && e.kind !== "removed") return 1;
+  const m = /^(\d+)\s/.exec(e.detail);
+  const n = m ? Number(m[1]) : 1;
+  return n > 0 ? n : 1;
+}
+
+const plural = (n: number, one: string, many: string) =>
+  `${n} ${n === 1 ? one : many}`;
+
+/** Group added/removed by the source they landed in: "3 new from Tauri
+ *  blog". Past three sources the list collapses to a count. */
+function perSource(events: SourceEvent[], verb: string): string[] {
+  const bySource = new Map<string, number>();
+  for (const e of events)
+    bySource.set(e.sourceTitle, (bySource.get(e.sourceTitle) ?? 0) + eventCount(e));
+  const total = [...bySource.values()].reduce((a, b) => a + b, 0);
+  if (bySource.size === 0) return [];
+  if (bySource.size > 3)
+    return [`${total} ${verb} from ${plural(bySource.size, "source", "sources")}`];
+  return [...bySource.entries()].map(([title, n]) => `${n} ${verb} from ${title}`);
+}
+
+/** The strip's one line: tallies grouped by kind, e.g.
+ *  "3 new from Tauri blog · 1 page changed · 2 reminders done". Empty when
+ *  there is nothing to say. Order follows the RFC's vocabulary table. */
+export function tallyEvents(events: SourceEvent[]): string[] {
+  const of = (kind: string) => events.filter((e) => e.kind === kind);
+  const parts: string[] = [...perSource(of("added"), "new")];
+  const updated = of("updated");
+  if (updated.length === 1) parts.push(`${updated[0].sourceTitle} changed`);
+  else if (updated.length > 1) parts.push(`${updated.length} changed`);
+  parts.push(...perSource(of("removed"), "gone"));
+  const unreachable = of("unreachable");
+  if (unreachable.length) parts.push(`${unreachable.length} unreachable`);
+  const completed = of("completed");
+  if (completed.length)
+    parts.push(plural(completed.length, "reminder done", "reminders done"));
+  const moved = of("moved");
+  if (moved.length) parts.push(`${moved.length} rescheduled`);
+  return parts;
+}
+
+/** Events the reader has not dismissed, newest first (the backend already
+ *  sorts; this only filters). */
+export function unseenEvents(events: SourceEvent[], seenAt: number): SourceEvent[] {
+  return events.filter((e) => e.at > seenAt);
+}
+
+/** Verb for one event row in the expanded list. */
+export const EVENT_VERB: Record<string, string> = {
+  added: "new",
+  updated: "changed",
+  removed: "gone",
+  unreachable: "unreachable",
+  completed: "done",
+  moved: "rescheduled",
+};

--- a/src/lib/arrivals.ts
+++ b/src/lib/arrivals.ts
@@ -1,3 +1,4 @@
+import { api } from "./api";
 import type { SourceEvent } from "./types";
 
 /**
@@ -6,30 +7,24 @@ import type { SourceEvent } from "./types";
  * sources panel and the Home digest both tally with these, and neither
  * calls a model.
  *
- * The seen watermark is UI state, per notebook, in localStorage (the RFC's
- * decision: notebooks are the isolation boundary the user reaches for, and
- * nothing about events becomes notebook-partitioned storage).
+ * The seen watermark is per notebook, in the database (`app_state`): the
+ * app is single-tenant by design, so UI state belongs there too, not in a
+ * webview's localStorage that another window or a reinstall forgets.
  */
 
-const SEEN_KEY = "arrivalsSeenAt:";
-
 /** Epoch ms the notebook's arrivals were last dismissed; 0 = never. */
-export function loadSeenAt(notebookId: string): number {
+export async function loadSeenAt(notebookId: string): Promise<number> {
   try {
-    const raw = localStorage.getItem(SEEN_KEY + notebookId);
-    const n = raw ? Number(raw) : 0;
-    return Number.isFinite(n) ? n : 0;
+    return await api.arrivalsSeenAt(notebookId);
   } catch {
     return 0;
   }
 }
 
 export function saveSeenAt(notebookId: string, at: number) {
-  try {
-    localStorage.setItem(SEEN_KEY + notebookId, String(at));
-  } catch {
-    /* storage full or unavailable — the strip just shows again next time */
-  }
+  void api.markArrivalsSeen(notebookId, at).catch(() => {
+    /* best-effort — the strip just shows again next time */
+  });
 }
 
 /** How many items an event stands for. Folder scans coalesce a pass into

--- a/src/lib/liveCards.test.ts
+++ b/src/lib/liveCards.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import {
+  isStale,
+  liveKind,
+  parseCalendar,
+  parseFeed,
+  parseLiveCard,
+  parseReminders,
+  parseStocks,
+} from "./liveCards";
+
+// Fixtures are byte-for-byte what src-tauri/src/mac.rs renders (its tests
+// pin the same strings), so a renderer drift fails on both sides.
+
+const STOCKS = `# Stocks — My Symbols
+
+| Symbol | Name | Price | Change | Status |
+|---|---|---|---|---|
+| AAPL | Apple Inc. | 231.46 USD | -1.23% | closed |
+| ZZZZ |  |  |  |  |
+
+_Prices as of 2026-09-02T20:00:00Z (Apple Stocks cache)._
+`;
+
+const CALENDAR = `# Calendar — next 7 days
+
+## 2026-09-03
+- 14:00 — Inspection (Home) at 12 Elm St
+  - bring the report
+## 2026-09-07
+- all day — Labor Day (US Holidays)
+`;
+
+const REMINDERS = `# Reminders — Home
+
+- [ ] Call the insurer \`x-apple-reminder://A1\` — due 2026-09-04
+  - policy 4471
+- [ ] Buy stamps \`x-apple-reminder://B2\`
+`;
+
+const FEED = `# Tauri blog
+
+Release notes and announcements.
+
+- 2026-09-01T10:00 — [Tauri 2.9](https://tauri.app/blog/tauri-2-9) — Smaller bundles and a new tray API.
+- 2026-08-20 — Community roundup
+`;
+
+describe("liveKind", () => {
+  it("names the card for live sources and nothing else", () => {
+    expect(liveKind({ sourceType: "mac", url: "cider://stocks/watchlist/My Symbols" })).toBe("stocks");
+    expect(liveKind({ sourceType: "mac", url: "cider://calendar/upcoming/7" })).toBe("calendar");
+    expect(liveKind({ sourceType: "mac", url: "cider://reminders/list/Home" })).toBe("reminders");
+    expect(liveKind({ sourceType: "feed", url: "https://tauri.app/feed.xml" })).toBe("feed");
+    // An Apple Note is prose already; a page is not live.
+    expect(liveKind({ sourceType: "mac", url: "cider://notes/note/x" })).toBeNull();
+    expect(liveKind({ sourceType: "url", url: "https://tauri.app" })).toBeNull();
+  });
+});
+
+describe("parseStocks", () => {
+  it("reads the quote table and the as-of stamp", () => {
+    const card = parseStocks(STOCKS);
+    expect(card?.asOf).toBe("2026-09-02T20:00:00Z");
+    expect(card?.rows).toEqual([
+      { symbol: "AAPL", name: "Apple Inc.", price: "231.46 USD", change: "-1.23%", changePct: -1.23, status: "closed" },
+      { symbol: "ZZZZ", name: "", price: "", change: "", changePct: null, status: "" },
+    ]);
+  });
+  it("falls back to nothing on corrupted text", () => {
+    expect(parseStocks("# Stocks — My Symbols\n\nnothing here")).toBeNull();
+    expect(parseStocks(STOCKS.replace("| Symbol |", "| Ticker |"))).toBeNull();
+    // A row with the wrong column count means the shape drifted.
+    expect(parseStocks(STOCKS.replace("| closed |", "|"))).toBeNull();
+  });
+});
+
+describe("parseCalendar", () => {
+  it("reads day headings, times, calendars, locations and notes", () => {
+    expect(parseCalendar(CALENDAR)?.events).toEqual([
+      { day: "2026-09-03", time: "14:00", title: "Inspection", calendar: "Home", location: "12 Elm St", notes: "bring the report" },
+      { day: "2026-09-07", time: "all day", title: "Labor Day", calendar: "US Holidays", location: null, notes: null },
+    ]);
+  });
+  it("keeps a parenthesised title whole", () => {
+    const card = parseCalendar("## 2026-09-03\n- 09:00 — Standup (maybe) (Work)\n");
+    expect(card?.events[0]).toMatchObject({ title: "Standup (maybe)", calendar: "Work" });
+  });
+  it("falls back to nothing without a day heading or on prose", () => {
+    expect(parseCalendar("- 09:00 — Standup (Work)\n")).toBeNull();
+    expect(parseCalendar("# Calendar\n\nNo events.\n")).toBeNull();
+  });
+});
+
+describe("parseReminders", () => {
+  it("reads title, id, due and notes", () => {
+    expect(parseReminders(REMINDERS)?.items).toEqual([
+      { title: "Call the insurer", id: "x-apple-reminder://A1", due: "2026-09-04", done: false, notes: "policy 4471" },
+      { title: "Buy stamps", id: "x-apple-reminder://B2", due: null, done: false, notes: null },
+    ]);
+  });
+  it("reads a checked box as done", () => {
+    expect(parseReminders("- [x] Paid `r1`\n")?.items[0].done).toBe(true);
+  });
+  it("falls back to nothing on prose", () => {
+    expect(parseReminders("# Reminders — Home\n\nAll clear.\n")).toBeNull();
+  });
+});
+
+describe("parseFeed", () => {
+  it("reads linked and bare entries", () => {
+    expect(parseFeed(FEED)?.entries).toEqual([
+      { published: "2026-09-01T10:00", title: "Tauri 2.9", link: "https://tauri.app/blog/tauri-2-9", excerpt: "Smaller bundles and a new tray API." },
+      { published: "2026-08-20", title: "Community roundup", link: null, excerpt: null },
+    ]);
+  });
+  it("falls back to nothing on prose", () => {
+    expect(parseFeed("# Tauri blog\n\nRelease notes.\n")).toBeNull();
+  });
+});
+
+describe("parseLiveCard / isStale", () => {
+  it("dispatches by kind", () => {
+    expect(parseLiveCard("stocks", STOCKS)?.kind).toBe("stocks");
+    expect(parseLiveCard("reminders", STOCKS)).toBeNull();
+  });
+  it("calls a day-old copy stale and a fresh one not", () => {
+    const now = 1_000_000_000_000;
+    expect(isStale(now - 60_000, now)).toBe(false);
+    expect(isStale(now - 25 * 3_600_000, now)).toBe(true);
+    // No stamp at all (legacy rows) is unknown, not stale.
+    expect(isStale(0, now)).toBe(false);
+  });
+});

--- a/src/lib/liveCards.ts
+++ b/src/lib/liveCards.ts
@@ -1,0 +1,221 @@
+/**
+ * Live answer cards (docs/RFC-events.md §7): when a chat reply cites a live
+ * source, the reply grows a native card beneath the prose, rendered from the
+ * source's STORED text — never from a model. These are the parsers, in the
+ * MindMap/Flashcards contract: a rigid spec goes in, a typed card comes out,
+ * and anything that does not parse is `null` (the prose stands alone).
+ *
+ * The specs are what `src-tauri/src/mac.rs` renders (its tests pin them —
+ * change a renderer only together with its parser here):
+ *
+ *   stocks     `| Symbol | Name | Price | Change | Status |` rows, then
+ *              `_Prices as of <time> (Apple Stocks cache)._`
+ *   calendar   `## YYYY-MM-DD` day headings, `- HH:MM — Title (Calendar)
+ *              [ at Location]` per event, `all day` in the time slot
+ *   reminders  `- [ ] Title \`id\`[ — due YYYY-MM-DD]`, notes as `  - …`
+ *   feed       one entry per line: `- YYYY-MM-DD[THH:MM] — [Title](link)
+ *              [ — excerpt]` (the feed parent's rolling index, RFC §2; a
+ *              plain `Title` without a link is accepted too)
+ */
+
+export type LiveKind = "stocks" | "calendar" | "reminders" | "feed";
+
+/** Which card a source draws, or null when it is not live (or is a live
+ *  source with no tabular shape — an Apple Note is prose already). */
+export function liveKind(source: { sourceType: string; url: string }): LiveKind | null {
+  if (source.sourceType === "feed") return "feed";
+  if (source.sourceType !== "mac") return null;
+  if (source.url.startsWith("cider://stocks/")) return "stocks";
+  if (source.url.startsWith("cider://calendar/")) return "calendar";
+  if (source.url.startsWith("cider://reminders/")) return "reminders";
+  return null;
+}
+
+export interface StockRow {
+  symbol: string;
+  name: string;
+  price: string;
+  /** As rendered ("+1.23%"); empty when the quote cache had no row. */
+  change: string;
+  /** Signed percent parsed from `change`; null when blank or unparseable. */
+  changePct: number | null;
+  status: string;
+}
+export interface StocksCard {
+  kind: "stocks";
+  rows: StockRow[];
+  /** The renderer's "as of" stamp, verbatim; null when no quote carried one. */
+  asOf: string | null;
+}
+
+export interface CalendarItem {
+  day: string;
+  /** "HH:MM" or "all day". */
+  time: string;
+  title: string;
+  calendar: string;
+  location: string | null;
+  notes: string | null;
+}
+export interface CalendarCard {
+  kind: "calendar";
+  events: CalendarItem[];
+}
+
+export interface ReminderItem {
+  title: string;
+  id: string | null;
+  /** YYYY-MM-DD or null. */
+  due: string | null;
+  done: boolean;
+  notes: string | null;
+}
+export interface RemindersCard {
+  kind: "reminders";
+  items: ReminderItem[];
+}
+
+export interface FeedEntry {
+  published: string;
+  title: string;
+  link: string | null;
+  excerpt: string | null;
+}
+export interface FeedCard {
+  kind: "feed";
+  entries: FeedEntry[];
+}
+
+export type LiveCard = StocksCard | CalendarCard | RemindersCard | FeedCard;
+
+const lines = (text: string) => text.split("\n").map((l) => l.replace(/\s+$/, ""));
+
+export function parseStocks(text: string): StocksCard | null {
+  const ls = lines(text);
+  const head = ls.findIndex((l) => /^\|\s*Symbol\s*\|\s*Name\s*\|\s*Price\s*\|\s*Change\s*\|\s*Status\s*\|$/.test(l));
+  if (head < 0) return null;
+  const rows: StockRow[] = [];
+  for (let i = head + 1; i < ls.length; i++) {
+    const l = ls[i];
+    if (!l.startsWith("|")) break;
+    if (/^\|[-\s|]+\|$/.test(l)) continue; // the header separator
+    const cells = l.split("|").slice(1, -1).map((c) => c.trim());
+    if (cells.length !== 5 || !cells[0]) return null;
+    const pct = /^([+-]?\d+(?:\.\d+)?)%$/.exec(cells[3]);
+    rows.push({
+      symbol: cells[0],
+      name: cells[1],
+      price: cells[2],
+      change: cells[3],
+      changePct: pct ? Number(pct[1]) : null,
+      status: cells[4],
+    });
+  }
+  if (rows.length === 0) return null;
+  const asOf = /_Prices as of (.+?) \(Apple Stocks cache\)\._/.exec(text);
+  return { kind: "stocks", rows, asOf: asOf ? asOf[1] : null };
+}
+
+export function parseCalendar(text: string): CalendarCard | null {
+  const events: CalendarItem[] = [];
+  let day = "";
+  for (const l of lines(text)) {
+    const h = /^## (\d{4}-\d{2}-\d{2})$/.exec(l);
+    if (h) {
+      day = h[1];
+      continue;
+    }
+    const ev = /^- (all day|\d{2}:\d{2}) — (.+)$/.exec(l);
+    if (ev) {
+      // Title is greedy up to the LAST "(Calendar)"; a location follows
+      // " at ". A title with its own parentheses still resolves, because
+      // the calendar group cannot itself contain parentheses.
+      const m = /^(.*) \(([^()]*)\)(?: at (.+))?$/.exec(ev[2]);
+      if (!m || !day) return null;
+      events.push({
+        day,
+        time: ev[1],
+        title: m[1],
+        calendar: m[2],
+        location: m[3] ?? null,
+        notes: null,
+      });
+      continue;
+    }
+    const note = /^ {2}- (.+)$/.exec(l);
+    if (note && events.length) events[events.length - 1].notes = note[1];
+  }
+  return events.length ? { kind: "calendar", events } : null;
+}
+
+export function parseReminders(text: string): RemindersCard | null {
+  const items: ReminderItem[] = [];
+  for (const l of lines(text)) {
+    const m = /^- \[([ xX])\] (.+)$/.exec(l);
+    if (m) {
+      let rest = m[2];
+      let due: string | null = null;
+      let id: string | null = null;
+      const d = / — due (\d{4}-\d{2}-\d{2})$/.exec(rest);
+      if (d) {
+        due = d[1];
+        rest = rest.slice(0, -d[0].length);
+      }
+      const i = / `([^`]+)`$/.exec(rest);
+      if (i) {
+        id = i[1];
+        rest = rest.slice(0, -i[0].length);
+      }
+      if (!rest) return null;
+      items.push({ title: rest, id, due, done: m[1] !== " ", notes: null });
+      continue;
+    }
+    const note = /^ {2}- (.+)$/.exec(l);
+    if (note && items.length) items[items.length - 1].notes = note[1];
+  }
+  return items.length ? { kind: "reminders", items } : null;
+}
+
+export function parseFeed(text: string): FeedCard | null {
+  const entries: FeedEntry[] = [];
+  for (const l of lines(text)) {
+    const m = /^- (\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2})?) — (.+)$/.exec(l);
+    if (!m) continue;
+    const linked = /^\[(.+?)\]\((\S+?)\)(?: — (.+))?$/.exec(m[2]);
+    if (linked) {
+      entries.push({ published: m[1], title: linked[1], link: linked[2], excerpt: linked[3] ?? null });
+      continue;
+    }
+    const cut = m[2].indexOf(" — ");
+    entries.push(
+      cut < 0
+        ? { published: m[1], title: m[2], link: null, excerpt: null }
+        : { published: m[1], title: m[2].slice(0, cut), link: null, excerpt: m[2].slice(cut + 3) },
+    );
+  }
+  return entries.length ? { kind: "feed", entries } : null;
+}
+
+/** One door: the card for a live source's stored text, or null. */
+export function parseLiveCard(kind: LiveKind, text: string): LiveCard | null {
+  switch (kind) {
+    case "stocks":
+      return parseStocks(text);
+    case "calendar":
+      return parseCalendar(text);
+    case "reminders":
+      return parseReminders(text);
+    case "feed":
+      return parseFeed(text);
+  }
+}
+
+/** A card older than this says "as of …" instead of pretending. Mac sources
+ *  resync every 15 minutes while the app runs, so a day-old copy means the
+ *  app was closed or the Mac app was; a feed's own cadence tops out at a
+ *  day (RFC §2). */
+export const STALE_AFTER_MS = 24 * 60 * 60 * 1000;
+
+export function isStale(fetchedAt: number, now = Date.now()): boolean {
+  return fetchedAt > 0 && now - fetchedAt > STALE_AFTER_MS;
+}

--- a/src/lib/sourceGroups.ts
+++ b/src/lib/sourceGroups.ts
@@ -34,6 +34,7 @@ export const GROUP_OF: Record<Source["sourceType"], Exclude<TypeGroup, "all">> =
     git: "folders",
     notion: "folders",
     obsidian: "folders",
+    feed: "folders",
   };
 
 export const GROUP_LABEL: Record<Exclude<TypeGroup, "all">, string> = {

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -2965,11 +2965,20 @@ export const useStore = create<AppState>((set, get) => {
       if (nb) await get().selectNotebook(nb.id);
     },
 
-    createReport: (name, kind, prompt, trigger, intervalSecs) =>
+    createReport: (name, kind, prompt, trigger, intervalSecs, watchSources = "", watchKinds = "") =>
       guard(async () => {
         const id = get().currentId;
         if (!id) return;
-        await api.createReportSchedule(id, name, kind, prompt, trigger, intervalSecs);
+        await api.createReportSchedule(
+          id,
+          name,
+          kind,
+          prompt,
+          trigger,
+          intervalSecs,
+          watchSources,
+          watchKinds,
+        );
         set({ reportSchedules: await api.listReportSchedules(id) });
         get().pushToast("success", `Scheduled “${name}”`);
       }),
@@ -2984,6 +2993,8 @@ export const useStore = create<AppState>((set, get) => {
           r.trigger,
           r.intervalSecs,
           r.enabled,
+          r.watchSources,
+          r.watchKinds,
         );
         const id = get().currentId;
         if (id) set({ reportSchedules: await api.listReportSchedules(id) });
@@ -3013,6 +3024,8 @@ export const useStore = create<AppState>((set, get) => {
               gone.prompt,
               gone.trigger,
               gone.intervalSecs,
+              gone.watchSources,
+              gone.watchKinds,
             );
             restoredId = restored.id;
             if (!gone.enabled)
@@ -3024,6 +3037,8 @@ export const useStore = create<AppState>((set, get) => {
                 gone.trigger,
                 gone.intervalSecs,
                 false,
+                gone.watchSources,
+                gone.watchKinds,
               );
             const id = get().currentId;
             if (id) set({ reportSchedules: await api.listReportSchedules(id) });

--- a/src/lib/storeTypes.ts
+++ b/src/lib/storeTypes.ts
@@ -403,6 +403,8 @@ export interface AppState {
     prompt: string,
     trigger: string,
     intervalSecs: number,
+    watchSources?: string,
+    watchKinds?: string,
   ) => Promise<void>;
   updateReport: (report: ReportSchedule) => Promise<void>;
   deleteReport: (id: string) => Promise<void>;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -71,7 +71,8 @@ export interface Source {
     | "code"
     | "git"
     | "notion"
-    | "obsidian";
+    | "obsidian"
+    | "feed";
   url: string;
   content: string;
   /** "placeholder" = cloud-sync file not downloaded yet; listed, not embedded.
@@ -279,8 +280,9 @@ export interface GrowthWebSearch {
 
 export interface GrowthProposal {
   /** "web" (link mined from sources) | "local" (on-disk path) |
-   *  "search" (found on the open web via Firecrawl). */
-  kind: "web" | "local" | "search";
+   *  "search" (found on the open web via Firecrawl) | "feed" (a feed one
+   *  of the notebook's pages advertised — docs/RFC-events.md §2). */
+  kind: "web" | "local" | "search" | "feed";
   url: string;
   /** Best anchor text seen for the link, or the file's name. */
   anchor: string;
@@ -553,6 +555,16 @@ export interface RegistryCard {
 
 /** One observed source change (watchers, RFC-night-shift): written by the
  *  refresh paths, read by the Brief, the Staff section, and agents. */
+/** A feed the app can offer to follow for a source (docs/RFC-events.md §2). */
+export interface FeedCandidate {
+  url: string;
+  /** "Releases", "Page history", "Feed", … */
+  label: string;
+  /** "page" (advertised by the page) | "host" (the host's shape) |
+   *  "well-known" (found at a conventional path). */
+  tier: "page" | "host" | "well-known";
+}
+
 /** Every SourceEvent.kind a producer writes (docs/RFC-events.md §1). */
 export const EVENT_KINDS = [
   "added",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -456,6 +456,10 @@ export interface ReportSchedule {
   notBefore: number;
   intervalSecs: number;
   enabled: boolean;
+  /** Change-trigger filters (docs/RFC-events.md §5): space-separated source
+   *  ids and event kinds; empty = any. Ignored unless trigger is "change". */
+  watchSources: string;
+  watchKinds: string;
   lastRunAt: number;
   createdAt: number;
 }
@@ -549,12 +553,23 @@ export interface RegistryCard {
 
 /** One observed source change (watchers, RFC-night-shift): written by the
  *  refresh paths, read by the Brief, the Staff section, and agents. */
+/** Every SourceEvent.kind a producer writes (docs/RFC-events.md §1). */
+export const EVENT_KINDS = [
+  "added",
+  "updated",
+  "removed",
+  "unreachable",
+  "completed",
+  "moved",
+] as const;
+export type EventKind = (typeof EVENT_KINDS)[number];
+
 export interface SourceEvent {
   id: string;
   notebookId: string;
   sourceId: string;
   sourceTitle: string;
-  kind: string;
+  kind: EventKind | string;
   detail: string;
   /** Capped ±-prefixed line excerpt; empty when nothing textual changed. */
   diff: string;


### PR DESCRIPTION
Implements docs/RFC-events.md, all six phases (tracking: bd alchemy-release-jcd).

## What's in
- **Phase 1 — vocabulary + triggers.** Folder scans write one coalesced `added`/`removed` event per pass; hygiene writes `unreachable` at the third strike; the parent map rewrite no longer doubles as `updated`. Standing questions gain `watch_sources` / `watch_kinds` (additive columns, editor UI, MCP `schedule_report`); `list_source_events` takes `since`, `kinds`, `source_ids`, `notebook_id`.
- **Phase 2 — feed sources.** RSS/Atom/JSON Feed URLs become a parent with a rolling index plus entry children. Conditional polls on a cadence derived from the feed (30 min–24 h), 5 new entries per feed and 20 per pass, one `added` event per poll. Three discovery tiers (page `<link rel=alternate>` remembered at import → Grow proposals; host rules incl. an arXiv query feed from standing questions; well-known paths only from *Follow updates…*). `discover_feeds` MCP tool. Sitemaps are watches, not imports: connecting one marks its URLs seen and only later additions arrive, sitemap indexes are refused, and nothing built-in uses one.
- **Phase 3 — Arrivals + live cards.** Per-notebook Arrivals strip with new-dots and a per-notebook seen watermark; Home digest tallies; live cards (stocks, calendar, reminders, feed) rendered from the cited source's stored text with fetched-at and a refresh affordance — zero inference.
- **Phase 4 — detection cost.** FSEvents on open notebooks' folders (2 s debounce); closed notebooks' folders sweep every 10 minutes.
- **Phase 5 — Mac item events.** One resident cider watch over the Reminders, Calendar, and Notes stores (EventKit's own notifications when the bridge CLI is installed and allowed, FSEvents otherwise); a change re-fetches that provider's sources and diffs the rendering into item-level events: `completed`, `added`, `moved`, `removed`, `updated`. Write-backs and the watch serialize under the scan lock, and an unchanged rendering is a no-op, so nothing doubles.
- **Phase 6 — agent stream.** `GET /events` SSE beside `/mcp` (same bearer + no-Origin gate), `events_url` in the discovery file, `alchemy events [--follow]` in the CLI.

## Storage and manners
- All small state lives in the database: a new `app_state` key/value table holds feed watermarks, discovered feeds, the Arrivals seen mark, and robots caches. No sidecar files, no localStorage.
- Sitemap watches honor `robots.txt` (Alchemy's group over `*`, longest match, `Crawl-delay` up to 30 s, 5xx = unavailable, cached 24 h); a disallowed sitemap is refused at connect and disallowed pages are marked seen, never fetched.
- cider 0.6.2 from crates.io: the library logs through the `log` facade instead of printing, and `diagnostics::install_log_bridge` lands those lines in the app log — no `eprintln!` left on any path the app runs.

## Verified live (dev app, "Events test" notebook)
- 3-file folder add → one `added` naming the files; delete → one `removed`; a filtered standing question round-trips and fired.
- Tauri blog feed → parent index + 10 children, ETag + daily cadence persisted; a forced poll re-added entries with one `added` event; a GitHub page → releases/commits candidates. Sitemap watch on a small site: connect ingests nothing, a forced poll reports 0 new, robots rules cached under `robots.<origin>`.
- Arrivals strip reads "25 new from Events Folder · 5 new from Tauri | Blog · 2 changed · 1 gone"; a stocks question renders a quote card.
- FSEvents: a single file landed in under 6 s; a 20-file burst → one rescan, one event.
- Reminders: adding to the watched list produced one `added`; completing produced `completed`; a manual Sync now on an unchanged list writes nothing.
- `/events`: 401 without token, 403 with an Origin header, live frame while tailing; the CLI one-shot lists the day.

## Gates
`cargo fmt --check` · `cargo clippy --all-targets -D warnings` · `cargo test` (484) · `pnpm build` · `pnpm vitest run` · `node --test cli` — all green.

## Not in this PR
- ACP `session/new` hand-off of `events_url`.
- Follow-ups: deleted feed entries re-arrive on the next poll; feed children are never pruned past 50 (the retirement pass owns it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
